### PR TITLE
admin /providers page and dynamic llms settings

### DIFF
--- a/.changeset/admin-providers-dynamic-llms.md
+++ b/.changeset/admin-providers-dynamic-llms.md
@@ -1,0 +1,7 @@
+---
+"@workspace/web": patch
+"@workspace/lib": patch
+"@workspace/worker": patch
+---
+
+Admin `/admin/providers` page shows the active `SCRAPE_TARGETS`, per-provider credential status, and a per-target smoke-test button. Brand `settings/llms` now renders one card per active model and writes to `brand.enabledModels` (matching the `null` / `[]` / opt-in semantics enforced by the worker). Whitelabel deployments get a warning badge for any SCRAPE_TARGETS model missing from the report-run map.

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -12,6 +12,7 @@ import {
 	IconReport,
 	IconTimeline,
 	IconTool,
+	IconPlugConnected,
 } from "@tabler/icons-react";
 
 import {
@@ -126,6 +127,12 @@ export function AppSidebar({ isAdmin = false, hasReportAccess = false, adminOnly
 						title: "Workflows",
 						url: "/admin/workflows",
 						icon: IconTimeline,
+						absolute: true,
+					},
+					{
+						title: "Providers",
+						url: "/admin/providers",
+						icon: IconPlugConnected,
 						absolute: true,
 					},
 					{

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -28,6 +28,7 @@ import { Route as AuthedAppBrandRouteImport } from './routes/_authed/app/$brand'
 import { Route as AuthedAdminWorkflowsRouteImport } from './routes/_authed/admin/workflows'
 import { Route as AuthedAdminWizardTestRouteImport } from './routes/_authed/admin/wizard-test'
 import { Route as AuthedAdminToolsRouteImport } from './routes/_authed/admin/tools'
+import { Route as AuthedAdminProvidersRouteImport } from './routes/_authed/admin/providers'
 import { Route as ApiV1ReportsIndexRouteImport } from './routes/api/v1/reports/index'
 import { Route as ApiV1PromptsIndexRouteImport } from './routes/api/v1/prompts/index'
 import { Route as ApiV1DocsIndexRouteImport } from './routes/api/v1/docs/index'
@@ -142,6 +143,11 @@ const AuthedAdminWizardTestRoute = AuthedAdminWizardTestRouteImport.update({
 const AuthedAdminToolsRoute = AuthedAdminToolsRouteImport.update({
   id: '/tools',
   path: '/tools',
+  getParentRoute: () => AuthedAdminRoute,
+} as any)
+const AuthedAdminProvidersRoute = AuthedAdminProvidersRouteImport.update({
+  id: '/providers',
+  path: '/providers',
   getParentRoute: () => AuthedAdminRoute,
 } as any)
 const ApiV1ReportsIndexRoute = ApiV1ReportsIndexRouteImport.update({
@@ -270,6 +276,7 @@ export interface FileRoutesByFullPath {
   '/auth/login': typeof AuthLoginRoute
   '/auth/logout': typeof AuthLogoutRoute
   '/auth/register': typeof AuthRegisterRoute
+  '/admin/providers': typeof AuthedAdminProvidersRoute
   '/admin/tools': typeof AuthedAdminToolsRoute
   '/admin/wizard-test': typeof AuthedAdminWizardTestRoute
   '/admin/workflows': typeof AuthedAdminWorkflowsRoute
@@ -308,6 +315,7 @@ export interface FileRoutesByTo {
   '/auth/login': typeof AuthLoginRoute
   '/auth/logout': typeof AuthLogoutRoute
   '/auth/register': typeof AuthRegisterRoute
+  '/admin/providers': typeof AuthedAdminProvidersRoute
   '/admin/tools': typeof AuthedAdminToolsRoute
   '/admin/wizard-test': typeof AuthedAdminWizardTestRoute
   '/admin/workflows': typeof AuthedAdminWorkflowsRoute
@@ -350,6 +358,7 @@ export interface FileRoutesById {
   '/auth/login': typeof AuthLoginRoute
   '/auth/logout': typeof AuthLogoutRoute
   '/auth/register': typeof AuthRegisterRoute
+  '/_authed/admin/providers': typeof AuthedAdminProvidersRoute
   '/_authed/admin/tools': typeof AuthedAdminToolsRoute
   '/_authed/admin/wizard-test': typeof AuthedAdminWizardTestRoute
   '/_authed/admin/workflows': typeof AuthedAdminWorkflowsRoute
@@ -393,6 +402,7 @@ export interface FileRouteTypes {
     | '/auth/login'
     | '/auth/logout'
     | '/auth/register'
+    | '/admin/providers'
     | '/admin/tools'
     | '/admin/wizard-test'
     | '/admin/workflows'
@@ -431,6 +441,7 @@ export interface FileRouteTypes {
     | '/auth/login'
     | '/auth/logout'
     | '/auth/register'
+    | '/admin/providers'
     | '/admin/tools'
     | '/admin/wizard-test'
     | '/admin/workflows'
@@ -472,6 +483,7 @@ export interface FileRouteTypes {
     | '/auth/login'
     | '/auth/logout'
     | '/auth/register'
+    | '/_authed/admin/providers'
     | '/_authed/admin/tools'
     | '/_authed/admin/wizard-test'
     | '/_authed/admin/workflows'
@@ -660,6 +672,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedAdminToolsRouteImport
       parentRoute: typeof AuthedAdminRoute
     }
+    '/_authed/admin/providers': {
+      id: '/_authed/admin/providers'
+      path: '/providers'
+      fullPath: '/admin/providers'
+      preLoaderRoute: typeof AuthedAdminProvidersRouteImport
+      parentRoute: typeof AuthedAdminRoute
+    }
     '/api/v1/reports/': {
       id: '/api/v1/reports/'
       path: '/api/v1/reports'
@@ -811,6 +830,7 @@ declare module '@tanstack/react-router' {
 }
 
 interface AuthedAdminRouteChildren {
+  AuthedAdminProvidersRoute: typeof AuthedAdminProvidersRoute
   AuthedAdminToolsRoute: typeof AuthedAdminToolsRoute
   AuthedAdminWizardTestRoute: typeof AuthedAdminWizardTestRoute
   AuthedAdminWorkflowsRoute: typeof AuthedAdminWorkflowsRoute
@@ -818,6 +838,7 @@ interface AuthedAdminRouteChildren {
 }
 
 const AuthedAdminRouteChildren: AuthedAdminRouteChildren = {
+  AuthedAdminProvidersRoute: AuthedAdminProvidersRoute,
   AuthedAdminToolsRoute: AuthedAdminToolsRoute,
   AuthedAdminWizardTestRoute: AuthedAdminWizardTestRoute,
   AuthedAdminWorkflowsRoute: AuthedAdminWorkflowsRoute,

--- a/apps/web/src/routes/_authed/admin/providers.tsx
+++ b/apps/web/src/routes/_authed/admin/providers.tsx
@@ -1,0 +1,266 @@
+/**
+ * /admin/providers - View SCRAPE_TARGETS configuration, per-model smoke tests,
+ * and registered-provider credential status.
+ */
+import { useEffect, useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { getAppName } from "@/lib/route-head";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@workspace/ui/components/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@workspace/ui/components/table";
+import { Badge } from "@workspace/ui/components/badge";
+import { Button } from "@workspace/ui/components/button";
+import { Skeleton } from "@workspace/ui/components/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
+import { CheckCircle2, XCircle, AlertTriangle, Play, Loader2, RefreshCw } from "lucide-react";
+import { getProviderStatusFn, testProviderFn, type ProviderStatus } from "@/server/admin";
+import { WHITELABEL_REPORT_RUNS_PER_MODEL, getModelMeta, type ModelConfig, type TestResult } from "@workspace/lib/providers";
+
+function formatTarget(cfg: ModelConfig): string {
+	const parts = [cfg.model, cfg.provider];
+	if (cfg.version) parts.push(cfg.version);
+	if (cfg.webSearch) parts.push("online");
+	return parts.join(":");
+}
+
+function TestCell({ target }: { target: string }) {
+	const [state, setState] = useState<"idle" | "loading" | TestResult>("idle");
+
+	const handleTest = async () => {
+		setState("loading");
+		try {
+			const result = await testProviderFn({ data: { target } });
+			setState(result);
+		} catch (err) {
+			setState({
+				success: false,
+				latencyMs: 0,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	};
+
+	if (state === "idle") {
+		return (
+			<Button size="sm" variant="outline" onClick={handleTest} className="cursor-pointer">
+				<Play className="h-3 w-3 mr-1" />
+				Test
+			</Button>
+		);
+	}
+	if (state === "loading") {
+		return (
+			<Button size="sm" variant="outline" disabled>
+				<Loader2 className="h-3 w-3 mr-1 animate-spin" />
+				Testing…
+			</Button>
+		);
+	}
+	return (
+		<div className="flex flex-col gap-1 items-start">
+			<div className="flex items-center gap-2">
+				{state.success ? (
+					<Badge className="bg-emerald-600">
+						<CheckCircle2 className="h-3 w-3 mr-1" />
+						Pass
+					</Badge>
+				) : (
+					<Badge className="bg-red-500">
+						<XCircle className="h-3 w-3 mr-1" />
+						Fail
+					</Badge>
+				)}
+				<span className="text-xs text-muted-foreground">{state.latencyMs}ms</span>
+				<Button size="sm" variant="ghost" onClick={handleTest} className="cursor-pointer h-6 px-2">
+					<RefreshCw className="h-3 w-3" />
+				</Button>
+			</div>
+			{state.success && state.sampleOutput && (
+				<p className="text-xs text-muted-foreground font-mono max-w-md truncate" title={state.sampleOutput}>
+					{state.sampleOutput}
+				</p>
+			)}
+			{!state.success && state.error && (
+				<p className="text-xs text-red-600 max-w-md break-words" title={state.error}>
+					{state.error}
+				</p>
+			)}
+		</div>
+	);
+}
+
+export const Route = createFileRoute("/_authed/admin/providers")({
+	head: ({ match }) => {
+		const appName = getAppName(match);
+		return {
+			meta: [
+				{ title: `Providers | ${appName}` },
+				{ name: "description", content: "SCRAPE_TARGETS configuration and provider connectivity tests." },
+			],
+		};
+	},
+	component: ProvidersPage,
+});
+
+function ProvidersPage() {
+	const [data, setData] = useState<ProviderStatus | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		getProviderStatusFn()
+			.then(setData)
+			.catch((err) => setError(err instanceof Error ? err.message : "An error occurred"))
+			.finally(() => setLoading(false));
+	}, []);
+
+	if (loading) {
+		return (
+			<div className="space-y-8">
+				<div className="space-y-2">
+					<Skeleton className="h-8 w-64" />
+					<Skeleton className="h-4 w-96" />
+				</div>
+				<Skeleton className="h-48" />
+				<Skeleton className="h-48" />
+			</div>
+		);
+	}
+
+	if (error || !data) {
+		return (
+			<Card>
+				<CardHeader>
+					<CardTitle className="text-destructive">Error</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<p>{error ?? "Failed to load provider status"}</p>
+				</CardContent>
+			</Card>
+		);
+	}
+
+	const isWhitelabel = data.deploymentMode === "whitelabel";
+	const whitelabelKeys = new Set(Object.keys(WHITELABEL_REPORT_RUNS_PER_MODEL));
+
+	return (
+		<div className="space-y-8">
+			<div className="space-y-2">
+				<h1 className="text-3xl font-bold tracking-tight">Providers</h1>
+				<p className="text-muted-foreground">
+					Current <code className="text-xs bg-muted px-1 py-0.5 rounded">SCRAPE_TARGETS</code> configuration and provider
+					connectivity. Changing targets requires a redeploy.
+				</p>
+			</div>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Active Targets</CardTitle>
+					<CardDescription>
+						{data.activeTargets.length} target{data.activeTargets.length === 1 ? "" : "s"} dispatched by the worker for
+						each prompt run. Deployment mode: <span className="font-mono">{data.deploymentMode}</span>.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Model</TableHead>
+								<TableHead>Provider</TableHead>
+								<TableHead>Version</TableHead>
+								<TableHead className="text-center">Web Search</TableHead>
+								<TableHead>Test</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{data.activeTargets.map((cfg) => {
+								const target = formatTarget(cfg);
+								const meta = getModelMeta(cfg.model);
+								const whitelabelMissing = isWhitelabel && !whitelabelKeys.has(cfg.model);
+								return (
+									<TableRow key={target}>
+										<TableCell>
+											<div className="flex items-center gap-2">
+												<span className="font-medium">{meta.label}</span>
+												<code className="text-xs text-muted-foreground">{cfg.model}</code>
+												{whitelabelMissing && (
+													<Tooltip>
+														<TooltipTrigger asChild>
+															<Badge variant="outline" className="border-amber-500 text-amber-700">
+																<AlertTriangle className="h-3 w-3 mr-1" />
+																Report runs
+															</Badge>
+														</TooltipTrigger>
+														<TooltipContent className="max-w-xs text-xs">
+															New models need a run count added to{" "}
+															<code className="text-[10px]">WHITELABEL_REPORT_RUNS_PER_MODEL</code> in{" "}
+															<code className="text-[10px]">apps/worker/src/report-worker.ts</code> before
+															report generation will succeed on this deployment.
+														</TooltipContent>
+													</Tooltip>
+												)}
+											</div>
+										</TableCell>
+										<TableCell className="font-mono text-xs">{cfg.provider}</TableCell>
+										<TableCell className="font-mono text-xs text-muted-foreground">{cfg.version ?? "—"}</TableCell>
+										<TableCell className="text-center">
+											{cfg.webSearch ? (
+												<CheckCircle2 className="h-4 w-4 text-emerald-600 inline" />
+											) : (
+												<XCircle className="h-4 w-4 text-muted-foreground inline" />
+											)}
+										</TableCell>
+										<TableCell>
+											<TestCell target={target} />
+										</TableCell>
+									</TableRow>
+								);
+							})}
+						</TableBody>
+					</Table>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Registered Providers</CardTitle>
+					<CardDescription>
+						Providers available to SCRAPE_TARGETS. A provider is "configured" when its required credentials are present in
+						the environment.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>ID</TableHead>
+								<TableHead>Name</TableHead>
+								<TableHead className="text-center">Configured</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{data.providers.map((p) => (
+								<TableRow key={p.id}>
+									<TableCell className="font-mono text-xs">{p.id}</TableCell>
+									<TableCell>{p.name}</TableCell>
+									<TableCell className="text-center">
+										{p.configured ? (
+											<Badge className="bg-emerald-600">
+												<CheckCircle2 className="h-3 w-3 mr-1" />
+												Ready
+											</Badge>
+										) : (
+											<Badge variant="outline" className="text-muted-foreground">
+												<XCircle className="h-3 w-3 mr-1" />
+												Missing credentials
+											</Badge>
+										)}
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/apps/web/src/routes/_authed/app/$brand/settings/llms.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/settings/llms.tsx
@@ -1,72 +1,49 @@
 /**
  * /app/$brand/settings/llms - LLM configuration page
  *
- * Shows info about tracked LLMs and their web search status.
+ * Shows every model the worker is configured to dispatch (from SCRAPE_TARGETS)
+ * and lets brand admins opt in/out per model via brand.enabledModels.
+ *
+ * brand.enabledModels semantics (matches selectTargetsForBrand in
+ * packages/lib/src/providers/runner.ts):
+ *   - null        → no override, every configured target runs
+ *   - []          → explicit opt-out, nothing runs for this brand
+ *   - [model,...] → opt-in list; entries must be in current SCRAPE_TARGETS
  */
+import { useEffect, useMemo, useState } from "react";
+import type { ComponentType, SVGProps } from "react";
 import { createFileRoute } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import { getAppName, getBrandName, buildTitle } from "@/lib/route-head";
-import { Card, CardContent, CardDescription, CardFooter, CardHeader } from "@workspace/ui/components/card";
+import { Card, CardContent, CardHeader } from "@workspace/ui/components/card";
+import { Button } from "@workspace/ui/components/button";
+import { Checkbox } from "@workspace/ui/components/checkbox";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
-import { IconCircleCheck, IconCircleX, IconInfoCircle } from "@tabler/icons-react";
-import { SiOpenai, SiAnthropic, SiGoogle } from "react-icons/si";
+import { Alert, AlertDescription } from "@workspace/ui/components/alert";
+import { Skeleton } from "@workspace/ui/components/skeleton";
+import { IconInfoCircle, IconCpu } from "@tabler/icons-react";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { SiOpenai, SiAnthropic, SiGoogle, SiPerplexity, SiX } from "react-icons/si";
+import { useBrand, brandKeys } from "@/hooks/use-brands";
+import { getProviderStatusFn, type ProviderStatus } from "@/server/admin";
+import { updateBrandEnabledModelsFn } from "@/server/brands";
+import { getModelMeta, type ModelConfig } from "@workspace/lib/providers";
 
-interface ModelGroupInfo {
-	id: string;
-	name: string;
-	provider: string;
-	currentModel: string;
-	description: string;
-	icon: React.ReactNode;
-	trackedEnabled: boolean;
-	webSearchEnabled: boolean;
-	webSearchStatus: string;
-	webSearchDetail: string;
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+const ICON_BY_ID: Record<string, IconComponent> = {
+	openai: SiOpenai,
+	anthropic: SiAnthropic,
+	google: SiGoogle,
+	perplexity: SiPerplexity,
+	x: SiX,
+};
+
+function ModelIcon({ iconId, className }: { iconId: string; className?: string }) {
+	const Icon = ICON_BY_ID[iconId];
+	if (Icon) return <Icon className={className} />;
+	return <IconCpu className={className} />;
 }
-
-const MODEL_GROUPS: ModelGroupInfo[] = [
-	{
-		id: "chatgpt",
-		name: "ChatGPT",
-		provider: "OpenAI",
-		currentModel: "gpt-5-mini",
-		description:
-			"ChatGPT is OpenAI's consumer assistant, and it's often the first place people turn for product recommendations and comparisons. Tracking visibility here shows how your brand appears in everyday ChatGPT responses.",
-		icon: <SiOpenai className="h-6 w-6" />,
-		trackedEnabled: true,
-		webSearchEnabled: true,
-		webSearchStatus: "Enabled",
-		webSearchDetail:
-			"Responses include real-time information from the web, making visibility here especially impactful for brand discovery.",
-	},
-	{
-		id: "claude",
-		name: "Claude",
-		provider: "Anthropic",
-		currentModel: "claude-sonnet-4-20250514",
-		description:
-			"Claude is Anthropic's assistant and is popular with professionals for nuanced, long-form research. Tracking Claude highlights how your brand appears in deeper analysis and decision making.",
-		icon: <SiAnthropic className="h-6 w-6" />,
-		trackedEnabled: true,
-		webSearchEnabled: false,
-		webSearchStatus: "Disabled",
-		webSearchDetail:
-			"Responses are based on Claude's training data. Brand mentions reflect how well your brand is represented in publicly available content.",
-	},
-	{
-		id: "google-ai-mode",
-		name: "Google AI Overviews",
-		provider: "Google",
-		currentModel: "AI Mode",
-		description:
-			"Google AI Mode powers AI Overviews in Search. Tracking AI Mode shows how your brand is summarized and cited as Google blends AI answers with traditional results.",
-		icon: <SiGoogle className="h-6 w-6" />,
-		trackedEnabled: true,
-		webSearchEnabled: true,
-		webSearchStatus: "Enabled",
-		webSearchDetail:
-			"Always uses live web data — results reflect real-time Google Search content, including your website, reviews, and mentions across the web.",
-	},
-];
 
 export const Route = createFileRoute("/_authed/app/$brand/settings/llms")({
 	head: ({ matches, match }) => {
@@ -83,98 +60,266 @@ export const Route = createFileRoute("/_authed/app/$brand/settings/llms")({
 });
 
 function LlmsSettingsPage() {
+	const { brand, isLoading: brandLoading, revalidate } = useBrand();
+	const queryClient = useQueryClient();
+
+	const [status, setStatus] = useState<ProviderStatus | null>(null);
+	const [statusError, setStatusError] = useState<string | null>(null);
+	const [statusLoading, setStatusLoading] = useState(true);
+
+	useEffect(() => {
+		getProviderStatusFn()
+			.then(setStatus)
+			.catch((err) => setStatusError(err instanceof Error ? err.message : "Failed to load providers"))
+			.finally(() => setStatusLoading(false));
+	}, []);
+
+	const activeTargets = status?.activeTargets ?? [];
+	const activeModels = useMemo(() => new Set(activeTargets.map((t) => t.model)), [activeTargets]);
+
+	const persistedEnabled: string[] | null = brand?.enabledModels ?? null;
+
+	// Seed the toggle state from the brand. null (no override) surfaces as "all
+	// currently-active models selected" so the grid is in a consistent shape;
+	// saving that state sends back the full array, which the worker enforces.
+	const [selected, setSelected] = useState<Set<string>>(new Set());
+	const [selectionInitialized, setSelectionInitialized] = useState(false);
+
+	useEffect(() => {
+		if (!brand || statusLoading) return;
+		if (persistedEnabled === null) {
+			setSelected(new Set(activeTargets.map((t) => t.model)));
+		} else {
+			setSelected(new Set(persistedEnabled.filter((m) => activeModels.has(m))));
+		}
+		setSelectionInitialized(true);
+	}, [brand?.updatedAt, statusLoading, status]);
+
+	const orphaned = useMemo(() => {
+		if (!persistedEnabled) return [];
+		return persistedEnabled.filter((m) => !activeModels.has(m));
+	}, [persistedEnabled, activeModels]);
+
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [saveError, setSaveError] = useState<string | null>(null);
+	const [saveSuccess, setSaveSuccess] = useState<string | null>(null);
+
+	const toggle = (model: string) => {
+		setSaveError(null);
+		setSaveSuccess(null);
+		setSelected((prev) => {
+			const next = new Set(prev);
+			if (next.has(model)) next.delete(model);
+			else next.add(model);
+			return next;
+		});
+	};
+
+	const persistArray = async (value: string[] | null) => {
+		if (!brand) return;
+		setIsSubmitting(true);
+		setSaveError(null);
+		setSaveSuccess(null);
+		try {
+			await updateBrandEnabledModelsFn({ data: { brandId: brand.id, enabledModels: value } });
+			queryClient.invalidateQueries({ queryKey: brandKeys.detail(brand.id) });
+			await revalidate();
+			setSaveSuccess(
+				value === null
+					? "Reset to default. Every configured model will run."
+					: value.length === 0
+						? "Saved. No models will run for this brand until you enable one."
+						: `Saved. ${value.length} model${value.length === 1 ? "" : "s"} enabled.`,
+			);
+		} catch (err) {
+			setSaveError(err instanceof Error ? err.message : "An error occurred");
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const handleSave = () => persistArray([...selected]);
+	const handleResetDefault = () => persistArray(null);
+
+	if (brandLoading || statusLoading || !selectionInitialized) {
+		return (
+			<div className="space-y-6 max-w-6xl">
+				<div className="space-y-2">
+					<Skeleton className="h-8 w-32" />
+					<Skeleton className="h-4 w-80" />
+				</div>
+				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+					{[0, 1, 2].map((n) => (
+						<Skeleton key={n} className="h-48" />
+					))}
+				</div>
+			</div>
+		);
+	}
+
+	if (!brand) {
+		return (
+			<div className="space-y-6">
+				<h1 className="text-3xl font-bold">LLMs</h1>
+				<p className="text-destructive">Brand not found</p>
+			</div>
+		);
+	}
+
+	if (statusError || !status) {
+		return (
+			<div className="space-y-6">
+				<h1 className="text-3xl font-bold">LLMs</h1>
+				<Alert variant="destructive">
+					<AlertDescription>{statusError ?? "Failed to load provider status"}</AlertDescription>
+				</Alert>
+			</div>
+		);
+	}
+
+	const nothingSelected = selected.size === 0;
+	const usingDefault = persistedEnabled === null;
+
 	return (
 		<div className="space-y-6 max-w-6xl">
 			<div>
 				<h1 className="text-3xl font-bold">LLMs</h1>
 				<p className="text-muted-foreground">
-					Your prompts are evaluated against multiple types of AI models to track how your brand appears across different
-					types of AI search.
+					Your prompts are evaluated against multiple AI models to track how your brand appears across different types of AI
+					search. Toggle off any model you don't want included in runs for this brand.
 				</p>
 			</div>
 
-			<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-				{MODEL_GROUPS.map((group) => (
-					<Card key={group.id} className="h-full">
-						<CardHeader className="py-2 border-b">
-							<div className="flex items-start justify-between gap-2">
-								<div className="flex items-start gap-3">
-									<div className="flex items-center justify-center">{group.icon}</div>
-								</div>
-							</div>
-						</CardHeader>
-						<CardContent className="pt-2">
-							<div className="divide-y text-sm">
-								<div className="flex items-center justify-between py-2">
-									<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-										<span>Provider</span>
-									</div>
-									<span className="text-xs text-foreground">{group.provider}</span>
-								</div>
-								<div className="flex items-center justify-between py-2">
-									<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-										<span>Model</span>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<IconInfoCircle className="h-3.5 w-3.5 cursor-help" />
-											</TooltipTrigger>
-											<TooltipContent className="max-w-xs text-xs font-normal">
-												Exact model version used for this group.
-											</TooltipContent>
-										</Tooltip>
-									</div>
-									<span className="font-mono text-xs text-foreground">{group.currentModel}</span>
-								</div>
-								<div className="flex items-center justify-between py-2">
-									<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-										<span>Tracked</span>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<IconInfoCircle className="h-3.5 w-3.5 cursor-help" />
-											</TooltipTrigger>
-											<TooltipContent className="max-w-xs text-xs font-normal">
-												Whether this model group is included in your visibility runs.
-											</TooltipContent>
-										</Tooltip>
-									</div>
-									<div className="flex items-center gap-2 text-xs text-foreground">
-										{group.trackedEnabled ? (
-											<IconCircleCheck className="h-4 w-4 text-emerald-600" />
-										) : (
-											<IconCircleX className="h-4 w-4 text-red-600" />
-										)}
-										<span className="sr-only">{group.trackedEnabled ? "Enabled" : "Disabled"}</span>
-									</div>
-								</div>
-								<div className="flex items-center justify-between py-2">
-									<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-										<span>Web search</span>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<IconInfoCircle className="h-3.5 w-3.5 cursor-help" />
-											</TooltipTrigger>
-											<TooltipContent className="max-w-xs text-xs font-normal">
-												{group.webSearchDetail}
-											</TooltipContent>
-										</Tooltip>
-									</div>
-									<div className="flex items-center gap-2 text-xs text-foreground">
-										{group.webSearchEnabled ? (
-											<IconCircleCheck className="h-4 w-4 text-emerald-600" />
-										) : (
-											<IconCircleX className="h-4 w-4 text-red-600" />
-										)}
-										<span className="sr-only">{group.webSearchStatus}</span>
-									</div>
-								</div>
-							</div>
-						</CardContent>
-						<CardFooter className="pt-2 border-t">
-							<CardDescription className="text-xs text-muted-foreground">{group.description}</CardDescription>
-						</CardFooter>
-					</Card>
-				))}
+			{activeTargets.length === 0 && (
+				<Alert>
+					<AlertDescription>
+						No models are configured for this deployment. Ask an admin to set{" "}
+						<code className="text-xs">SCRAPE_TARGETS</code>.
+					</AlertDescription>
+				</Alert>
+			)}
+
+			{orphaned.length > 0 && (
+				<Alert variant="destructive">
+					<AlertTriangle className="h-4 w-4" />
+					<AlertDescription>
+						The following saved models are no longer in this deployment's{" "}
+						<code className="text-xs">SCRAPE_TARGETS</code> and will cause the worker to throw on next dispatch:{" "}
+						<strong>{orphaned.join(", ")}</strong>. Click Save to drop them.
+					</AlertDescription>
+				</Alert>
+			)}
+
+			{nothingSelected && activeTargets.length > 0 && (
+				<Alert variant="destructive">
+					<AlertTriangle className="h-4 w-4" />
+					<AlertDescription>
+						No models are selected. If you save now, prompts will stop running for this brand until a model is re-enabled.
+					</AlertDescription>
+				</Alert>
+			)}
+
+			{activeTargets.length > 0 && (
+				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+					{activeTargets.map((cfg) => (
+						<ModelCard
+							key={`${cfg.model}:${cfg.provider}`}
+							config={cfg}
+							enabled={selected.has(cfg.model)}
+							onToggle={() => toggle(cfg.model)}
+						/>
+					))}
+				</div>
+			)}
+
+			<div className="flex items-center gap-3 pt-2">
+				<Button onClick={handleSave} disabled={isSubmitting} className="cursor-pointer">
+					{isSubmitting ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
+					Save
+				</Button>
+				{!usingDefault && (
+					<Button variant="outline" onClick={handleResetDefault} disabled={isSubmitting} className="cursor-pointer">
+						Reset to default (all models)
+					</Button>
+				)}
+				{usingDefault && (
+					<p className="text-xs text-muted-foreground">
+						Using deployment default — every configured model runs. Toggle any card off to start an opt-in list.
+					</p>
+				)}
+				{saveSuccess && <p className="text-sm text-emerald-600">{saveSuccess}</p>}
+				{saveError && <p className="text-sm text-red-600">{saveError}</p>}
 			</div>
 		</div>
+	);
+}
+
+function ModelCard({
+	config,
+	enabled,
+	onToggle,
+}: {
+	config: ModelConfig;
+	enabled: boolean;
+	onToggle: () => void;
+}) {
+	const meta = getModelMeta(config.model);
+	const checkboxId = `llm-toggle-${config.model}`;
+	return (
+		<Card className={`h-full ${enabled ? "" : "opacity-60"}`}>
+			<CardHeader className="py-2 border-b">
+				<div className="flex items-center justify-between gap-2">
+					<div className="flex items-center gap-3">
+						<ModelIcon iconId={meta.iconId} className="h-6 w-6" />
+						<div className="flex flex-col">
+							<span className="font-medium">{meta.label}</span>
+							<code className="text-[10px] text-muted-foreground">{config.model}</code>
+						</div>
+					</div>
+					<label htmlFor={checkboxId} className="flex items-center gap-2 cursor-pointer">
+						<span className="text-xs text-muted-foreground">{enabled ? "Enabled" : "Disabled"}</span>
+						<Checkbox id={checkboxId} checked={enabled} onCheckedChange={onToggle} />
+					</label>
+				</div>
+			</CardHeader>
+			<CardContent className="pt-2">
+				<div className="divide-y text-sm">
+					<div className="flex items-center justify-between py-2">
+						<span className="text-xs uppercase tracking-wide text-muted-foreground">Provider</span>
+						<span className="text-xs font-mono text-foreground">{config.provider}</span>
+					</div>
+					<div className="flex items-center justify-between py-2">
+						<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+							<span>Version</span>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<IconInfoCircle className="h-3.5 w-3.5 cursor-help" />
+								</TooltipTrigger>
+								<TooltipContent className="max-w-xs text-xs font-normal">
+									Exact version slug passed to the provider when this model runs.
+								</TooltipContent>
+							</Tooltip>
+						</div>
+						<span className="font-mono text-xs text-foreground">{config.version ?? "—"}</span>
+					</div>
+					<div className="flex items-center justify-between py-2">
+						<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+							<span>Web search</span>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<IconInfoCircle className="h-3.5 w-3.5 cursor-help" />
+								</TooltipTrigger>
+								<TooltipContent className="max-w-xs text-xs font-normal">
+									{config.webSearch
+										? "Responses include real-time information from the web."
+										: "Responses are based on the model's training data only."}
+								</TooltipContent>
+							</Tooltip>
+						</div>
+						<span className="text-xs text-foreground">{config.webSearch ? "Enabled" : "Disabled"}</span>
+					</div>
+				</div>
+			</CardContent>
+		</Card>
 	);
 }

--- a/apps/web/src/server/admin.ts
+++ b/apps/web/src/server/admin.ts
@@ -17,7 +17,13 @@ import { analyzeWebsite, getCompetitors, generateCandidatePromptsForReports } fr
 import { DEFAULT_DELAY_HOURS } from "@workspace/lib/constants";
 import { sendImmediatePromptJob } from "@/lib/job-scheduler";
 import { Client } from "pg";
-import { parseScrapeTargets } from "@workspace/lib/providers";
+import {
+	parseScrapeTargets,
+	getAllProviders,
+	getProvider,
+	type ModelConfig,
+	type TestResult,
+} from "@workspace/lib/providers";
 
 // ============================================================================
 // Admin guard helper
@@ -839,4 +845,75 @@ export const getJobLogsFn = createServerFn({ method: "GET" })
 		}
 
 		return { jobId: data.jobId, logs, count: logs.length };
+	});
+
+// ============================================================================
+// Admin Providers - SCRAPE_TARGETS status + per-target smoke test
+// ============================================================================
+
+export interface ProviderStatus {
+	activeTargets: ModelConfig[];
+	providers: { id: string; name: string; configured: boolean }[];
+	deploymentMode: string;
+}
+
+/**
+ * Snapshot of what the worker will dispatch: the parsed SCRAPE_TARGETS plus
+ * which registered providers have credentials configured. Used by
+ * /admin/providers to render the current configuration.
+ */
+export const getProviderStatusFn = createServerFn({ method: "GET" }).handler(
+	async (): Promise<ProviderStatus> => {
+		await requireAdmin();
+
+		const activeTargets = parseScrapeTargets(process.env.SCRAPE_TARGETS);
+		const providers = getAllProviders().map((p) => ({
+			id: p.id,
+			name: p.name,
+			configured: p.isConfigured(),
+		}));
+
+		return {
+			activeTargets,
+			providers,
+			deploymentMode: process.env.DEPLOYMENT_MODE ?? "local",
+		};
+	},
+);
+
+/**
+ * Run a single SCRAPE_TARGETS entry through its provider with a canned prompt.
+ * Surfaces credential and connectivity problems before prompts start failing.
+ */
+export const testProviderFn = createServerFn({ method: "POST" })
+	.inputValidator(z.object({ target: z.string() }))
+	.handler(async ({ data }): Promise<TestResult> => {
+		await requireAdmin();
+
+		const configs = parseScrapeTargets(data.target);
+		if (configs.length !== 1) {
+			throw new Error(
+				`testProviderFn expects a single target; got ${configs.length} from "${data.target}"`,
+			);
+		}
+		const cfg = configs[0];
+		const provider = getProvider(cfg.provider);
+
+		const start = Date.now();
+		try {
+			const result = await provider.run(cfg.model, "What is 2+2?", {
+				webSearch: cfg.webSearch,
+				version: cfg.version,
+			});
+			const latencyMs = Date.now() - start;
+			const sample = result.textContent.trim().slice(0, 240);
+			return { success: true, latencyMs, sampleOutput: sample };
+		} catch (err) {
+			const latencyMs = Date.now() - start;
+			return {
+				success: false,
+				latencyMs,
+				error: err instanceof Error ? err.message : String(err),
+			};
+		}
 	});

--- a/apps/web/src/server/brands.ts
+++ b/apps/web/src/server/brands.ts
@@ -10,6 +10,7 @@ import { brands, prompts, competitors, type BrandWithPrompts, type Brand } from 
 import { eq, and, count, sql } from "drizzle-orm";
 import { MAX_COMPETITORS } from "@workspace/lib/constants";
 import { cleanAndValidateDomain } from "@/lib/domain-categories";
+import { parseScrapeTargets } from "@workspace/lib/providers";
 
 function getDefaultBrandDomains(): string[] {
 	const raw = process.env.DEFAULT_BRAND_DOMAINS;
@@ -216,6 +217,50 @@ export const updateBrandFn = createServerFn({ method: "POST" })
 		}
 
 		return result[0];
+	});
+
+/**
+ * Update the set of models that should run for this brand.
+ *
+ * Semantics (must match `selectTargetsForBrand` in packages/lib):
+ *   - `null` clears the override; every configured SCRAPE_TARGETS model runs.
+ *   - `[]` is an explicit opt-out; no models run for this brand.
+ *   - `[...]` is an opt-in list; every entry must be a model currently in
+ *     SCRAPE_TARGETS, else the worker throws on the next dispatch. Validated
+ *     here so the save surfaces the error instead of a silent future break.
+ */
+export const updateBrandEnabledModelsFn = createServerFn({ method: "POST" })
+	.inputValidator(
+		z.object({
+			brandId: z.string(),
+			enabledModels: z.array(z.string()).nullable(),
+		}),
+	)
+	.handler(async ({ data }) => {
+		const session = await requireAuthSession();
+		await requireOrgAccess(session.user.id, data.brandId);
+
+		if (data.enabledModels && data.enabledModels.length > 0) {
+			const activeModels = new Set(
+				parseScrapeTargets(process.env.SCRAPE_TARGETS).map((c) => c.model),
+			);
+			const unknown = data.enabledModels.filter((m) => !activeModels.has(m));
+			if (unknown.length > 0) {
+				throw new Error(
+					`Cannot enable model(s) not in SCRAPE_TARGETS: ${unknown.join(", ")}. ` +
+						`Available models: ${[...activeModels].join(", ") || "(none)"}.`,
+				);
+			}
+		}
+
+		const [result] = await db
+			.update(brands)
+			.set({ enabledModels: data.enabledModels, updatedAt: new Date() })
+			.where(eq(brands.id, data.brandId))
+			.returning();
+
+		if (!result) throw new Error("Brand not found");
+		return result;
 	});
 
 /**

--- a/apps/worker/src/report-worker.ts
+++ b/apps/worker/src/report-worker.ts
@@ -2,7 +2,12 @@ import { db } from "@workspace/lib/db/db";
 import { reports, type Brand, brands } from "@workspace/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { RUNS_PER_PROMPT } from "@workspace/lib/constants";
-import { getProvider, parseScrapeTargets, type ModelConfig } from "@workspace/lib/providers";
+import {
+	getProvider,
+	parseScrapeTargets,
+	WHITELABEL_REPORT_RUNS_PER_MODEL,
+	type ModelConfig,
+} from "@workspace/lib/providers";
 import {
 	analyzeWebsite,
 	getCompetitors,
@@ -21,17 +26,6 @@ import { isPromptBranded, computeSystemTags } from "@workspace/lib/tag-utils";
 const TARGET_PROMPTS_COUNT = 70;
 const MIN_BRAND_MENTIONS = 14;
 const MAX_BRAND_MENTIONS = 28;
-
-// Whitelabel deployments preserve the legacy asymmetric per-candidate sample
-// counts used before SCRAPE_TARGETS drove dispatch. Any model outside this map
-// on a whitelabel deployment is a configuration error (the legacy report flow
-// only knew how to sample these three). Other deployment modes use
-// RUNS_PER_PROMPT (same frequency as day-to-day prompt tracking).
-const WHITELABEL_REPORT_RUNS_PER_MODEL: Record<string, number> = {
-	chatgpt: 2,
-	claude: 1,
-	"google-ai-mode": 1,
-};
 
 function getReportRunsForModel(model: string): number {
 	if (process.env.DEPLOYMENT_MODE === "whitelabel") {

--- a/packages/lib/src/providers/index.ts
+++ b/packages/lib/src/providers/index.ts
@@ -11,6 +11,7 @@ export { KNOWN_MODELS, getModelMeta } from "./models";
 export type { ModelMeta } from "./models";
 export { parseScrapeTargets, validateScrapeTargets } from "./config";
 export { selectTargetsForBrand } from "./runner";
+export { WHITELABEL_REPORT_RUNS_PER_MODEL } from "./report-runs";
 
 const providerMap: Record<string, Provider> = {
 	olostep,

--- a/packages/lib/src/providers/report-runs.ts
+++ b/packages/lib/src/providers/report-runs.ts
@@ -1,0 +1,14 @@
+/**
+ * Whitelabel deployments preserve the legacy asymmetric per-candidate sample
+ * counts used before SCRAPE_TARGETS drove dispatch. Any model outside this
+ * map on a whitelabel deployment is a configuration error — the legacy report
+ * flow only knew how to sample these three.
+ *
+ * Exported so the web app can warn admins when a SCRAPE_TARGETS entry would
+ * crash report generation (see `/admin/providers`).
+ */
+export const WHITELABEL_REPORT_RUNS_PER_MODEL: Record<string, number> = {
+	chatgpt: 2,
+	claude: 1,
+	"google-ai-mode": 1,
+};


### PR DESCRIPTION
## Summary

Completes PR 5 of the provider migration (`#153`) — the UI data-binding layer on top of the worker dispatch that landed in #197.

- **New `/admin/providers` route.** Renders the current `SCRAPE_TARGETS` configuration (model, provider, version, webSearch), the full provider registry with `isConfigured()` credential status, and a per-target **Test** button that calls the real provider with a canned prompt and shows pass/fail + latency + a sample of the response.
- **`/app/$brand/settings/llms` is now data-driven.** The three hardcoded ChatGPT/Claude/Google cards are gone; the page now renders one card per active `SCRAPE_TARGETS` model using `getModelMeta` for labels + icons. Toggles write to `brand.enabledModels` via a new `updateBrandEnabledModelsFn` server function.
- **Exact `enabledModels` semantics** (match `selectTargetsForBrand` in `packages/lib/src/providers/runner.ts:13`, which is what the worker enforces):
  - `null` — no override, every configured target runs.
  - `[]` — explicit opt-out, **nothing runs** for this brand.
  - `[x, y, ...]` — opt-in list; every entry must be in the current `SCRAPE_TARGETS` or the server-side validator rejects the save.
  - "Reset to default (all models)" button is the escape hatch that persists `null`, so brands can opt out of the opt-in list.
- **Orphan handling.** If a brand's `enabledModels` references a model no longer in `SCRAPE_TARGETS` (ops removed it from the env), the settings page flags it visibly and drops it from the payload on next save — before the worker would have thrown on next dispatch.
- **Whitelabel report-run coupling.** `WHITELABEL_REPORT_RUNS_PER_MODEL` moved from `apps/worker/src/report-worker.ts` into `@workspace/lib/providers` so the web can read it without importing worker code. `/admin/providers` now renders a warning badge next to any active target missing from that map on `DEPLOYMENT_MODE=whitelabel`, where report generation would otherwise throw on first run.

## Test plan

- [x] `pnpm turbo build` — all 6 packages compile; routeTree.gen.ts regenerated.
- [x] `pnpm turbo test` — 206 tests pass (150 lib + 56 web); no new tests needed (the runner semantics this binds to are already covered by `selectTargetsForBrand`'s unit tests).