### PR TITLE
aggregate package changelogs into a single GitHub release

### DIFF
--- a/.changeset/cli-scraper-providers.md
+++ b/.changeset/cli-scraper-providers.md
@@ -1,5 +1,5 @@
 ---
-"@elmohq/cli": minor
+"@elmohq/cli": patch
 "@workspace/lib": patch
 "@workspace/docs": patch
 ---

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,15 +47,51 @@ jobs:
         id: version
         run: echo "version=$(node -p "require('./apps/cli/package.json').version")" >> $GITHUB_OUTPUT
 
-      - name: Publish and create GitHub releases
+      - name: Publish packages
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm release
-          createGithubReleases: true
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create aggregated GitHub release
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          node <<'EOF'
+          const fs = require('fs');
+          const path = require('path');
+          const version = process.env.VERSION;
+          const sections = [];
+          for (const root of ['apps', 'packages']) {
+            if (!fs.existsSync(root)) continue;
+            for (const dir of fs.readdirSync(root)) {
+              const pkgPath = path.join(root, dir, 'package.json');
+              const clPath = path.join(root, dir, 'CHANGELOG.md');
+              if (!fs.existsSync(pkgPath) || !fs.existsSync(clPath)) continue;
+              const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+              const lines = fs.readFileSync(clPath, 'utf8').split('\n');
+              let start = -1, end = lines.length;
+              for (let i = 0; i < lines.length; i++) {
+                if (lines[i].trim() === `## ${version}`) { start = i + 1; continue; }
+                if (start >= 0 && lines[i].startsWith('## ')) { end = i; break; }
+              }
+              if (start < 0) continue;
+              const body = lines.slice(start, end).join('\n').trim();
+              if (!body) continue;
+              sections.push(`## ${pkg.name}\n\n${body}`);
+            }
+          }
+          const notes = sections.length ? sections.join('\n\n') : `Release v${version}`;
+          fs.writeFileSync('release-notes.md', notes);
+          EOF
+          gh release create "v$VERSION" --title "v$VERSION" --notes-file release-notes.md
 
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v1


### PR DESCRIPTION
## Summary
- The last release cut one GitHub release for `@elmohq/cli` with an empty body. Root cause: `changesets/action` with `createGithubReleases: true` emits one release per published npm package, and every package except the CLI is `"private": true`. The CLI's CHANGELOG section for 0.2.0 was also empty because none of the consumed changesets listed `@elmohq/cli` — only the fixed-group version bump touched it.
- Drop `createGithubReleases` and add a post-publish step that walks `apps/*` and `packages/*`, pulls each package's `## <version>` section from its CHANGELOG.md, and concatenates them under `## <package-name>` headers into a single `v<version>` release via `gh`. Gated on `steps.changesets.outputs.published == 'true'` so dry runs don't create empty releases.
- Downgrade the pending `cli-scraper-providers` changeset from minor to patch.