### PR TITLE
CLI: treat external DATABASE_URL as secret, note IPv4 requirement

### DIFF
--- a/.changeset/cli-postgres-secret.md
+++ b/.changeset/cli-postgres-secret.md
@@ -1,0 +1,5 @@
+---
+"@elmohq/cli": patch
+---
+
+CLI: mask the external `DATABASE_URL` prompt and note that it must be an IPv4-compatible direct connection or pooler.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -319,7 +319,11 @@ async function runInit(options: InitOptions, version: string): Promise<void> {
 	env.VITE_APP_URL = DEFAULT_APP_URL;
 
 	if (postgresMode === "external") {
-		const url = await p.text({
+		p.note(
+			"Must be an IPv4-compatible direct connection or database pooler.",
+			"DATABASE_URL",
+		);
+		const url = await p.password({
 			message: "DATABASE_URL",
 			validate: (v) => (!v ? "Required" : undefined),
 		});


### PR DESCRIPTION
## Summary
- Mask the external Postgres connection string prompt in the CLI (`p.password` instead of `p.text`).
- Add an inline note that a user-provided `DATABASE_URL` must be an IPv4-compatible direct connection or database pooler.