### PR TITLE
show brand switcher for demo users with multiple memberships

### DIFF
--- a/.changeset/demo-multi-org-switcher.md
+++ b/.changeset/demo-multi-org-switcher.md
@@ -1,0 +1,6 @@
+---
+"@workspace/local": patch
+"@workspace/web": patch
+---
+
+Demo deployments now surface the brand switcher when the signed-in user has memberships in multiple organizations. `supportsMultiOrg` is enabled for demo mode, and `/app` always renders the switcher for users with 2+ brands (falling back to the previous single-org redirect otherwise).

--- a/.changeset/demo-multi-org-switcher.md
+++ b/.changeset/demo-multi-org-switcher.md
@@ -3,4 +3,4 @@
 "@workspace/web": patch
 ---
 
-Demo deployments now surface the brand switcher when the signed-in user has memberships in multiple organizations. `supportsMultiOrg` is enabled for demo mode, and `/app` always renders the switcher for users with 2+ brands (falling back to the previous single-org redirect otherwise).
+Demo deployments (`READ_ONLY=true`) now enable `supportsMultiOrg`, so the `/app` brand switcher renders when the demo user is seeded into multiple organizations. Pure local deployments continue to auto-redirect to the default org.

--- a/apps/web/src/routes/_authed/app/index.tsx
+++ b/apps/web/src/routes/_authed/app/index.tsx
@@ -57,11 +57,6 @@ export const Route = createFileRoute("/_authed/app/")({
 	loader: async () => {
 		const result = await getOrganizations();
 
-		// Always show the switcher when the user has multiple brands, regardless of deployment flag.
-		if (result.organizations.length >= 2) {
-			return result;
-		}
-
 		// Single-org mode: redirect to default org
 		if (!result.supportsMultiOrg && result.defaultOrgId) {
 			throw redirect({ to: "/app/$brand", params: { brand: result.defaultOrgId } });

--- a/apps/web/src/routes/_authed/app/index.tsx
+++ b/apps/web/src/routes/_authed/app/index.tsx
@@ -57,6 +57,11 @@ export const Route = createFileRoute("/_authed/app/")({
 	loader: async () => {
 		const result = await getOrganizations();
 
+		// Always show the switcher when the user has multiple brands, regardless of deployment flag.
+		if (result.organizations.length >= 2) {
+			return result;
+		}
+
 		// Single-org mode: redirect to default org
 		if (!result.supportsMultiOrg && result.defaultOrgId) {
 			throw redirect({ to: "/app/$brand", params: { brand: result.defaultOrgId } });

--- a/packages/local/src/auth-provider.ts
+++ b/packages/local/src/auth-provider.ts
@@ -25,7 +25,7 @@ export function createLocalDeployment(
 		features: {
 			readOnly,
 			showOptimizeButton: false,
-			supportsMultiOrg: false,
+			supportsMultiOrg: readOnly,
 		},
 		branding: {
 			name: getEnv("APP_NAME", DEFAULT_APP_NAME, env),


### PR DESCRIPTION
## Summary
- enable `supportsMultiOrg` for the demo deployment (`readOnly === true`) so `/app` can surface the switcher
- render the brand switcher whenever the signed-in user has 2+ memberships, regardless of the deployment flag; single-membership users keep the previous auto-redirect behavior
- demo DB seeding is expected to be done manually (extra `organization` + `member` + `brand` rows for the demo user)
