### PR TITLE
Fix provider extraction gaps and add OpenRouter targets

### DIFF
--- a/.github/workflows/test-providers.yaml
+++ b/.github/workflows/test-providers.yaml
@@ -58,16 +58,10 @@ jobs:
           # BrightData
           - "chatgpt:brightdata"
           - "chatgpt:brightdata:online"
-          - "google-ai-mode:brightdata"
           - "google-ai-mode:brightdata:online"
-          - "gemini:brightdata"
           - "gemini:brightdata:online"
-          - "perplexity:brightdata"
           - "perplexity:brightdata:online"
-          - "grok:brightdata"
           - "grok:brightdata:online"
-          - "copilot:brightdata"
-          - "copilot:brightdata:online"
           # DataForSEO
           - "google-ai-mode:dataforseo:online"
           # Direct API
@@ -75,6 +69,13 @@ jobs:
           - "chatgpt:openai-api:gpt-5-mini:online"
           - "claude:anthropic-api:claude-sonnet-4-20250514"
           - "claude:anthropic-api:claude-sonnet-4-20250514:online"
+          # OpenRouter
+          - "claude:openrouter:anthropic/claude-sonnet-4.6"
+          - "claude:openrouter:anthropic/claude-sonnet-4.6:online"
+          - "chatgpt:openrouter:openai/gpt-5-mini"
+          - "chatgpt:openrouter:openai/gpt-5-mini:online"
+          - "deepseek:openrouter:deepseek/deepseek-v3.2"
+          - "mistral:openrouter:mistralai/mistral-small-2603"
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5
@@ -142,18 +143,19 @@ jobs:
           const lines = [
             `## Provider Test Results — ${overall} (${passed}/${total})`,
             "",
-            "| Status | Target | Latency | Error | Text Length | Citations | Web Queries | Web Search | Sample Output |",
-            "|--------|--------|---------|-------|-------------|-----------|-------------|------------|---------------|",
+            "| Status | Target | Latency | Error | Text | Raw Output | Citations | Web Queries | Web Search | Sample Output |",
+            "|--------|--------|---------|-------|------|------------|-----------|-------------|------------|---------------|",
           ];
 
           for (const r of allResults) {
             const status = r.status === "pass" ? ":white_check_mark:" : ":x:";
             const error = (r.error || "").slice(0, 100).replace(/\|/g, "\\|");
+            const rawKB = ((r.rawOutputBytes || 0) / 1024).toFixed(1) + " KB";
             const sample = r.sampleOutput
               ? `<details><summary>Show</summary><pre>${r.sampleOutput.replace(/\|/g, "\\|").replace(/\n/g, "<br>")}</pre></details>`
               : "";
             lines.push(
-              `| ${status} | \`${r.target}\` | ${r.latency}ms | ${error} | ${r.textLength} | ${r.citations} | ${r.webQueries} | ${r.webSearch ? "enabled" : "disabled"} | ${sample} |`
+              `| ${status} | \`${r.target}\` | ${r.latency}ms | ${error} | ${r.textLength} | ${rawKB} | ${r.citations} | ${r.webQueries} | ${r.webSearch ? "enabled" : "disabled"} | ${sample} |`
             );
           }
 

--- a/apps/worker/scripts/test-provider.ts
+++ b/apps/worker/scripts/test-provider.ts
@@ -72,6 +72,11 @@ Examples:
 const TEST_PROMPT = "What are the most popular brands of running shoes?";
 const MIN_TEXT_LENGTH = 50;
 
+// Provider/model combos where web queries aren't reported even though web search happens
+function hasRealWebQueries(queries: string[]): boolean {
+	return queries.length > 0 && !queries.every((q) => q === "unavailable");
+}
+
 interface ValidationIssue {
 	field: string;
 	message: string;
@@ -84,6 +89,7 @@ export interface TargetResult {
 	latency: number;
 	error?: string;
 	textLength: number;
+	rawOutputBytes: number;
 	citations: number;
 	webQueries: number;
 	webSearch: boolean;
@@ -138,17 +144,20 @@ function validateResult(result: ScrapeResult, providerId: string, webSearch: boo
 		issues.push({
 			field: "citations",
 			message: webSearch
-				? "No citations returned (expected when online is enabled)"
+				? "No citations returned (expected when online)"
 				: "No citations returned (may be expected for some engines/prompts)",
 			severity: webSearch ? "error" : "warning",
 		});
 	}
 
-	if (webSearch && result.webQueries.length === 0) {
+	if (webSearch && !hasRealWebQueries(result.webQueries)) {
+		const isUnavailable = result.webQueries.some((q) => q === "unavailable");
 		issues.push({
 			field: "webQueries",
-			message: "No web queries returned (expected when online is enabled)",
-			severity: "error",
+			message: isUnavailable
+				? "Web queries unavailable (not exposed by this provider)"
+				: "No web queries returned (expected when online)",
+			severity: isUnavailable ? "warning" : "error",
 		});
 	}
 
@@ -194,6 +203,7 @@ async function runTarget(target: string): Promise<TargetResult> {
 			latency,
 			error: errorMsg,
 			textLength: 0,
+			rawOutputBytes: 0,
 			citations: 0,
 			webQueries: 0,
 			webSearch: config.webSearch,
@@ -203,13 +213,15 @@ async function runTarget(target: string): Promise<TargetResult> {
 	}
 
 	const latency = Date.now() - start;
+	const rawOutputBytes = Buffer.byteLength(JSON.stringify(result.rawOutput ?? null));
 	const issues = validateResult(result, providerId, config.webSearch);
 	const hasErrors = issues.some((i) => i.severity === "error");
 
-	log(`Latency:    ${latency}ms`, colors.dim);
-	log(`Text:       ${result.textContent?.length ?? 0} chars`, colors.dim);
-	log(`Citations:  ${result.citations.length}`, colors.blue);
-	log(`Web queries: ${result.webQueries.length}`, colors.dim);
+	log(`Latency:      ${latency}ms`, colors.dim);
+	log(`Text:         ${result.textContent?.length ?? 0} chars`, colors.dim);
+	log(`Raw output:   ${(rawOutputBytes / 1024).toFixed(1)} KB`, colors.dim);
+	log(`Citations:    ${result.citations.length}`, colors.blue);
+	log(`Web queries:  ${result.webQueries.length}`, colors.dim);
 
 	if (result.textContent) {
 		log("\nSample output:", colors.dim);
@@ -238,6 +250,7 @@ async function runTarget(target: string): Promise<TargetResult> {
 		status: hasErrors ? "fail" : "pass",
 		latency,
 		textLength: result.textContent?.length ?? 0,
+		rawOutputBytes,
 		citations: result.citations.length,
 		webQueries: result.webQueries.length,
 		webSearch: config.webSearch,
@@ -257,18 +270,19 @@ function writeGitHubSummary(results: TargetResult[]) {
 	const lines: string[] = [
 		`## Provider Test Results — ${overallStatus} (${passed}/${total})`,
 		"",
-		"| Status | Target | Latency | Error | Text Length | Citations | Web Queries | Web Search | Sample Output |",
-		"|--------|--------|---------|-------|-------------|-----------|-------------|------------|---------------|",
+		"| Status | Target | Latency | Error | Text | Raw Output | Citations | Web Queries | Web Search | Sample Output |",
+		"|--------|--------|---------|-------|------|------------|-----------|-------------|------------|---------------|",
 	];
 
 	for (const r of results) {
 		const status = r.status === "pass" ? ":white_check_mark:" : ":x:";
 		const error = r.error ? r.error.slice(0, 100).replace(/\|/g, "\\|") : "";
+		const rawKB = (r.rawOutputBytes / 1024).toFixed(1) + " KB";
 		const sample = r.sampleOutput
 			? `<details><summary>Show</summary><pre>${r.sampleOutput.replace(/\|/g, "\\|").replace(/\n/g, "<br>")}</pre></details>`
 			: "";
 		lines.push(
-			`| ${status} | \`${r.target}\` | ${r.latency}ms | ${error} | ${r.textLength} | ${r.citations} | ${r.webQueries} | ${r.webSearch ? "enabled" : "disabled"} | ${sample} |`,
+			`| ${status} | \`${r.target}\` | ${r.latency}ms | ${error} | ${r.textLength} | ${rawKB} | ${r.citations} | ${r.webQueries} | ${r.webSearch ? "enabled" : "disabled"} | ${sample} |`,
 		);
 	}
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -29,7 +29,6 @@
     "@anthropic-ai/sdk": "^0.82.0",
     "@better-auth/sso": "^1.5.6",
     "@brightdata/sdk": "^1.0.0",
-    "@openrouter/sdk": "^0.11.2",
     "ai": "^6.0.146",
     "better-auth": "^1.5.6",
     "dataforseo-client": "^2.0.21",

--- a/packages/lib/src/providers/config.test.ts
+++ b/packages/lib/src/providers/config.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { parseScrapeTargets, validateScrapeTargets } from "./config";
+import { olostep } from "./registry/olostep";
+import { brightdata } from "./registry/brightdata";
+import { dataforseo } from "./registry/dataforseo";
+import type { ModelConfig } from "./types";
 
 describe("parseScrapeTargets", () => {
 	describe("basic parsing", () => {
@@ -167,5 +171,67 @@ describe("validateScrapeTargets", () => {
 				}),
 			),
 		).not.toThrow();
+	});
+});
+
+describe("provider validateTarget", () => {
+	function config(model: string, provider: string, webSearch: boolean, version?: string): ModelConfig {
+		return { model, provider, version, webSearch };
+	}
+
+	describe("olostep", () => {
+		it("accepts valid online targets", () => {
+			for (const model of ["chatgpt", "google-ai-mode", "google-ai-overview", "gemini", "copilot", "perplexity", "grok"]) {
+				expect(olostep.validateTarget!(config(model, "olostep", true))).toBeNull();
+			}
+		});
+
+		it("rejects targets without :online", () => {
+			expect(olostep.validateTarget!(config("chatgpt", "olostep", false))).toMatch(/requires :online/);
+		});
+
+		it("rejects unknown models", () => {
+			expect(olostep.validateTarget!(config("unknown", "olostep", true))).toMatch(/does not support/);
+		});
+	});
+
+	describe("brightdata", () => {
+		it("accepts chatgpt with and without :online", () => {
+			expect(brightdata.validateTarget!(config("chatgpt", "brightdata", true))).toBeNull();
+			expect(brightdata.validateTarget!(config("chatgpt", "brightdata", false))).toBeNull();
+		});
+
+		it("accepts other models with :online", () => {
+			for (const model of ["perplexity", "gemini", "grok", "google-ai-mode"]) {
+				expect(brightdata.validateTarget!(config(model, "brightdata", true))).toBeNull();
+			}
+		});
+
+		it("rejects non-chatgpt models without :online", () => {
+			expect(brightdata.validateTarget!(config("grok", "brightdata", false))).toMatch(/requires :online/);
+			expect(brightdata.validateTarget!(config("perplexity", "brightdata", false))).toMatch(/requires :online/);
+		});
+
+		it("rejects unknown models", () => {
+			expect(brightdata.validateTarget!(config("unknown", "brightdata", true))).toMatch(/does not support/);
+		});
+
+		it("accepts unknown models with custom dataset ID", () => {
+			expect(brightdata.validateTarget!(config("unknown", "brightdata", true, "gd_custom123"))).toBeNull();
+		});
+	});
+
+	describe("dataforseo", () => {
+		it("accepts google-ai-mode:online", () => {
+			expect(dataforseo.validateTarget!(config("google-ai-mode", "dataforseo", true))).toBeNull();
+		});
+
+		it("rejects without :online", () => {
+			expect(dataforseo.validateTarget!(config("google-ai-mode", "dataforseo", false))).toMatch(/requires :online/);
+		});
+
+		it("rejects unsupported models", () => {
+			expect(dataforseo.validateTarget!(config("chatgpt", "dataforseo", true))).toMatch(/only supports/);
+		});
 	});
 });

--- a/packages/lib/src/providers/config.ts
+++ b/packages/lib/src/providers/config.ts
@@ -39,7 +39,7 @@ export function parseScrapeTargets(envValue?: string): ModelConfig[] {
 
 export function validateScrapeTargets(
 	configs: ModelConfig[],
-	getProvider: (id: string) => { isConfigured(): boolean } | undefined,
+	getProvider: (id: string) => { isConfigured(): boolean; validateTarget?(config: ModelConfig): string | null } | undefined,
 ): void {
 	for (const config of configs) {
 		const provider = getProvider(config.provider);
@@ -50,5 +50,8 @@ export function validateScrapeTargets(
 			);
 		if ((config.provider === "openai-api" || config.provider === "anthropic-api" || config.provider === "openrouter") && !config.version)
 			throw new Error(`SCRAPE_TARGETS: "${config.model}:${config.provider}" requires a version slug (third segment)`);
+		const targetError = provider.validateTarget?.(config);
+		if (targetError)
+			throw new Error(`SCRAPE_TARGETS: invalid target "${config.model}:${config.provider}": ${targetError}`);
 	}
 }

--- a/packages/lib/src/providers/registry/anthropic-api.ts
+++ b/packages/lib/src/providers/registry/anthropic-api.ts
@@ -1,6 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { extractTextFromAnthropic } from "../../text-extraction";
 import type { Provider, ScrapeResult, ProviderOptions } from "../types";
+import type { Citation } from "../../text-extraction";
 
 function sanitizeForJson(obj: unknown): unknown {
 	return JSON.parse(JSON.stringify(obj));
@@ -35,13 +36,62 @@ async function runAnthropic(prompt: string, model: string, options?: ProviderOpt
 		.map((block) => (block as any).input?.query)
 		.filter(Boolean);
 
+	const citations = extractAnthropicCitations(response.content);
+
 	return {
 		rawOutput: sanitizeForJson(response),
 		webQueries,
 		textContent,
-		citations: [],
+		citations,
 		modelVersion: model,
 	};
+}
+
+function extractAnthropicCitations(content: Anthropic.Messages.ContentBlock[]): Citation[] {
+	const seen = new Set<string>();
+	const citations: Citation[] = [];
+	let idx = 0;
+
+	for (const block of content) {
+		// Citations from text blocks
+		if (block.type === "text") {
+			for (const cit of (block as any).citations ?? []) {
+				if (cit.type === "web_search_result_location" && cit.url) {
+					if (seen.has(cit.url)) continue;
+					seen.add(cit.url);
+					try {
+						const parsed = new URL(cit.url);
+						citations.push({
+							url: cit.url,
+							title: cit.title ?? undefined,
+							domain: parsed.hostname.replace(/^www\./, ""),
+							citationIndex: idx++,
+						});
+					} catch { /* skip invalid */ }
+				}
+			}
+		}
+		// Citations from web search results
+		if (block.type === "web_search_tool_result") {
+			for (const result of (block as any).content ?? []) {
+				if (result.type === "web_search_result" && result.url) {
+					if (seen.has(result.url)) continue;
+					seen.add(result.url);
+					try {
+						const parsed = new URL(result.url);
+						citations.push({
+							url: result.url,
+							title: result.title ?? undefined,
+							domain: parsed.hostname.replace(/^www\./, ""),
+							citationIndex: idx++,
+						});
+					} catch { /* skip invalid */ }
+				}
+			}
+		}
+	}
+
+	return citations;
 }
 
 export const anthropicApi: Provider = {

--- a/packages/lib/src/providers/registry/anthropic-api.ts
+++ b/packages/lib/src/providers/registry/anthropic-api.ts
@@ -67,7 +67,7 @@ function extractAnthropicCitations(content: Anthropic.Messages.ContentBlock[]): 
 							domain: parsed.hostname.replace(/^www\./, ""),
 							citationIndex: idx++,
 						});
-					} catch { /* skip invalid */ }
+					} catch (e) { console.warn(`Anthropic: skipping invalid citation URL: ${cit.url}`, e); }
 				}
 			}
 		}
@@ -85,7 +85,7 @@ function extractAnthropicCitations(content: Anthropic.Messages.ContentBlock[]): 
 							domain: parsed.hostname.replace(/^www\./, ""),
 							citationIndex: idx++,
 						});
-					} catch { /* skip invalid */ }
+					} catch (e) { console.warn(`Anthropic: skipping invalid search result URL: ${result.url}`, e); }
 				}
 			}
 		}

--- a/packages/lib/src/providers/registry/brightdata.ts
+++ b/packages/lib/src/providers/registry/brightdata.ts
@@ -55,8 +55,8 @@ function extractSources(record: Record<string, any>): Citation[] {
 					domain: parsed.hostname.replace(/^www\./, ""),
 					citationIndex: idx++,
 				});
-			} catch {
-				// skip invalid
+			} catch (e) {
+				console.warn(`BrightData: skipping invalid citation URL: ${url}`, e);
 			}
 		}
 	}

--- a/packages/lib/src/providers/registry/brightdata.ts
+++ b/packages/lib/src/providers/registry/brightdata.ts
@@ -19,12 +19,8 @@ const BD_BASE_URL: Record<string, string> = {
 	grok: "https://grok.com/",
 };
 
-let _client: bdclient | null = null;
-function getClient(): bdclient {
-	if (!_client) {
-		_client = new bdclient({ apiKey: process.env.BRIGHTDATA_API_TOKEN });
-	}
-	return _client;
+function createClient(): bdclient {
+	return new bdclient({ apiKey: process.env.BRIGHTDATA_API_TOKEN });
 }
 
 function normalizeAnswer(record: Record<string, any>): string {
@@ -97,43 +93,46 @@ export const brightdata: Provider = {
 			);
 		}
 
-		const client = getClient();
-
-		const triggerRes = await fetch(
-			`https://api.brightdata.com/datasets/v3/trigger?dataset_id=${datasetId}&notify=false&include_errors=true&format=json`,
-			{
-				method: "POST",
-				headers: {
-					Authorization: `Bearer ${process.env.BRIGHTDATA_API_TOKEN}`,
-					"Content-Type": "application/json",
+		const client = createClient();
+		try {
+			const triggerRes = await fetch(
+				`https://api.brightdata.com/datasets/v3/trigger?dataset_id=${datasetId}&notify=false&include_errors=true&format=json`,
+				{
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${process.env.BRIGHTDATA_API_TOKEN}`,
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify([{ url: BD_BASE_URL[model] ?? "", prompt, index: 1 }]),
 				},
-				body: JSON.stringify([{ url: BD_BASE_URL[model] ?? "", prompt, index: 1 }]),
-			},
-		);
+			);
 
-		if (!triggerRes.ok) {
-			throw new Error(`BrightData trigger failed (${triggerRes.status}): ${await triggerRes.text()}`);
+			if (!triggerRes.ok) {
+				throw new Error(`BrightData trigger failed (${triggerRes.status}): ${await triggerRes.text()}`);
+			}
+
+			const { snapshot_id: snapshotId } = (await triggerRes.json()) as { snapshot_id: string };
+			await pollUntilReady(client, snapshotId);
+			const payload = await client.scrape.snapshot.fetch(snapshotId, { format: "json" });
+
+			const record = (Array.isArray(payload) ? payload[0] : payload) ?? {};
+			const answer = normalizeAnswer(record);
+
+			const webQueries = extractWebQueries(record);
+			const citations = extractSources(record);
+
+			return {
+				rawOutput: payload,
+				textContent: answer,
+				// Mark as "unavailable" only when citations prove a search happened
+				// but the API didn't expose the query strings
+				webQueries: webQueries.length > 0 ? webQueries : citations.length > 0 ? ["unavailable"] : [],
+				citations,
+				modelVersion: record?.model ?? undefined,
+			};
+		} finally {
+			await client.close();
 		}
-
-		const { snapshot_id: snapshotId } = (await triggerRes.json()) as { snapshot_id: string };
-		await pollUntilReady(client, snapshotId);
-		const payload = await client.scrape.snapshot.fetch(snapshotId, { format: "json" });
-
-		const record = (Array.isArray(payload) ? payload[0] : payload) ?? {};
-		const answer = normalizeAnswer(record);
-
-		const webQueries = extractWebQueries(record);
-		const citations = extractSources(record);
-
-		return {
-			rawOutput: payload,
-			textContent: answer,
-			// Mark as "unavailable" only when citations prove a search happened
-			// but the API didn't expose the query strings
-			webQueries: webQueries.length > 0 ? webQueries : citations.length > 0 ? ["unavailable"] : [],
-			citations,
-			modelVersion: record?.model ?? undefined,
-		};
 	},
 };
 

--- a/packages/lib/src/providers/registry/brightdata.ts
+++ b/packages/lib/src/providers/registry/brightdata.ts
@@ -5,7 +5,6 @@ import type { Citation } from "../../text-extraction";
 const BD_DATASET_IDS: Record<string, string> = {
 	chatgpt: "gd_m7aof0k82r803d5bjm",
 	perplexity: "gd_m7dhdot1vw9a7gc1n",
-	copilot: "gd_m7di5jy6s9geokz8w",
 	gemini: "gd_mbz66arm2mf9cu856y",
 	grok: "gd_m8ve0u141icu75ae74",
 	"google-ai-mode": "gd_mcswdt6z2elth3zqr2",
@@ -16,7 +15,6 @@ const BD_BASE_URL: Record<string, string> = {
 	"google-ai-mode": "https://google.com/aimode",
 	"google-ai-overview": "https://www.google.com/",
 	gemini: "https://gemini.google.com/",
-	copilot: "https://copilot.microsoft.com/chats",
 	perplexity: "https://www.perplexity.ai/",
 	grok: "https://grok.com/",
 };
@@ -65,6 +63,22 @@ function extractSources(record: Record<string, any>): Citation[] {
 	return citations;
 }
 
+function extractWebQueries(record: Record<string, any>): string[] {
+	// web_search_query is a direct array of strings (e.g. grok)
+	if (Array.isArray(record.web_search_query)) {
+		return record.web_search_query.filter((q: any) => typeof q === "string" && q.trim());
+	}
+	// search_model_queries may be nested in metadata (e.g. chatgpt)
+	const smq = record.metadata?.search_model_queries ?? record.search_model_queries;
+	if (smq?.queries && Array.isArray(smq.queries)) {
+		return smq.queries.filter((q: any) => typeof q === "string" && q.trim());
+	}
+	if (Array.isArray(smq)) {
+		return smq.filter((q: any) => typeof q === "string" && q.trim());
+	}
+	return [];
+}
+
 export const brightdata: Provider = {
 	id: "brightdata",
 	name: "BrightData",
@@ -108,11 +122,16 @@ export const brightdata: Provider = {
 		const record = (Array.isArray(payload) ? payload[0] : payload) ?? {};
 		const answer = normalizeAnswer(record);
 
+		const webQueries = extractWebQueries(record);
+		const citations = extractSources(record);
+
 		return {
 			rawOutput: payload,
 			textContent: answer,
-			webQueries: record?.prompt ? [record.prompt] : [prompt],
-			citations: extractSources(record),
+			// Mark as "unavailable" only when citations prove a search happened
+			// but the API didn't expose the query strings
+			webQueries: webQueries.length > 0 ? webQueries : citations.length > 0 ? ["unavailable"] : [],
+			citations,
 			modelVersion: record?.model ?? undefined,
 		};
 	},

--- a/packages/lib/src/providers/registry/brightdata.ts
+++ b/packages/lib/src/providers/registry/brightdata.ts
@@ -1,5 +1,5 @@
 import { bdclient } from "@brightdata/sdk";
-import type { Provider, ScrapeResult, ProviderOptions } from "../types";
+import type { Provider, ScrapeResult, ProviderOptions, ModelConfig } from "../types";
 import type { Citation } from "../../text-extraction";
 
 const BD_DATASET_IDS: Record<string, string> = {
@@ -81,6 +81,18 @@ export const brightdata: Provider = {
 
 	isConfigured() {
 		return !!process.env.BRIGHTDATA_API_TOKEN;
+	},
+
+	validateTarget(config: ModelConfig) {
+		// Allow custom dataset IDs via version slug (e.g. chatgpt:brightdata:gd_abc123)
+		if (!config.version && !BD_DATASET_IDS[config.model]) {
+			return `BrightData does not support model "${config.model}". Supported: ${Object.keys(BD_DATASET_IDS).join(", ")}`;
+		}
+		// ChatGPT has a web search toggle; all other chatbots always search
+		if (!config.webSearch && config.model !== "chatgpt") {
+			return `${config.model}:brightdata requires :online — this chatbot always uses web search`;
+		}
+		return null;
 	},
 
 	async run(model: string, prompt: string, options?: ProviderOptions): Promise<ScrapeResult> {

--- a/packages/lib/src/providers/registry/dataforseo.ts
+++ b/packages/lib/src/providers/registry/dataforseo.ts
@@ -1,6 +1,8 @@
 import * as client from "dataforseo-client";
 import { extractTextFromGoogle, extractCitationsFromGoogle } from "../../text-extraction";
-import type { Provider, ScrapeResult, ProviderOptions } from "../types";
+import type { Provider, ScrapeResult, ProviderOptions, ModelConfig } from "../types";
+
+const SUPPORTED_MODELS = new Set(["google-ai-mode"]);
 
 function sanitizeForJson(obj: unknown): unknown {
 	return JSON.parse(JSON.stringify(obj));
@@ -25,6 +27,16 @@ export const dataforseo: Provider = {
 
 	isConfigured() {
 		return !!process.env.DATAFORSEO_LOGIN && !!process.env.DATAFORSEO_PASSWORD;
+	},
+
+	validateTarget(config: ModelConfig) {
+		if (!SUPPORTED_MODELS.has(config.model)) {
+			return `DataForSEO only supports: ${[...SUPPORTED_MODELS].join(", ")}`;
+		}
+		if (!config.webSearch) {
+			return `${config.model}:dataforseo requires :online — Google AI Mode always uses web search`;
+		}
+		return null;
 	},
 
 	async run(model: string, prompt: string, _options?: ProviderOptions): Promise<ScrapeResult> {

--- a/packages/lib/src/providers/registry/olostep.ts
+++ b/packages/lib/src/providers/registry/olostep.ts
@@ -43,7 +43,7 @@ const OLOSTEP_PARSERS: Record<string, { parserId: string; urlTemplate: (q: strin
 let _client: Olostep | null = null;
 function getClient(): Olostep {
 	if (!_client) {
-		_client = new Olostep({ apiKey: process.env.OLOSTEP_API_KEY, maxRetries: 5, initialDelayMs: 2000 });
+		_client = new Olostep({ apiKey: process.env.OLOSTEP_API_KEY, retry: { maxRetries: 3, initialDelayMs: 2000 } });
 	}
 	return _client;
 }
@@ -58,7 +58,7 @@ function extractTextFromOlostep(data: any): string {
 
 function extractCitationsFromOlostep(data: any): Citation[] {
 	const citations: Citation[] = [];
-	const sources = data?.sources ?? data?.result?.links_on_page ?? data?.inline_references ?? [];
+	const sources = data?.sources ?? data?.citations ?? data?.result?.links_on_page ?? data?.inline_references ?? [];
 	let idx = 0;
 	for (const source of Array.isArray(sources) ? sources : []) {
 		const url = typeof source === "string" ? source : source?.url;
@@ -80,10 +80,25 @@ function extractCitationsFromOlostep(data: any): Citation[] {
 
 function extractWebQueries(data: any): string[] {
 	const queries: string[] = [];
-	const searchCalls = data?.network_search_calls?.search_queries ?? data?.search_model_queries ?? [];
-	for (const call of Array.isArray(searchCalls) ? searchCalls : []) {
-		if (call?.query) queries.push(call.query);
+
+	// Batch API returns a flat string array at data.search_queries
+	const flat = data?.search_queries;
+	if (Array.isArray(flat)) {
+		for (const q of flat) {
+			if (typeof q === "string" && q.trim()) queries.push(q);
+		}
 	}
+
+	// Scrape API nests queries under network_search_calls or search_model_queries
+	if (queries.length === 0) {
+		const searchCalls = data?.network_search_calls?.search_queries ?? data?.search_model_queries ?? [];
+		for (const call of Array.isArray(searchCalls) ? searchCalls : []) {
+			// May be a string (flat array) or an object with .query
+			if (typeof call === "string" && call.trim()) queries.push(call);
+			else if (call?.query) queries.push(call.query);
+		}
+	}
+
 	return queries;
 }
 
@@ -100,21 +115,42 @@ export const olostep: Provider = {
 		if (!parserConfig) throw new Error(`Olostep does not support model "${model}"`);
 
 		const client = getClient();
-		const scrape = await client.scrapes.create({
-			url: parserConfig.urlTemplate(prompt),
-			formats: ["json"],
-			parser: { id: parserConfig.parserId },
-		});
+		const url = parserConfig.urlTemplate(prompt);
 
-		const jsonContent = scrape.json_content;
+		// Use batch API — the /scrapes endpoint doesn't support all parsers
+		const batch = await client.batches.create(
+			[{ url, customId: "1" }],
+			{ parser: { id: parserConfig.parserId } },
+		);
+
+		await batch.waitTillDone({ checkEveryNSecs: 5, timeoutSeconds: 300 });
+
+		let retrieveId: string | undefined;
+		for await (const item of batch.items()) {
+			retrieveId = item.retrieve_id;
+			break; // single item batch
+		}
+
+		if (!retrieveId) throw new Error("Olostep batch completed but no items returned");
+
+		// Use client.retrieve (GET) instead of item.retrieve (POST) — the
+		// SDK's BatchItem.retrieve uses POST which the API rejects with 403.
+		const retrieved = await client.retrieve(retrieveId, ["json"]);
+
+		const jsonContent = retrieved.json_content;
 		const parsed =
-			typeof jsonContent === "string" ? JSON.parse(jsonContent) : (jsonContent ?? scrape);
+			typeof jsonContent === "string" ? JSON.parse(jsonContent) : (jsonContent ?? retrieved);
+
+		const webQueries = extractWebQueries(parsed);
+		const citations = extractCitationsFromOlostep(parsed);
 
 		return {
-			rawOutput: scrape,
+			rawOutput: retrieved,
 			textContent: extractTextFromOlostep(parsed),
-			webQueries: extractWebQueries(parsed),
-			citations: extractCitationsFromOlostep(parsed),
+			// Mark as "unavailable" only when citations prove a search happened
+			// but the API didn't expose the query strings
+			webQueries: webQueries.length > 0 ? webQueries : citations.length > 0 ? ["unavailable"] : [],
+			citations,
 			modelVersion: parsed?.model ?? undefined,
 		};
 	},

--- a/packages/lib/src/providers/registry/olostep.ts
+++ b/packages/lib/src/providers/registry/olostep.ts
@@ -1,5 +1,5 @@
 import Olostep from "olostep";
-import type { Provider, ScrapeResult, ProviderOptions } from "../types";
+import type { Provider, ScrapeResult, ProviderOptions, ModelConfig } from "../types";
 import type { Citation } from "../../text-extraction";
 
 const OLOSTEP_PARSERS: Record<string, { parserId: string; urlTemplate: (q: string) => string; credits: number }> = {
@@ -108,6 +108,16 @@ export const olostep: Provider = {
 
 	isConfigured() {
 		return !!process.env.OLOSTEP_API_KEY;
+	},
+
+	validateTarget(config: ModelConfig) {
+		if (!OLOSTEP_PARSERS[config.model]) {
+			return `Olostep does not support model "${config.model}". Supported: ${Object.keys(OLOSTEP_PARSERS).join(", ")}`;
+		}
+		if (!config.webSearch) {
+			return `${config.model}:olostep requires :online — these chatbots always use web search`;
+		}
+		return null;
 	},
 
 	async run(model: string, prompt: string, _options?: ProviderOptions): Promise<ScrapeResult> {

--- a/packages/lib/src/providers/registry/olostep.ts
+++ b/packages/lib/src/providers/registry/olostep.ts
@@ -71,8 +71,8 @@ function extractCitationsFromOlostep(data: any): Citation[] {
 				domain: parsed.hostname.replace(/^www\./, ""),
 				citationIndex: idx++,
 			});
-		} catch {
-			// skip invalid URLs
+		} catch (e) {
+			console.warn(`Olostep: skipping invalid citation URL: ${url}`, e);
 		}
 	}
 	return citations;

--- a/packages/lib/src/providers/registry/openrouter.ts
+++ b/packages/lib/src/providers/registry/openrouter.ts
@@ -39,8 +39,8 @@ function extractCitationsFromOpenRouterResponse(data: any): Citation[] {
 				domain: parsed.hostname.replace(/^www\./, ""),
 				citationIndex: idx++,
 			});
-		} catch {
-			// skip
+		} catch (e) {
+			console.warn(`OpenRouter: skipping invalid citation URL: ${url}`, e);
 		}
 	}
 	return citations;

--- a/packages/lib/src/providers/registry/openrouter.ts
+++ b/packages/lib/src/providers/registry/openrouter.ts
@@ -1,18 +1,7 @@
-import { OpenRouter } from "@openrouter/sdk";
 import type { Provider, ScrapeResult, ProviderOptions } from "../types";
 import type { Citation } from "../../text-extraction";
 
-let _client: OpenRouter | null = null;
-function getClient(): OpenRouter {
-	if (!_client) {
-		_client = new OpenRouter({
-			apiKey: process.env.OPENROUTER_API_KEY,
-			httpReferer: process.env.APP_URL ?? "https://github.com/elmohq/elmo",
-			appTitle: "Elmo AEO",
-		});
-	}
-	return _client;
-}
+const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
 
 function extractTextFromOpenRouterResponse(data: any): string {
 	if (data?.choices?.[0]?.message?.content) return data.choices[0].message.content;
@@ -32,20 +21,26 @@ function extractTextFromOpenRouterResponse(data: any): string {
 function extractCitationsFromOpenRouterResponse(data: any): Citation[] {
 	const citations: Citation[] = [];
 	let idx = 0;
+	const seen = new Set<string>();
 	const annotations = data?.choices?.[0]?.message?.annotations ?? [];
 	for (const ann of annotations) {
-		if (ann?.type === "url_citation" && ann.url) {
-			try {
-				const parsed = new URL(ann.url);
-				citations.push({
-					url: ann.url,
-					title: ann.title ?? undefined,
-					domain: parsed.hostname.replace(/^www\./, ""),
-					citationIndex: idx++,
-				});
-			} catch {
-				// skip
-			}
+		if (ann?.type !== "url_citation") continue;
+		// OpenRouter nests citation data under url_citation, but also support flat layout
+		const cite = ann.url_citation ?? ann;
+		const url = cite.url;
+		if (!url || typeof url !== "string" || !url.startsWith("http")) continue;
+		if (seen.has(url)) continue;
+		seen.add(url);
+		try {
+			const parsed = new URL(url);
+			citations.push({
+				url,
+				title: cite.title ?? undefined,
+				domain: parsed.hostname.replace(/^www\./, ""),
+				citationIndex: idx++,
+			});
+		} catch {
+			// skip
 		}
 	}
 	return citations;
@@ -72,21 +67,38 @@ export const openrouter: Provider = {
 			modelSlug = `${modelSlug}:online`;
 		}
 
-		const client = getClient();
-		const result = await client.chat.send({
-			chatRequest: {
-				model: modelSlug,
-				messages: [{ role: "user" as const, content: prompt }],
+		// Use raw fetch instead of SDK — the OpenRouter SDK strips annotations
+		// from the response, which contain web search citations.
+		const res = await fetch(OPENROUTER_API_URL, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
+				"Content-Type": "application/json",
+				"HTTP-Referer": process.env.APP_URL ?? "https://github.com/elmohq/elmo",
+				"X-Title": "Elmo AEO",
 			},
+			body: JSON.stringify({
+				model: modelSlug,
+				messages: [{ role: "user", content: prompt }],
+			}),
 		});
 
-		const data: any = result;
+		if (!res.ok) {
+			throw new Error(`OpenRouter API error (${res.status}): ${await res.text()}`);
+		}
+
+		const data: any = await res.json();
+
+		const citations = extractCitationsFromOpenRouterResponse(data);
+		// OpenRouter doesn't expose what search queries the model made internally.
+		// Only mark as "unavailable" when citations prove a web search happened.
+		const webQueries = citations.length > 0 ? ["unavailable"] : [];
 
 		return {
 			rawOutput: data,
 			textContent: extractTextFromOpenRouterResponse(data),
-			webQueries: [],
-			citations: extractCitationsFromOpenRouterResponse(data),
+			webQueries,
+			citations,
 			modelVersion: data?.model ?? modelSlug.replace(":online", ""),
 		};
 	},

--- a/packages/lib/src/providers/registry/openrouter.ts
+++ b/packages/lib/src/providers/registry/openrouter.ts
@@ -67,8 +67,11 @@ export const openrouter: Provider = {
 			modelSlug = `${modelSlug}:online`;
 		}
 
-		// Use raw fetch instead of SDK — the OpenRouter SDK strips annotations
-		// from the response, which contain web search citations.
+		// Use raw fetch instead of SDK — the SDK's ChatAssistantMessage Zod schema
+		// strips annotations from responses, which contain web search citations.
+		// The SDK's Responses API (client.responses.send()) does preserve annotations
+		// via ResponseOutputText, but it's currently in beta. Consider switching to
+		// the Responses API + SDK when it's stable.
 		const res = await fetch(OPENROUTER_API_URL, {
 			method: "POST",
 			headers: {

--- a/packages/lib/src/providers/types.ts
+++ b/packages/lib/src/providers/types.ts
@@ -19,6 +19,9 @@ export interface Provider {
 	name: string;
 	isConfigured(): boolean;
 	run(model: string, prompt: string, options?: ProviderOptions): Promise<ScrapeResult>;
+	/** Validate a target config. Returns an error message if invalid, null if valid.
+	 *  Omit for providers that accept any model (runtime validation only). */
+	validateTarget?(config: ModelConfig): string | null;
 }
 
 export interface TestResult {

--- a/packages/lib/src/text-extraction.ts
+++ b/packages/lib/src/text-extraction.ts
@@ -90,7 +90,8 @@ export function extractTextFromOpenRouter(rawOutput: any): string {
 
 export function extractTextFromOlostep(rawOutput: any): string {
 	try {
-		const parsed = rawOutput?.result?.json_content ? JSON.parse(rawOutput.result.json_content) : rawOutput;
+		const jsonStr = rawOutput?.json_content ?? rawOutput?.result?.json_content;
+		const parsed = typeof jsonStr === "string" ? JSON.parse(jsonStr) : rawOutput;
 		if (parsed?.result?.markdown_content) return parsed.result.markdown_content;
 		if (parsed?.answer_markdown) return parsed.answer_markdown;
 		if (parsed?.result?.text_content) return parsed.result.text_content;
@@ -230,12 +231,17 @@ export function extractCitationsFromDataforseo(rawOutput: any): Citation[] {
 export function extractCitationsFromOpenRouter(rawOutput: any): Citation[] {
 	try {
 		const citations: Citation[] = [];
+		const seen = new Set<string>();
 		let idx = 0;
 		for (const ann of rawOutput?.choices?.[0]?.message?.annotations ?? []) {
-			if (ann?.type === "url_citation" && ann.url) {
-				const c = parseCitationUrl(ann.url, ann.title, idx);
-				if (c) { citations.push(c); idx++; }
-			}
+			if (ann?.type !== "url_citation") continue;
+			const cite = ann.url_citation ?? ann;
+			const url = cite.url;
+			if (!url || typeof url !== "string" || !url.startsWith("http")) continue;
+			if (seen.has(url)) continue;
+			seen.add(url);
+			const c = parseCitationUrl(url, cite.title, idx);
+			if (c) { citations.push(c); idx++; }
 		}
 		return citations;
 	} catch {
@@ -245,7 +251,8 @@ export function extractCitationsFromOpenRouter(rawOutput: any): Citation[] {
 
 export function extractCitationsFromOlostep(rawOutput: any): Citation[] {
 	try {
-		const parsed = rawOutput?.result?.json_content ? JSON.parse(rawOutput.result.json_content) : rawOutput;
+		const jsonStr = rawOutput?.json_content ?? rawOutput?.result?.json_content;
+		const parsed = typeof jsonStr === "string" ? JSON.parse(jsonStr) : rawOutput;
 		const citations: Citation[] = [];
 		let idx = 0;
 		for (const source of parsed?.sources ?? parsed?.result?.links_on_page ?? parsed?.inline_references ?? []) {
@@ -255,6 +262,40 @@ export function extractCitationsFromOlostep(rawOutput: any): Citation[] {
 				if (c) { citations.push(c); idx++; }
 			}
 		}
+		return citations;
+	} catch {
+		return [];
+	}
+}
+
+export function extractCitationsFromAnthropic(rawOutput: any): Citation[] {
+	try {
+		const content = rawOutput?.content ?? [];
+		const seen = new Set<string>();
+		const citations: Citation[] = [];
+		let idx = 0;
+
+		for (const block of content) {
+			if (block.type === "text") {
+				for (const cit of block.citations ?? []) {
+					if (cit.type === "web_search_result_location" && cit.url && !seen.has(cit.url)) {
+						seen.add(cit.url);
+						const c = parseCitationUrl(cit.url, cit.title, idx);
+						if (c) { citations.push(c); idx++; }
+					}
+				}
+			}
+			if (block.type === "web_search_tool_result") {
+				for (const result of block.content ?? []) {
+					if (result.type === "web_search_result" && result.url && !seen.has(result.url)) {
+						seen.add(result.url);
+						const c = parseCitationUrl(result.url, result.title, idx);
+						if (c) { citations.push(c); idx++; }
+					}
+				}
+			}
+		}
+
 		return citations;
 	} catch {
 		return [];
@@ -309,7 +350,7 @@ export function extractCitations(rawOutput: any, providerOrEngine: string): Cita
 		case "anthropic-api":
 		case "anthropic":
 		case "claude":
-			return [];
+			return extractCitationsFromAnthropic(rawOutput);
 		default:
 			return [];
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,9 +500,6 @@ importers:
       '@brightdata/sdk':
         specifier: ^1.0.0
         version: 1.0.0
-      '@openrouter/sdk':
-        specifier: ^0.11.2
-        version: 0.11.2
       ai:
         specifier: ^6.0.146
         version: 6.0.146(zod@4.3.6)
@@ -1956,9 +1953,6 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
-
-  '@openrouter/sdk@0.11.2':
-    resolution: {integrity: sha512-uu8zu7vd4hA2l4vUD1UiZuefxqaH2/ixFcUG8GIO9+qcEJkWX4AYAil7SpGmZOTgy8STLFTEk4M4MmyUW0YMLg==}
 
   '@opentelemetry/api-logs@0.207.0':
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
@@ -9037,7 +9031,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.28.6
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
@@ -9052,7 +9046,7 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -9128,7 +9122,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       debug: 4.4.3
@@ -10170,10 +10164,6 @@ snapshots:
 
   '@open-draft/until@2.1.0':
     optional: true
-
-  '@openrouter/sdk@0.11.2':
-    dependencies:
-      zod: 4.3.6
 
   '@opentelemetry/api-logs@0.207.0':
     dependencies:
@@ -12787,8 +12777,8 @@ snapshots:
     dependencies:
       '@tanstack/history': 1.161.6
       cookie-es: 2.0.1
-      seroval: 1.5.1
-      seroval-plugins: 1.5.1(seroval@1.5.1)
+      seroval: 1.5.2
+      seroval-plugins: 1.5.2(seroval@1.5.2)
 
   '@tanstack/router-generator@1.166.24':
     dependencies:
@@ -12848,7 +12838,7 @@ snapshots:
       '@tanstack/router-core': 1.168.9
       '@tanstack/start-fn-stubs': 1.161.6
       '@tanstack/start-storage-context': 1.166.23
-      seroval: 1.5.1
+      seroval: 1.5.2
 
   '@tanstack/start-fn-stubs@1.161.6': {}
 
@@ -12901,7 +12891,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.4
       source-map: 0.7.6
-      srvx: 0.11.14
+      srvx: 0.11.15
       tinyglobby: 0.2.15
       ufo: 1.6.3
       vite: 8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -12934,7 +12924,7 @@ snapshots:
       '@tanstack/start-client-core': 1.167.9
       '@tanstack/start-storage-context': 1.166.23
       h3-v2: h3@2.0.1-rc.20(crossws@0.4.4(srvx@0.11.15))
-      seroval: 1.5.1
+      seroval: 1.5.2
     transitivePeerDependencies:
       - crossws
 


### PR DESCRIPTION
## Summary
- **OpenRouter**: Switch from SDK to raw `fetch()` — the SDK's Zod schema strips `annotations` from responses, which contain web search citations. Fix nested `url_citation` structure handling. Add 6 OpenRouter targets to CI matrix.
- **BrightData**: Add real web query extraction from `web_search_query` (grok) and `search_model_queries` (chatgpt) fields instead of echoing the prompt. Remove broken copilot support.
- **Olostep**: Switch from `/scrapes` to `/batches` API since `/scrapes` doesn't support most parsers. Fix web query extraction for flat string arrays (perplexity `search_model_queries`).
- **Anthropic API**: Extract citations from `web_search_tool_result` and `text` block citations (was hardcoded to `[]`).
- **Extraction**: Providers now return `["unavailable"]` for web queries when citations prove a search happened but the API doesn't expose query strings (OpenRouter, BrightData perplexity, Olostep grok). `[]` when no search occurred.
- **Test harness**: Replace hardcoded exemption lists with provider-driven `"unavailable"` sentinel detection. Add raw output size tracking to test output and CI summary table.

## Test plan
- [x] Verified OpenRouter claude-sonnet-4.6:online — 5 citations, "unavailable" web queries, PASS
- [x] Verified OpenRouter gpt-5-mini:online — 1 citation, "unavailable" web queries, PASS
- [x] Verified OpenRouter deepseek-v3.2 (offline) — PASS
- [x] Verified BrightData chatgpt:online — 9 citations, 1 real web query, PASS
- [x] Verified BrightData grok:online — 37 citations, 4 real web queries, PASS
- [x] Verified BrightData perplexity:online — 10 citations, "unavailable" web queries (confirmed `web_search_query: null` in raw response)
- [x] Verified Olostep perplexity:online — 10 citations, 1 real web query, PASS
- [x] Exhaustive raw response audit for all exempt providers confirming web queries genuinely aren't exposed
