### PR TITLE
switch frontend model ids to chatgpt / claude / google-ai-mode

### DIFF
--- a/apps/web/src/components/cached-prompt-chart.tsx
+++ b/apps/web/src/components/cached-prompt-chart.tsx
@@ -22,7 +22,7 @@ const PLACEHOLDER_BARS_NO_VISIBILITY = [10, 15, 8, 12, 10, 14, 8, 12, 10, 15, 12
 	(h, i) => ({ key: String(i), h }),
 );
 
-type ModelType = "openai" | "anthropic" | "google" | "all";
+type ModelType = "chatgpt" | "claude" | "google-ai-mode" | "all";
 
 function PromptTitle({ name, highlight }: { name: string; highlight: string }) {
 	return (
@@ -38,7 +38,7 @@ export interface CachedPromptChartProps {
 	brandId: string;
 	lookback: LookbackPeriod;
 	selectedModel?: ModelType;
-	availableModels?: ("openai" | "anthropic" | "google")[];
+	availableModels?: ("chatgpt" | "claude" | "google-ai-mode")[];
 	searchHighlight?: string;
 	// Whether this prompt has ever been evaluated (all-time)
 	// Used to distinguish "never evaluated" vs "no data in selected window"
@@ -51,7 +51,7 @@ export function CachedPromptChart({
 	brandId,
 	lookback = "1m",
 	selectedModel = "all",
-	availableModels = ["openai", "anthropic", "google"],
+	availableModels = ["chatgpt", "claude", "google-ai-mode"],
 	searchHighlight = "",
 	hasEverBeenEvaluated = false,
 }: CachedPromptChartProps) {

--- a/apps/web/src/components/chart-actions-footer.tsx
+++ b/apps/web/src/components/chart-actions-footer.tsx
@@ -21,8 +21,8 @@ interface ChartActionsFooterProps {
 	isDownloading?: boolean;
 	
 	// For optimization
-	selectedModel?: "openai" | "anthropic" | "google" | "all";
-	availableModels?: ("openai" | "anthropic" | "google")[];
+	selectedModel?: "chatgpt" | "claude" | "google-ai-mode" | "all";
+	availableModels?: ("chatgpt" | "claude" | "google-ai-mode")[];
 	lookback?: LookbackPeriod;
 }
 
@@ -33,7 +33,7 @@ export function ChartActionsFooter({
 	onDownload,
 	isDownloading = false,
 	selectedModel = "all",
-	availableModels = ["openai", "anthropic", "google"],
+	availableModels = ["chatgpt", "claude", "google-ai-mode"],
 	lookback = "1m",
 }: ChartActionsFooterProps) {
 	const isSinglePrompt = Boolean(promptId && brandId);

--- a/apps/web/src/components/page-header.tsx
+++ b/apps/web/src/components/page-header.tsx
@@ -11,20 +11,20 @@ import { VisibilityBar, VisibilityBarSkeleton, VisibilityBarEmpty } from "@/comp
 import { type LookbackPeriod, getDefaultLookbackPeriod } from "@/lib/chart-utils";
 import { useBrand } from "@/hooks/use-brands";
 
-export type ModelType = "openai" | "anthropic" | "google" | "all";
+export type ModelType = "chatgpt" | "claude" | "google-ai-mode" | "all";
 
-const modelParser = parseAsStringLiteral(["openai", "anthropic", "google", "all"] as const);
+const modelParser = parseAsStringLiteral(["chatgpt", "claude", "google-ai-mode", "all"] as const);
 const lookbackParser = parseAsStringLiteral(["1w", "1m", "3m", "6m", "1y", "all"] as const);
 const tagsParser = parseAsArrayOf(parseAsString, ",");
 const searchParser = parseAsString;
 
 function getModelIcon(modelType: ModelType) {
 	switch (modelType) {
-		case "openai":
+		case "chatgpt":
 			return <SiOpenai className="size-3" />;
-		case "anthropic":
+		case "claude":
 			return <SiAnthropic className="size-3" />;
-		case "google":
+		case "google-ai-mode":
 			return <SiGoogle className="size-3" />;
 		case "all":
 			return <MdSelectAll className="size-3" />;
@@ -132,7 +132,7 @@ export function PageHeader({
 	showSearch = false,
 	showModelSelector = false,
 	showVisibilityBar = false,
-	availableModels = ["all", "openai", "anthropic", "google"],
+	availableModels = ["all", "chatgpt", "claude", "google-ai-mode"],
 	defaultModel = "all",
 	onModelChange,
 	selectedModel: controlledModel,
@@ -228,19 +228,19 @@ export function PageHeader({
 										{getModelIcon("all")} <span className="sr-only sm:not-sr-only">All</span>
 									</TabsTrigger>
 								)}
-								{availableModels.includes("openai") && (
-									<TabsTrigger value="openai" className="cursor-pointer">
-										{getModelIcon("openai")} <span className="sr-only sm:not-sr-only">OpenAI</span>
+								{availableModels.includes("chatgpt") && (
+									<TabsTrigger value="chatgpt" className="cursor-pointer">
+										{getModelIcon("chatgpt")} <span className="sr-only sm:not-sr-only">ChatGPT</span>
 									</TabsTrigger>
 								)}
-								{availableModels.includes("anthropic") && (
-									<TabsTrigger value="anthropic" className="cursor-pointer">
-										{getModelIcon("anthropic")} <span className="sr-only sm:not-sr-only">Anthropic</span>
+								{availableModels.includes("claude") && (
+									<TabsTrigger value="claude" className="cursor-pointer">
+										{getModelIcon("claude")} <span className="sr-only sm:not-sr-only">Claude</span>
 									</TabsTrigger>
 								)}
-								{availableModels.includes("google") && (
-									<TabsTrigger value="google" className="cursor-pointer">
-										{getModelIcon("google")} <span className="sr-only sm:not-sr-only">Google</span>
+								{availableModels.includes("google-ai-mode") && (
+									<TabsTrigger value="google-ai-mode" className="cursor-pointer">
+										{getModelIcon("google-ai-mode")} <span className="sr-only sm:not-sr-only">Google</span>
 									</TabsTrigger>
 								)}
 							</TabsList>

--- a/apps/web/src/components/progress-bar-chart.tsx
+++ b/apps/web/src/components/progress-bar-chart.tsx
@@ -175,9 +175,9 @@ export function ProgressBarChart({
 export { DOMAIN_CATEGORY_COLORS } from "@/lib/domain-categories";
 
 export const MODEL_COLORS: ColorMapping = {
-	openai: "#10b981", // green
-	anthropic: "#f59e0b", // amber/orange
-	google: "#3b82f6", // blue
+	chatgpt: "#10b981", // green
+	claude: "#f59e0b", // amber/orange
+	"google-ai-mode": "#3b82f6", // blue
 	all: "#8b5cf6", // purple
 };
 

--- a/apps/web/src/components/prompts-display.tsx
+++ b/apps/web/src/components/prompts-display.tsx
@@ -84,8 +84,8 @@ export function PromptsDisplay({
 
 
 	// Filter available models based on excludeModels prop
-	const availableIndividualModels: ("openai" | "anthropic" | "google")[] = (
-		["openai", "anthropic", "google"] as const
+	const availableIndividualModels: ("chatgpt" | "claude" | "google-ai-mode")[] = (
+		["chatgpt", "claude", "google-ai-mode"] as const
 	).filter((model) => !excludeModels.includes(model));
 
 	const availableModels: ModelType[] =

--- a/apps/web/src/components/virtualized-prompt-list.tsx
+++ b/apps/web/src/components/virtualized-prompt-list.tsx
@@ -4,7 +4,7 @@ import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { CachedPromptChart } from "./cached-prompt-chart";
 import type { LookbackPeriod } from "@/hooks/use-prompt-chart-data";
 
-type ModelType = "openai" | "anthropic" | "google" | "all";
+type ModelType = "chatgpt" | "claude" | "google-ai-mode" | "all";
 
 interface PromptItem {
 	id: string;
@@ -19,7 +19,7 @@ interface VirtualizedPromptListProps {
 	brandId: string;
 	lookback: LookbackPeriod;
 	selectedModel: ModelType;
-	availableModels: ("openai" | "anthropic" | "google")[];
+	availableModels: ("chatgpt" | "claude" | "google-ai-mode")[];
 	searchHighlight?: string;
 }
 

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -25,13 +25,6 @@ export function getModelDisplayName(model: string): string {
 			return "Perplexity";
 		case "grok":
 			return "Grok";
-		// Legacy names for backward compatibility with stored data
-		case "openai":
-			return "ChatGPT";
-		case "anthropic":
-			return "Claude";
-		case "google":
-			return "Google AI Mode";
 		default:
 			return model;
 	}

--- a/apps/web/src/routes/_authed/app/$brand/prompts/$promptId.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/prompts/$promptId.tsx
@@ -410,7 +410,7 @@ function WebQueriesTab({
 		return <div className="py-12 text-center text-muted-foreground text-sm">No web query data available for this time period.</div>;
 	}
 
-	const modelOrder = ["openai", "anthropic", "google"];
+	const modelOrder = ["chatgpt", "claude", "google-ai-mode"];
 
 	return (
 		<Card>

--- a/apps/web/src/routes/_authed/app/$brand/settings/llms.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/settings/llms.tsx
@@ -25,7 +25,7 @@ interface ModelGroupInfo {
 
 const MODEL_GROUPS: ModelGroupInfo[] = [
 	{
-		id: "openai",
+		id: "chatgpt",
 		name: "ChatGPT",
 		provider: "OpenAI",
 		currentModel: "gpt-5-mini",
@@ -39,7 +39,7 @@ const MODEL_GROUPS: ModelGroupInfo[] = [
 			"Responses include real-time information from the web, making visibility here especially impactful for brand discovery.",
 	},
 	{
-		id: "anthropic",
+		id: "claude",
 		name: "Claude",
 		provider: "Anthropic",
 		currentModel: "claude-sonnet-4-20250514",
@@ -53,7 +53,7 @@ const MODEL_GROUPS: ModelGroupInfo[] = [
 			"Responses are based on Claude's training data. Brand mentions reflect how well your brand is represented in publicly available content.",
 	},
 	{
-		id: "google",
+		id: "google-ai-mode",
 		name: "Google AI Overviews",
 		provider: "Google",
 		currentModel: "AI Mode",

--- a/apps/web/src/stories/prompt-chart.stories.tsx
+++ b/apps/web/src/stories/prompt-chart.stories.tsx
@@ -118,7 +118,7 @@ const baseProps = {
 	brandId: "brand-1",
 	lookback: "1m" as const,
 	selectedModel: "all" as const,
-	availableModels: ["openai", "anthropic", "google"] as ("openai" | "anthropic" | "google")[],
+	availableModels: ["chatgpt", "claude", "google-ai-mode"] as ("chatgpt" | "claude" | "google-ai-mode")[],
 	hasEverBeenEvaluated: true,
 };
 


### PR DESCRIPTION
## Summary

Migration 0008 remapped `prompt_runs.model` and `citations.model` from the legacy values (`openai`, `anthropic`, `google`) to the new canonical ids (`chatgpt`, `claude`, `google-ai-mode`). The DB no longer contains the legacy values, but the frontend was still sending them as the `?model=` URL param, so every filtered query on `/visibility`, `/citations`, and the prompts pages silently returned zero rows.

- Swap the model identifiers used by the `?model=` URL param and the model-selector tabs (`page-header.tsx`).
- Update `MODEL_COLORS` (`progress-bar-chart.tsx`), `MODEL_GROUPS` (llms settings), and the `modelOrder` on the single-prompt route.
- Propagate the new `"chatgpt" | "claude" | "google-ai-mode"` union through the prop types in `prompts-display`, `virtualized-prompt-list`, `chart-actions-footer`, `cached-prompt-chart`, and the chart story.
- Drop the now-dead legacy cases in `getModelDisplayName` (`lib/utils.ts`) — the DB no longer stores them.

This is a cold switchover: bookmarks using `?model=openai` etc. will no longer match. If we want to preserve old URLs we can add a one-line translator in `modelParser` later, but nothing in the DB would satisfy those filters anyway.
