### PR TITLE
fix: stylesheet/favicon 404 on Docker/Alpine demo builds

### DIFF
--- a/.changeset/tailwind-ssr-css-hash.md
+++ b/.changeset/tailwind-ssr-css-hash.md
@@ -2,4 +2,4 @@
 "@workspace/web": patch
 ---
 
-Fix missing stylesheet in Docker/Alpine builds. `@tailwindcss/vite`'s module-graph scanner produces different CSS bytes in the client and SSR Vite builds on Linux, so the SSR-rendered `<link href>` pointed at a hashed file the client build never wrote — manifesting as a 404 on `/assets/styles-*.css` and a missing favicon on the demo instance. Opting out with `@import "tailwindcss" source(none)` and keeping our existing explicit `@source` directives makes both builds produce the same CSS. See tailwindlabs/tailwindcss#16389 and TanStack/router#4959.
+Fix missing stylesheet and favicon in Docker builds caused by `@tailwindcss/vite` emitting different CSS hashes in the client and SSR passes.

--- a/.changeset/tailwind-ssr-css-hash.md
+++ b/.changeset/tailwind-ssr-css-hash.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Fix missing stylesheet in Docker/Alpine builds. `@tailwindcss/vite`'s module-graph scanner produces different CSS bytes in the client and SSR Vite builds on Linux, so the SSR-rendered `<link href>` pointed at a hashed file the client build never wrote — manifesting as a 404 on `/assets/styles-*.css` and a missing favicon on the demo instance. Opting out with `@import "tailwindcss" source(none)` and keeping our existing explicit `@source` directives makes both builds produce the same CSS. See tailwindlabs/tailwindcss#16389 and TanStack/router#4959.

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,11 +1,15 @@
-@import "tailwindcss";
+@import "tailwindcss" source(none);
 @import "@fontsource/titan-one";
 
 @import "tw-animate-css";
 
 @plugin "@tailwindcss/typography";
 
-/* Scan app components and pages for Tailwind classes */
+/* Explicit @source scanning only. source(none) on the import above disables
+   @tailwindcss/vite's module-graph-based class detection, which yields
+   different CSS between the client and SSR Vite builds (so the SSR-rendered
+   <link href> points at a hashed file the client build never wrote). See
+   tailwindlabs/tailwindcss#16389 and TanStack/router#4959. */
 @source "../src";
 @source "../../../packages/ui/src";
 


### PR DESCRIPTION
## Summary

- The Docker-built demo instance was serving HTML that linked `/assets/styles-D644lWFV.css`, which 404'd, so the page rendered unstyled and the favicon appeared broken.
- Root cause: `@tailwindcss/vite`'s module-graph scanner runs independently in the client and SSR Vite passes. On Linux/Alpine the two produce different CSS bytes → different content hashes. Only the client writes its CSS to disk, so the SSR bundle's baked-in URL points at a file that was never emitted. (Upstream tailwindlabs/tailwindcss#16389, tracked from our side in TanStack/router#4959.)
- Fix: add `source(none)` to `@import "tailwindcss"` in `apps/web/src/styles.css` so Tailwind uses only our existing explicit `@source` directives. Both builds then produce the same CSS.

## Test plan

- [x] Reproduced the pre-fix mismatch locally by building the Docker image twice (deterministic: server referenced `styles-D644lWFV.css`, public had `styles-wZvkwBL3.css`).
- [x] Re-built Docker image with the fix: server bundle and `public/assets/` both resolve to `styles-wZvkwBL3.css`; `curl /assets/styles-wZvkwBL3.css` → `200 text/css`, `curl /icons/elmo-icon.svg` → `200 image/svg+xml`.
- [x] `tsc --noEmit` passes.