### PR TITLE
Bump pnpm from 10.32.1 to 10.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "elmo",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.32.1",
+  "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## Summary
- Bumps `packageManager` from `pnpm@10.32.1` to `pnpm@10.33.0`.
- Unblocks the `pnpm/action-setup` v5 → v6 upgrade in #176.

## Why
`pnpm/action-setup@v6.0.0` has [a bug](https://github.com/pnpm/action-setup/issues/225) where it force-installs a pnpm 11 beta even when `packageManager` (or the explicit `version:` input) pins pnpm 10. That pre-run writes a two-document `pnpm-lock.yaml`, which pnpm 10.32.1 rejects as `ERR_PNPM_BROKEN_LOCKFILE` ("expected a single document in the stream, but found more") — breaking both the license-check and E2E workflows on #176.

pnpm 10.33.0 added forward-compat parsing for the two-document lockfile format that pnpm 11 will write (release note: *"When a pnpm-lock.yaml contains two documents, ignore the first one."*), so upgrading sidesteps the `action-setup` bug without having to pull in pnpm 11 beta.

No lockfile regeneration needed — `pnpm install` on 10.33 reports the existing lockfile as up-to-date.

## Test plan
- [x] License Check workflow passes on this branch
- [x] E2E Tests workflow passes on this branch
- [ ] After merge, rebase #176 and confirm its CI goes green