### PR TITLE
Make default brand cadence configurable via DEFAULT_DELAY_HOURS env var

### DIFF
--- a/apps/web/src/lib/chart-utils.ts
+++ b/apps/web/src/lib/chart-utils.ts
@@ -1,5 +1,5 @@
 import type { PerPromptVisibilityPoint, PerPromptDailyCitationStats } from "@/lib/postgres-read";
-import { DEFAULT_DELAY_HOURS } from "@workspace/lib/constants";
+import { getDefaultDelayHours } from "@workspace/lib/constants";
 
 export type LookbackPeriod = "1w" | "1m" | "3m" | "6m" | "1y" | "all";
 
@@ -176,7 +176,7 @@ export function applyPerPromptCitationLVCF(
 	cadenceHours: number | null | undefined,
 	categorizeDomain: (domain: string) => "brand" | "competitor" | "social_media" | "google" | "institutional" | "other",
 ): Map<string, CitationCategories> {
-	const cadenceDays = Math.max(1, Math.ceil((cadenceHours ?? DEFAULT_DELAY_HOURS) / 24));
+	const cadenceDays = Math.max(1, Math.ceil((cadenceHours ?? getDefaultDelayHours()) / 24));
 
 	// Group by prompt_id -> date -> category totals
 	const byPrompt = new Map<string, Map<string, CitationCategories>>();

--- a/apps/web/src/lib/job-scheduler.ts
+++ b/apps/web/src/lib/job-scheduler.ts
@@ -1,7 +1,7 @@
 import { db } from "@workspace/lib/db/db";
 import { prompts, brands } from "@workspace/lib/db/schema";
 import { eq } from "drizzle-orm";
-import { DEFAULT_DELAY_HOURS } from "@workspace/lib/constants";
+import { getDefaultDelayHours } from "@workspace/lib/constants";
 import { getBoss } from "@/lib/boss-client";
 
 /**
@@ -15,6 +15,7 @@ export function hoursToMs(hours: number): number {
  * Gets the cadence (delay between runs) for a prompt based on its brand's delay override or the default
  */
 export async function getPromptCadenceHours(promptId: string): Promise<number> {
+	const defaultDelayHours = getDefaultDelayHours();
 	try {
 		// Get the prompt to find its brand
 		const prompt = await db.query.prompts.findFirst({
@@ -23,7 +24,7 @@ export async function getPromptCadenceHours(promptId: string): Promise<number> {
 
 		if (!prompt) {
 			console.warn(`Prompt ${promptId} not found, using default cadence`);
-			return DEFAULT_DELAY_HOURS;
+			return defaultDelayHours;
 		}
 
 		// Get the brand to check for delay override
@@ -33,7 +34,7 @@ export async function getPromptCadenceHours(promptId: string): Promise<number> {
 
 		if (!brand) {
 			console.warn(`Brand ${prompt.brandId} not found, using default cadence`);
-			return DEFAULT_DELAY_HOURS;
+			return defaultDelayHours;
 		}
 
 		// Use override if set, otherwise use default
@@ -42,10 +43,10 @@ export async function getPromptCadenceHours(promptId: string): Promise<number> {
 			return brand.delayOverrideHours;
 		}
 
-		return DEFAULT_DELAY_HOURS;
+		return defaultDelayHours;
 	} catch (error) {
 		console.error(`Error fetching cadence for prompt ${promptId}:`, error);
-		return DEFAULT_DELAY_HOURS;
+		return defaultDelayHours;
 	}
 }
 

--- a/apps/web/src/routes/_authed/admin/index.tsx
+++ b/apps/web/src/routes/_authed/admin/index.tsx
@@ -2,7 +2,8 @@
  * /admin - Admin dashboard with brand statistics and charts
  */
 import { useEffect, useState, type ReactNode } from "react";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useRouteContext } from "@tanstack/react-router";
+import type { ClientConfig } from "@workspace/config/types";
 import { getAppName } from "@/lib/route-head";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@workspace/ui/components/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@workspace/ui/components/table";
@@ -44,7 +45,10 @@ interface BrandStats {
 	promptsRemovedLast30Days: number;
 }
 
-const DEFAULT_DELAY_HOURS = 72;
+function useDefaultDelayHours(): number {
+	const context = useRouteContext({ strict: false }) as { clientConfig?: ClientConfig };
+	return context.clientConfig?.defaultDelayHours ?? 24;
+}
 
 function formatDelayHours(hours: number): string {
 	const weeks = Math.floor(hours / (7 * 24));
@@ -70,11 +74,12 @@ function timeUnitsToHours(units: { weeks: number; days: number; hours: number })
 }
 
 function DelayOverrideDialog({ brand, onUpdate }: { brand: BrandStats; onUpdate: () => void }) {
+	const defaultDelayHours = useDefaultDelayHours();
 	const [open, setOpen] = useState(false);
 	const [timeUnits, setTimeUnits] = useState({ weeks: 0, days: 0, hours: 0 });
 	const [isUpdating, setIsUpdating] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const currentDelay = brand.delayOverrideHours ?? DEFAULT_DELAY_HOURS;
+	const currentDelay = brand.delayOverrideHours ?? defaultDelayHours;
 
 	useEffect(() => {
 		if (open) {
@@ -127,7 +132,7 @@ function DelayOverrideDialog({ brand, onUpdate }: { brand: BrandStats; onUpdate:
 			<DialogContent className="max-w-2xl">
 				<DialogHeader>
 					<DialogTitle>Configure Job Delay for {brand.name}</DialogTitle>
-					<DialogDescription>Set a custom delay for how often prompt jobs run. Default is {formatDelayHours(DEFAULT_DELAY_HOURS)}.</DialogDescription>
+					<DialogDescription>Set a custom delay for how often prompt jobs run. Default is {formatDelayHours(defaultDelayHours)}.</DialogDescription>
 				</DialogHeader>
 				<div className="space-y-4 py-4">
 					<div className="space-y-3">
@@ -197,6 +202,7 @@ export const Route = createFileRoute("/_authed/admin/")({
 });
 
 function AdminDashboard() {
+	const defaultDelayHours = useDefaultDelayHours();
 	const [brands, setBrands] = useState<BrandStats[]>([]);
 	const [brandsOverTime, setBrandsOverTime] = useState<{ date: string; count: number }[]>([]);
 	const [activeBrandsOverTime, setActiveBrandsOverTime] = useState<{ date: string; count: number }[]>([]);
@@ -373,7 +379,7 @@ function AdminDashboard() {
 							</TableHeader>
 							<TableBody>
 								{brands.map((brand) => {
-									const currentDelayHours = brand.delayOverrideHours ?? DEFAULT_DELAY_HOURS;
+									const currentDelayHours = brand.delayOverrideHours ?? defaultDelayHours;
 									const currentDelayMs = currentDelayHours * 60 * 60 * 1000;
 									const isOverdue = brand.lastPromptRunAt && brand.activePrompts > 0
 										? new Date().getTime() - new Date(brand.lastPromptRunAt).getTime() > currentDelayMs

--- a/apps/web/src/routes/_authed/app/$brand/index.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/index.tsx
@@ -199,8 +199,6 @@ function formatRelativeTime(dateString: string | null): string {
 	return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
-const DEFAULT_DELAY_HOURS = 72;
-
 function formatRunFrequency(hours: number): string {
 	const weeks = Math.floor(hours / (7 * 24));
 	const days = Math.floor((hours % (7 * 24)) / 24);
@@ -732,8 +730,8 @@ function DashboardPage() {
 							<StatWithTooltip
 								icon={IconClock}
 								label="run frequency"
-								value={formatRunFrequency(brand?.delayOverrideHours ?? DEFAULT_DELAY_HOURS)}
-								tooltip={`Prompts are automatically evaluated every ${formatRunFrequency(brand?.delayOverrideHours ?? DEFAULT_DELAY_HOURS).replace("~", "")} on average to track changes in AI model responses over time.`}
+								value={formatRunFrequency(brand?.delayOverrideHours ?? clientConfig?.defaultDelayHours ?? 24)}
+								tooltip={`Prompts are automatically evaluated every ${formatRunFrequency(brand?.delayOverrideHours ?? clientConfig?.defaultDelayHours ?? 24).replace("~", "")} on average to track changes in AI model responses over time.`}
 							/>
 							<StatWithTooltip
 								icon={IconRefresh}

--- a/apps/web/src/server/admin.ts
+++ b/apps/web/src/server/admin.ts
@@ -14,7 +14,7 @@ import {
 	getAdminActiveBrandsOverTime,
 } from "@/lib/postgres-read";
 import { analyzeWebsite, getCompetitors, generateCandidatePromptsForReports } from "@workspace/lib/wizard-helpers";
-import { DEFAULT_DELAY_HOURS } from "@workspace/lib/constants";
+import { getDefaultDelayHours } from "@workspace/lib/constants";
 import { sendImmediatePromptJob } from "@/lib/job-scheduler";
 import { Client } from "pg";
 import { parseScrapeTargets } from "@workspace/lib/providers";
@@ -623,11 +623,12 @@ export const getWorkflowDataFn = createServerFn({ method: "GET" }).handler(async
 	}
 
 	const now = Date.now();
+	const defaultDelayHours = getDefaultDelayHours();
 	const defaultSchedulerInfo = { exists: false, nextRunAt: null as number | null, cadenceHours: null as number | null };
 
 	const brandSummaries = allBrands.map((brand) => {
 		const brandPrompts = promptsByBrand[brand.id] || [];
-		const delayHours = brand.delayOverrideHours ?? DEFAULT_DELAY_HOURS;
+		const delayHours = brand.delayOverrideHours ?? defaultDelayHours;
 		const runFrequencyMs = delayHours * 60 * 60 * 1000;
 
 		let overduePrompts = 0;

--- a/apps/web/src/server/config.ts
+++ b/apps/web/src/server/config.ts
@@ -5,6 +5,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { getDeployment } from "@/lib/config/server";
 import type { ClientConfig } from "@workspace/config/types";
 import { getEnvValidationState } from "@workspace/config/env";
+import { getDefaultDelayHours } from "@workspace/lib/constants";
 
 export type PublicClientConfig = Omit<ClientConfig, "branding"> & {
 	branding: Omit<ClientConfig["branding"], "onboardingRedirectUrl">;
@@ -41,6 +42,7 @@ export const getClientConfig = createServerFn({ method: "GET" }).handler(async (
 			posthogKey: resolvePosthogKey(),
 		},
 		defaultOrganization: deployment.defaultOrganization,
+		defaultDelayHours: getDefaultDelayHours(),
 	};
 });
 

--- a/apps/web/src/stories/_mocks/config-client.ts
+++ b/apps/web/src/stories/_mocks/config-client.ts
@@ -35,6 +35,7 @@ export interface ClientConfig {
 	branding: BrandingConfig;
 	analytics: AnalyticsConfig;
 	defaultOrganization?: string;
+	defaultDelayHours: number;
 }
 
 const DEFAULT_CHART_COLORS = [
@@ -64,6 +65,7 @@ let _config: ClientConfig = {
 		chartColors: DEFAULT_CHART_COLORS,
 	},
 	analytics: {},
+	defaultDelayHours: 24,
 };
 
 export function setMockClientConfig(config: ClientConfig) {

--- a/apps/worker/src/jobs/process-prompt.ts
+++ b/apps/worker/src/jobs/process-prompt.ts
@@ -2,7 +2,7 @@ import type { Job } from "pg-boss";
 import { db } from "@workspace/lib/db/db";
 import { brands, citations, competitors, promptRuns, prompts, type Brand, type Competitor } from "@workspace/lib/db/schema";
 import { eq } from "drizzle-orm";
-import { DEFAULT_DELAY_HOURS, RUNS_PER_PROMPT } from "@workspace/lib/constants";
+import { RUNS_PER_PROMPT, getDefaultDelayHours } from "@workspace/lib/constants";
 import {
 	getProvider,
 	parseScrapeTargets,
@@ -56,19 +56,20 @@ async function scheduleNextRun(promptId: string, cadenceHours: number): Promise<
  * Get the cadence hours for a prompt based on its brand's delay override.
  */
 async function getCadenceHours(promptId: string): Promise<number> {
+	const defaultDelayHours = getDefaultDelayHours();
 	const prompt = await db.query.prompts.findFirst({
 		where: eq(prompts.id, promptId),
 	});
 
-	if (!prompt) return DEFAULT_DELAY_HOURS;
+	if (!prompt) return defaultDelayHours;
 
 	const brand = await db.query.brands.findFirst({
 		where: eq(brands.id, prompt.brandId),
 	});
 
-	if (!brand) return DEFAULT_DELAY_HOURS;
+	if (!brand) return defaultDelayHours;
 
-	return brand.delayOverrideHours ?? DEFAULT_DELAY_HOURS;
+	return brand.delayOverrideHours ?? defaultDelayHours;
 }
 
 async function getPromptContext(promptId: string): Promise<PromptContext | null> {

--- a/apps/worker/src/jobs/schedule-maintenance.ts
+++ b/apps/worker/src/jobs/schedule-maintenance.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_DELAY_HOURS } from "@workspace/lib/constants";
+import { getDefaultDelayHours } from "@workspace/lib/constants";
 import { db } from "@workspace/lib/db/db";
 import { brands, promptRuns, prompts } from "@workspace/lib/db/schema";
 import { parseScrapeTargets } from "@workspace/lib/providers";
@@ -43,9 +43,10 @@ async function runMaintenanceCheck(): Promise<void> {
 	}
 
 	const brandIds = enabledBrands.map((b) => b.id);
+	const defaultDelayHours = getDefaultDelayHours();
 	const brandDelayMap: Record<string, number> = {};
 	for (const brand of enabledBrands) {
-		brandDelayMap[brand.id] = brand.delayOverrideHours ?? DEFAULT_DELAY_HOURS;
+		brandDelayMap[brand.id] = brand.delayOverrideHours ?? defaultDelayHours;
 	}
 
 	// Get all enabled prompts for enabled brands
@@ -96,7 +97,7 @@ async function runMaintenanceCheck(): Promise<void> {
 			continue;
 		}
 
-		const cadenceHours = brandDelayMap[prompt.brandId] ?? DEFAULT_DELAY_HOURS;
+		const cadenceHours = brandDelayMap[prompt.brandId] ?? defaultDelayHours;
 		const runFrequencyMs = cadenceHours * 60 * 60 * 1000;
 		const lastRuns = lastRunsMap[prompt.id] || {};
 

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -110,6 +110,8 @@ export interface ClientConfig {
   analytics: AnalyticsConfig;
   /** Default organization (for local/demo modes) */
   defaultOrganization?: DefaultOrganization;
+  /** Resolved default prompt cadence (hours) for brands without a delayOverrideHours */
+  defaultDelayHours: number;
 }
 
 // ============================================================================

--- a/packages/lib/src/constants.ts
+++ b/packages/lib/src/constants.ts
@@ -1,7 +1,24 @@
 // Constants for prompt processing
 export const RUNS_PER_PROMPT = 5;
 
-export const DEFAULT_DELAY_HOURS = 72;
+// Fallback cadence (hours) when the DEFAULT_DELAY_HOURS env var is unset or invalid.
+export const DEFAULT_DELAY_HOURS_FALLBACK = 24;
+
+/**
+ * Resolves the default prompt cadence (hours) for brands without a
+ * delayOverrideHours. Reads DEFAULT_DELAY_HOURS from the environment; falls
+ * back to DEFAULT_DELAY_HOURS_FALLBACK when unset, non-numeric, or <= 0.
+ *
+ * Server-only. Client code should read clientConfig.defaultDelayHours instead
+ * of calling this directly — `process` is not defined in browser bundles.
+ */
+export function getDefaultDelayHours(): number {
+	const raw = typeof process !== "undefined" ? process.env.DEFAULT_DELAY_HOURS : undefined;
+	if (!raw) return DEFAULT_DELAY_HOURS_FALLBACK;
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_DELAY_HOURS_FALLBACK;
+	return parsed;
+}
 
 // Maximum limits for brand resources
 export const MAX_COMPETITORS = 100;


### PR DESCRIPTION
## Summary
- Replace hard-coded `DEFAULT_DELAY_HOURS = 72` in `packages/lib/src/constants.ts` with `getDefaultDelayHours()` that reads `DEFAULT_DELAY_HOURS` from the environment (server-side), falling back to **24h** when the var is unset, non-numeric, or <= 0.
- Add `defaultDelayHours: number` to `ClientConfig` and populate it in `getClientConfig()` so browser code reads the resolved value via route context.
- Dedupe the two route-local `const DEFAULT_DELAY_HOURS = 72` copies in `apps/web/src/routes/_authed/admin/index.tsx` and `apps/web/src/routes/_authed/app/$brand/index.tsx` — both now read from `clientConfig.defaultDelayHours`.
- Resolution order remains: `brand.delayOverrideHours` → env var → `24`.

## Touched consumers
Server: `apps/web/src/server/admin.ts`, `apps/web/src/lib/job-scheduler.ts`, `apps/web/src/lib/chart-utils.ts`, `apps/worker/src/jobs/schedule-maintenance.ts`, `apps/worker/src/jobs/process-prompt.ts`.
Client: admin dashboard + brand overview routes, plus the Storybook client-config mock.

## Test plan
- [x] `pnpm -C apps/web check-types`
- [x] `pnpm -C apps/worker check-types` and `pnpm -C apps/worker build`
- [x] `pnpm -C packages/lib test` (150 passed)
- [x] `pnpm -C apps/web test` (56 passed)

## Notes
- Worker picks up the env var automatically — `apps/worker` runs with `--env-file=../web/.env` in dev; prod deployments need the same var set wherever the worker process runs.
- `DEFAULT_DELAY_HOURS_FALLBACK = 24` is exported but currently unused outside `constants.ts`; kept for tests / future direct access.