### PR TITLE
Run provider tests on a single runner in parallel

### DIFF
--- a/.github/workflows/test-providers.yaml
+++ b/.github/workflows/test-providers.yaml
@@ -14,12 +14,41 @@ permissions:
   contents: read
 
 jobs:
-  # When a specific target is provided, run just that one
-  single:
-    if: inputs.target != ''
-    name: "Test: ${{ inputs.target }}"
+  test:
+    name: Test Providers
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 10
+    # All targets run in parallel on a single runner (they're I/O-bound waiting
+    # on external provider APIs), so the job wall-clock is ~the slowest target.
+    timeout-minutes: 40
+    env:
+      # Full set of targets run on the schedule. workflow_dispatch can override
+      # via inputs.target to run just a subset.
+      ALL_TARGETS: >-
+        chatgpt:olostep:online,
+        google-ai-mode:olostep:online,
+        google-ai-overview:olostep:online,
+        gemini:olostep:online,
+        copilot:olostep:online,
+        perplexity:olostep:online,
+        grok:olostep:online,
+        chatgpt:brightdata,
+        chatgpt:brightdata:online,
+        google-ai-mode:brightdata:online,
+        gemini:brightdata:online,
+        perplexity:brightdata:online,
+        grok:brightdata:online,
+        copilot:brightdata:online,
+        google-ai-mode:dataforseo:online,
+        chatgpt:openai-api:gpt-5-mini,
+        chatgpt:openai-api:gpt-5-mini:online,
+        claude:anthropic-api:claude-sonnet-4-20250514,
+        claude:anthropic-api:claude-sonnet-4-20250514:online,
+        claude:openrouter:anthropic/claude-sonnet-4.6,
+        claude:openrouter:anthropic/claude-sonnet-4.6:online,
+        chatgpt:openrouter:openai/gpt-5-mini,
+        chatgpt:openrouter:openai/gpt-5-mini:online,
+        deepseek:openrouter:deepseek/deepseek-v3.2,
+        mistral:openrouter:mistralai/mistral-small-2603
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
@@ -28,8 +57,22 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --no-frozen-lockfile
-      - name: Test provider
-        timeout-minutes: 30
+      - name: Resolve target list
+        id: targets
+        env:
+          OVERRIDE: ${{ inputs.target }}
+        run: |
+          if [ -n "$OVERRIDE" ]; then
+            TARGETS="$OVERRIDE"
+          else
+            # Strip whitespace from the YAML-folded ALL_TARGETS list.
+            TARGETS="$(printf '%s' "$ALL_TARGETS" | tr -d '[:space:]')"
+          fi
+          echo "value=$TARGETS" >> "$GITHUB_OUTPUT"
+      - name: Test providers
+        id: test
+        timeout-minutes: 35
+        continue-on-error: true
         env:
           OLOSTEP_API_KEY: ${{ secrets.OLOSTEP_API_KEY }}
           BRIGHTDATA_API_TOKEN: ${{ secrets.BRIGHTDATA_API_TOKEN }}
@@ -38,67 +81,7 @@ jobs:
           DATAFORSEO_LOGIN: ${{ secrets.DATAFORSEO_LOGIN }}
           DATAFORSEO_PASSWORD: ${{ secrets.DATAFORSEO_PASSWORD }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-        run: pnpm tsx apps/worker/scripts/test-provider.ts --target "${{ inputs.target }}"
-
-  # When no target is provided, test all main targets in parallel
-  matrix:
-    if: inputs.target == ''
-    name: "Test: ${{ matrix.target }}"
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          # Olostep
-          - "chatgpt:olostep:online"
-          - "google-ai-mode:olostep:online"
-          - "google-ai-overview:olostep:online"
-          - "gemini:olostep:online"
-          - "copilot:olostep:online"
-          - "perplexity:olostep:online"
-          - "grok:olostep:online"
-          # BrightData
-          - "chatgpt:brightdata"
-          - "chatgpt:brightdata:online"
-          - "google-ai-mode:brightdata:online"
-          - "gemini:brightdata:online"
-          - "perplexity:brightdata:online"
-          - "grok:brightdata:online"
-          - "copilot:brightdata:online"
-          # DataForSEO
-          - "google-ai-mode:dataforseo:online"
-          # Direct API
-          - "chatgpt:openai-api:gpt-5-mini"
-          - "chatgpt:openai-api:gpt-5-mini:online"
-          - "claude:anthropic-api:claude-sonnet-4-20250514"
-          - "claude:anthropic-api:claude-sonnet-4-20250514:online"
-          # OpenRouter
-          - "claude:openrouter:anthropic/claude-sonnet-4.6"
-          - "claude:openrouter:anthropic/claude-sonnet-4.6:online"
-          - "chatgpt:openrouter:openai/gpt-5-mini"
-          - "chatgpt:openrouter:openai/gpt-5-mini:online"
-          - "deepseek:openrouter:deepseek/deepseek-v3.2"
-          - "mistral:openrouter:mistralai/mistral-small-2603"
-    steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --no-frozen-lockfile
-      - name: Test provider
-        timeout-minutes: 30
-        env:
-          OLOSTEP_API_KEY: ${{ secrets.OLOSTEP_API_KEY }}
-          BRIGHTDATA_API_TOKEN: ${{ secrets.BRIGHTDATA_API_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          DATAFORSEO_LOGIN: ${{ secrets.DATAFORSEO_LOGIN }}
-          DATAFORSEO_PASSWORD: ${{ secrets.DATAFORSEO_PASSWORD }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-        run: pnpm tsx apps/worker/scripts/test-provider.ts --target "${{ matrix.target }}" --output-json result.json
+        run: pnpm tsx apps/worker/scripts/test-provider.ts --target "${{ steps.targets.outputs.value }}" --output-json result.json
       - name: Push results to Upstash Redis
         if: always() && hashFiles('result.json') != ''
         env:
@@ -145,86 +128,15 @@ jobs:
           }
           push().catch(e => { console.error(e); process.exit(1); });
           '
-      - name: Sanitize artifact name
-        if: always()
-        id: artifact
-        run: echo "name=result-$(echo '${{ matrix.target }}' | tr ':/\\' '-')" >> $GITHUB_OUTPUT
-      - name: Upload result
-        if: always()
+      - name: Upload results artifact
+        if: always() && hashFiles('result.json') != ''
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ steps.artifact.outputs.name }}
+          name: provider-results
           path: result.json
-          retention-days: 1
-
-  summary:
-    if: inputs.target == '' && always()
-    needs: [matrix]
-    name: Summary
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    steps:
-      - name: Download results
-        uses: actions/download-artifact@v8
-        with:
-          pattern: result-*
-          path: results
-      - name: Generate summary
+          retention-days: 7
+      - name: Fail job if any target failed
+        if: always() && steps.test.outcome == 'failure'
         run: |
-          node -e '
-          const fs = require("fs");
-          const path = require("path");
-
-          const resultsDir = "results";
-          const allResults = [];
-
-          for (const dir of fs.readdirSync(resultsDir)) {
-            const file = path.join(resultsDir, dir, "result.json");
-            if (!fs.existsSync(file)) continue;
-            const data = JSON.parse(fs.readFileSync(file, "utf8"));
-            allResults.push(...(Array.isArray(data) ? data : [data]));
-          }
-
-          allResults.sort((a, b) => a.target.localeCompare(b.target));
-
-          const passed = allResults.filter(r => r.status === "pass").length;
-          const failed = allResults.filter(r => r.status === "fail").length;
-          const total = allResults.length;
-          const overall = failed > 0 ? `:x: ${failed} failed` : `:white_check_mark: All passed`;
-
-          const lines = [
-            `## Provider Test Results — ${overall} (${passed}/${total})`,
-            "",
-            "| Status | Target | Latency | Error | Text | Raw Output | Citations | Web Queries | Web Search | Sample Output |",
-            "|--------|--------|---------|-------|------|------------|-----------|-------------|------------|---------------|",
-          ];
-
-          for (const r of allResults) {
-            const status = r.status === "pass" ? ":white_check_mark:" : ":x:";
-            const error = (r.error || "").slice(0, 100).replace(/\|/g, "\\|");
-            const rawKB = ((r.rawOutputBytes || 0) / 1024).toFixed(1) + " KB";
-            const sample = r.sampleOutput
-              ? `<details><summary>Show</summary><pre>${r.sampleOutput.replace(/\|/g, "\\|").replace(/\n/g, "<br>")}</pre></details>`
-              : "";
-            lines.push(
-              `| ${status} | \`${r.target}\` | ${r.latency}ms | ${error} | ${r.textLength} | ${rawKB} | ${r.citations} | ${r.webQueries} | ${r.webSearch ? "enabled" : "disabled"} | ${sample} |`
-            );
-          }
-
-          const allIssues = allResults.flatMap(r =>
-            (r.issues || []).map(i => ({ target: r.target, ...i }))
-          );
-
-          if (allIssues.length > 0) {
-            lines.push("", "### Validation Issues", "");
-            lines.push("| Severity | Target | Field | Issue |");
-            lines.push("|----------|--------|-------|-------|");
-            for (const i of allIssues) {
-              const icon = i.severity === "error" ? ":x:" : ":warning:";
-              lines.push(`| ${icon} | \`${i.target}\` | \`${i.field}\` | ${i.message} |`);
-            }
-          }
-
-          lines.push("");
-          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join("\n"));
-          console.log(`Wrote summary for ${total} targets (${passed} passed, ${failed} failed)`);
-          '
+          echo "One or more provider targets failed — see the summary for details."
+          exit 1

--- a/apps/worker/scripts/test-provider.ts
+++ b/apps/worker/scripts/test-provider.ts
@@ -55,6 +55,7 @@ function parseArgs(): ParsedArgs {
 Usage: pnpm tsx --env-file=.env scripts/test-provider.ts --target <scrape-targets> [--output-json <path>] [--dump <path>]
 
   <scrape-targets>  Comma-separated SCRAPE_TARGETS entries, e.g. "chatgpt:olostep:online,gemini:olostep:online"
+                    When multiple targets are provided, they are all tested in parallel.
   --output-json     Write results as JSON to the given path (for CI artifact collection)
   --dump            Write full raw output for each target to the given directory
 
@@ -194,17 +195,22 @@ function validateResult(result: ScrapeResult, providerId: string, webSearch: boo
 	return issues;
 }
 
-async function runTarget(target: string, dumpDir?: string): Promise<TargetResult> {
+async function runTarget(target: string, dumpDir?: string): Promise<{ result: TargetResult; logs: string }> {
+	const buffered: string[] = [];
+	const tlog = (message: string, color?: string) => {
+		buffered.push(`${color || ""}${message}${colors.reset}`);
+	};
+
 	const [config] = parseScrapeTargets(target);
 	const providerId = config.provider;
 	const provider = getProvider(providerId);
 	const meta = getModelMeta(config.model);
 	const versionStr = config.version ? ` (${config.version})` : "";
 
-	log(`\nTesting: ${meta.label} via ${providerId}${versionStr}`, colors.bright);
-	log(`Web search: ${config.webSearch ? "enabled" : "disabled"}`, colors.dim);
-	log(`Test prompt: "${TEST_PROMPTS[0]}"`, colors.dim);
-	log(`Validating: text content (${MIN_TEXT_LENGTH}+ chars), citations, rawOutput re-extraction\n`, colors.dim);
+	tlog(`\nTesting: ${meta.label} via ${providerId}${versionStr}`, colors.bright);
+	tlog(`Web search: ${config.webSearch ? "enabled" : "disabled"}`, colors.dim);
+	tlog(`Test prompt: "${TEST_PROMPTS[0]}"`, colors.dim);
+	tlog(`Validating: text content (${MIN_TEXT_LENGTH}+ chars), citations, rawOutput re-extraction\n`, colors.dim);
 
 	let attemptStart = Date.now();
 	let result: ScrapeResult;
@@ -217,29 +223,32 @@ async function runTarget(target: string, dumpDir?: string): Promise<TargetResult
 	} catch (error) {
 		const latency = Date.now() - attemptStart;
 		const errorMsg = error instanceof Error ? error.message : String(error);
-		log(`FAIL (${formatLatency(latency)})`, colors.red);
-		log(`  Error: ${errorMsg}`, colors.red);
+		tlog(`FAIL (${formatLatency(latency)})`, colors.red);
+		tlog(`  Error: ${errorMsg}`, colors.red);
 		return {
-			target,
-			status: "fail",
-			latency,
-			retries: 0,
-			error: errorMsg,
-			textLength: 0,
-			rawOutputBytes: 0,
-			citations: 0,
-			webQueries: 0,
-			webSearch: config.webSearch,
-			sampleOutput: "",
-			issues: [],
-			timestamp: new Date().toISOString(),
+			result: {
+				target,
+				status: "fail",
+				latency,
+				retries: 0,
+				error: errorMsg,
+				textLength: 0,
+				rawOutputBytes: 0,
+				citations: 0,
+				webQueries: 0,
+				webSearch: config.webSearch,
+				sampleOutput: "",
+				issues: [],
+				timestamp: new Date().toISOString(),
+			},
+			logs: buffered.join("\n"),
 		};
 	}
 
 	// Retry with different prompts if web search was expected but no citations/queries came back
 	if (config.webSearch && result.citations.length === 0 && !hasRealWebQueries(result.webQueries)) {
 		for (let i = 1; i < TEST_PROMPTS.length; i++) {
-			log(`No citations or web queries — retrying with prompt ${i + 1}/${TEST_PROMPTS.length}: "${TEST_PROMPTS[i]}"`, colors.yellow);
+			tlog(`No citations or web queries — retrying with prompt ${i + 1}/${TEST_PROMPTS.length}: "${TEST_PROMPTS[i]}"`, colors.yellow);
 			retries++;
 			try {
 				attemptStart = Date.now();
@@ -265,50 +274,53 @@ async function runTarget(target: string, dumpDir?: string): Promise<TargetResult
 		mkdirSync(dumpDir, { recursive: true });
 		const filename = `${dumpDir}/${target.replace(/[/:]/g, "-")}.json`;
 		writeFileSync(filename, rawJson);
-		log(`Dumped raw output to ${filename}`, colors.dim);
+		tlog(`Dumped raw output to ${filename}`, colors.dim);
 	}
 
-	log(`Latency:      ${formatLatency(latency)}`, colors.dim);
-	log(`Text:         ${result.textContent?.length ?? 0} chars`, colors.dim);
-	log(`Raw output:   ${(rawOutputBytes / 1024).toFixed(1)} KB`, colors.dim);
-	log(`Citations:    ${result.citations.length}`, colors.blue);
-	log(`Web queries:  ${result.webQueries.length}`, colors.dim);
+	tlog(`Latency:      ${formatLatency(latency)}`, colors.dim);
+	tlog(`Text:         ${result.textContent?.length ?? 0} chars`, colors.dim);
+	tlog(`Raw output:   ${(rawOutputBytes / 1024).toFixed(1)} KB`, colors.dim);
+	tlog(`Citations:    ${result.citations.length}`, colors.blue);
+	tlog(`Web queries:  ${result.webQueries.length}`, colors.dim);
 
 	if (result.textContent) {
-		log("\nSample output:", colors.dim);
-		log(`  ${result.textContent.slice(0, 300).replace(/\n/g, "\n  ")}`, colors.dim);
+		tlog("\nSample output:", colors.dim);
+		tlog(`  ${result.textContent.slice(0, 300).replace(/\n/g, "\n  ")}`, colors.dim);
 	}
 
 	if (issues.length > 0) {
-		log("\nIssues:", colors.bright);
+		tlog("\nIssues:", colors.bright);
 		for (const issue of issues) {
 			const color = issue.severity === "error" ? colors.red : colors.yellow;
 			const prefix = issue.severity === "error" ? "ERROR" : "WARN";
-			log(`  ${prefix}: [${issue.field}] ${issue.message}`, color);
+			tlog(`  ${prefix}: [${issue.field}] ${issue.message}`, color);
 		}
 	}
 
-	console.log();
+	tlog("");
 
 	if (hasErrors) {
-		log("FAIL", colors.red);
+		tlog("FAIL", colors.red);
 	} else {
-		log("PASS", colors.green);
+		tlog("PASS", colors.green);
 	}
 
 	return {
-		target,
-		status: hasErrors ? "fail" : "pass",
-		latency,
-		retries,
-		textLength: result.textContent?.length ?? 0,
-		rawOutputBytes,
-		citations: result.citations.length,
-		webQueries: result.webQueries.length,
-		webSearch: config.webSearch,
-		sampleOutput: result.textContent?.slice(0, 500) ?? "",
-		issues,
-		timestamp: new Date().toISOString(),
+		result: {
+			target,
+			status: hasErrors ? "fail" : "pass",
+			latency,
+			retries,
+			textLength: result.textContent?.length ?? 0,
+			rawOutputBytes,
+			citations: result.citations.length,
+			webQueries: result.webQueries.length,
+			webSearch: config.webSearch,
+			sampleOutput: result.textContent?.slice(0, 500) ?? "",
+			issues,
+			timestamp: new Date().toISOString(),
+		},
+		logs: buffered.join("\n"),
 	};
 }
 
@@ -361,10 +373,16 @@ async function main() {
 	const { target: targetArg, outputJson, dump } = parseArgs();
 	const targets = targetArg.split(",").map((t) => t.trim()).filter(Boolean);
 
-	const results: TargetResult[] = [];
-	for (const target of targets) {
-		results.push(await runTarget(target, dump));
-	}
+	// Run all targets in parallel. Each is almost entirely waiting on an external
+	// HTTP call, so there's no benefit to throttling. Logs are buffered per target
+	// and flushed as a coherent block when that target finishes, so output from
+	// concurrent targets doesn't interleave.
+	const pending = targets.map(async (target) => {
+		const { result, logs } = await runTarget(target, dump);
+		process.stdout.write(`${logs}\n`);
+		return result;
+	});
+	const results = await Promise.all(pending);
 
 	const passed = results.filter((r) => r.status === "pass").length;
 	const failed = results.filter((r) => r.status === "fail").length;
@@ -376,9 +394,8 @@ async function main() {
 
 	if (outputJson) {
 		writeFileSync(outputJson, JSON.stringify(results, null, 2));
-	} else {
-		writeGitHubSummary(results);
 	}
+	writeGitHubSummary(results);
 
 	if (failed > 0) process.exit(1);
 }


### PR DESCRIPTION
## Summary
- The previous matrix strategy ran each of the 25 provider targets on its own Blacksmith runner, each paying the checkout + `pnpm install` overhead, to do a single HTTP-bound test. That's a lot of runner minutes for work that's almost entirely waiting on external APIs.
- `test-provider.ts` now runs all comma-separated targets in parallel on one runner, buffering logs per target so concurrent output doesn't interleave. It also unconditionally writes the GitHub step summary (when `GITHUB_STEP_SUMMARY` is set), in addition to `--output-json`.
- The workflow collapses to a single `test` job that runs the full target list, writes the summary via the script, pushes every result to Upstash Redis in one step (Redis code already supported arrays), and uploads a single `result.json` artifact. The separate summary job is gone.
- Reporting is preserved: the GitHub Actions summary shows the same markdown table as before, and Redis still receives one entry per target at `provider-status:<target>`.
