### PR TITLE
Surface demo banner and app info in sidebar

### DIFF
--- a/.changeset/sidebar-demo-banner.md
+++ b/.changeset/sidebar-demo-banner.md
@@ -1,5 +1,0 @@
----
-"@workspace/web": patch
----
-
-Show demo mode warning and version/GitHub/website links in the sidebar so they're visible alongside authenticated user info (and in Storybook).

--- a/.changeset/sidebar-demo-banner.md
+++ b/.changeset/sidebar-demo-banner.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Show demo mode warning and version/GitHub/website links in the sidebar so they're visible alongside authenticated user info (and in Storybook).

--- a/.changeset/sidebar-demo-pill.md
+++ b/.changeset/sidebar-demo-pill.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Replace the page-top demo-mode banner with a compact "Demo" pill next to the sidebar logo (with a tooltip explaining the read-only behavior), and move version / elmohq.com / GitHub links into the sidebar footer for every deployment mode except whitelabel. Also reads the better-auth `user.image` field so avatars actually render.

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -27,7 +27,7 @@ import {
 import { NavMain, type NavGroup } from "@/components/nav-main";
 import { NavUser } from "@/components/nav-user";
 import { NavAppInfo } from "@/components/nav-app-info";
-import { DemoModeBanner } from "@/components/demo-mode-banner";
+import { DemoModePill } from "@/components/demo-mode-pill";
 import { Logo } from "@/components/logo";
 import type { BrandWithPrompts } from "@workspace/lib/db/schema";
 
@@ -161,7 +161,7 @@ export function AppSidebar({ isAdmin = false, hasReportAccess = false, adminOnly
 						<Link to="/app" onClick={() => setOpenMobile(false)}>
 							<Logo iconClassName="!size-5" />
 							<div className="ml-auto group-data-[collapsible=icon]:hidden">
-								<DemoModeBanner />
+								<DemoModePill />
 							</div>
 						</Link>
 					</SidebarMenuButton>

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -26,6 +26,8 @@ import {
 } from "@workspace/ui/components/sidebar";
 import { NavMain, type NavGroup } from "@/components/nav-main";
 import { NavUser } from "@/components/nav-user";
+import { NavAppInfo } from "@/components/nav-app-info";
+import { DemoModeBanner } from "@/components/demo-mode-banner";
 import { Logo } from "@/components/logo";
 import type { BrandWithPrompts } from "@workspace/lib/db/schema";
 
@@ -164,10 +166,12 @@ export function AppSidebar({ isAdmin = false, hasReportAccess = false, adminOnly
 				</SidebarMenu>
 			</SidebarHeader>
 			<SidebarContent>
+				<DemoModeBanner variant="sidebar" />
 				<NavMain groups={groups} />
 			</SidebarContent>
 			<SidebarFooter>
 				<NavUser />
+				<NavAppInfo />
 			</SidebarFooter>
 		</Sidebar>
 	);

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -161,7 +161,7 @@ export function AppSidebar({ isAdmin = false, hasReportAccess = false, adminOnly
 						<Link to="/app" onClick={() => setOpenMobile(false)}>
 							<Logo iconClassName="!size-5" />
 							<div className="ml-auto group-data-[collapsible=icon]:hidden">
-								<DemoModeBanner variant="sidebar-pill" />
+								<DemoModeBanner />
 							</div>
 						</Link>
 					</SidebarMenuButton>

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -160,13 +160,15 @@ export function AppSidebar({ isAdmin = false, hasReportAccess = false, adminOnly
 					<SidebarMenuButton size="lg" asChild>
 						<Link to="/app" onClick={() => setOpenMobile(false)}>
 							<Logo iconClassName="!size-5" />
+							<div className="ml-auto group-data-[collapsible=icon]:hidden">
+								<DemoModeBanner variant="sidebar-pill" />
+							</div>
 						</Link>
 					</SidebarMenuButton>
 					</SidebarMenuItem>
 				</SidebarMenu>
 			</SidebarHeader>
 			<SidebarContent>
-				<DemoModeBanner variant="sidebar" />
 				<NavMain groups={groups} />
 			</SidebarContent>
 			<SidebarFooter>

--- a/apps/web/src/components/demo-mode-banner.tsx
+++ b/apps/web/src/components/demo-mode-banner.tsx
@@ -3,40 +3,23 @@ import { IconInfoCircle } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
 import type { ClientConfig } from "@workspace/config/types";
 
-interface DemoModeBannerProps {
-	variant?: "page" | "sidebar-pill";
-}
-
-export function DemoModeBanner({ variant = "page" }: DemoModeBannerProps = {}) {
+export function DemoModeBanner() {
 	const context = useRouteContext({ strict: false }) as { clientConfig?: ClientConfig };
 	const isReadOnly = context.clientConfig?.features.readOnly ?? false;
 
 	if (!isReadOnly) return null;
 
-	if (variant === "sidebar-pill") {
-		return (
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<span className="inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-700 dark:text-amber-400">
-						<IconInfoCircle className="size-3" />
-						Demo
-					</span>
-				</TooltipTrigger>
-				<TooltipContent>
-					This is a read-only demo. Any edits will fail.
-				</TooltipContent>
-			</Tooltip>
-		);
-	}
-
 	return (
-		<div className="bg-amber-500/10 border-b border-amber-500/20 px-4 py-2">
-			<div className="container mx-auto flex items-center justify-center gap-2 text-sm text-amber-700 dark:text-amber-400">
-				<IconInfoCircle className="h-4 w-4" />
-				<span>
-					<strong>Demo Mode</strong> — This is a read-only demo. Write operations are disabled.
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<span className="inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-700 dark:text-amber-400">
+					<IconInfoCircle className="size-3" />
+					Demo
 				</span>
-			</div>
-		</div>
+			</TooltipTrigger>
+			<TooltipContent>
+				This is a read-only demo. Any edits will fail.
+			</TooltipContent>
+		</Tooltip>
 	);
 }

--- a/apps/web/src/components/demo-mode-banner.tsx
+++ b/apps/web/src/components/demo-mode-banner.tsx
@@ -1,14 +1,9 @@
 import { useRouteContext } from "@tanstack/react-router";
 import { IconInfoCircle } from "@tabler/icons-react";
-import {
-	SidebarGroup,
-	SidebarGroupContent,
-	SidebarGroupLabel,
-} from "@workspace/ui/components/sidebar";
 import type { ClientConfig } from "@workspace/config/types";
 
 interface DemoModeBannerProps {
-	variant?: "page" | "sidebar";
+	variant?: "page" | "sidebar-pill";
 }
 
 export function DemoModeBanner({ variant = "page" }: DemoModeBannerProps = {}) {
@@ -17,16 +12,14 @@ export function DemoModeBanner({ variant = "page" }: DemoModeBannerProps = {}) {
 
 	if (!isReadOnly) return null;
 
-	if (variant === "sidebar") {
+	if (variant === "sidebar-pill") {
 		return (
-			<SidebarGroup>
-				<SidebarGroupLabel>Demo Mode</SidebarGroupLabel>
-				<SidebarGroupContent>
-					<p className="rounded-md border border-amber-500/20 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
-						Edits will fail. Only reading data is supported.
-					</p>
-				</SidebarGroupContent>
-			</SidebarGroup>
+			<span
+				className="inline-flex items-center rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-700 dark:text-amber-400"
+				title="Read-only demo — edits will fail"
+			>
+				Demo
+			</span>
 		);
 	}
 

--- a/apps/web/src/components/demo-mode-banner.tsx
+++ b/apps/web/src/components/demo-mode-banner.tsx
@@ -1,12 +1,34 @@
 import { useRouteContext } from "@tanstack/react-router";
 import { IconInfoCircle } from "@tabler/icons-react";
+import {
+	SidebarGroup,
+	SidebarGroupContent,
+	SidebarGroupLabel,
+} from "@workspace/ui/components/sidebar";
 import type { ClientConfig } from "@workspace/config/types";
 
-export function DemoModeBanner() {
+interface DemoModeBannerProps {
+	variant?: "page" | "sidebar";
+}
+
+export function DemoModeBanner({ variant = "page" }: DemoModeBannerProps = {}) {
 	const context = useRouteContext({ strict: false }) as { clientConfig?: ClientConfig };
 	const isReadOnly = context.clientConfig?.features.readOnly ?? false;
 
 	if (!isReadOnly) return null;
+
+	if (variant === "sidebar") {
+		return (
+			<SidebarGroup>
+				<SidebarGroupLabel>Demo Mode</SidebarGroupLabel>
+				<SidebarGroupContent>
+					<p className="rounded-md border border-amber-500/20 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
+						Edits will fail. Only reading data is supported.
+					</p>
+				</SidebarGroupContent>
+			</SidebarGroup>
+		);
+	}
 
 	return (
 		<div className="bg-amber-500/10 border-b border-amber-500/20 px-4 py-2">

--- a/apps/web/src/components/demo-mode-banner.tsx
+++ b/apps/web/src/components/demo-mode-banner.tsx
@@ -1,5 +1,6 @@
 import { useRouteContext } from "@tanstack/react-router";
 import { IconInfoCircle } from "@tabler/icons-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
 import type { ClientConfig } from "@workspace/config/types";
 
 interface DemoModeBannerProps {
@@ -14,12 +15,17 @@ export function DemoModeBanner({ variant = "page" }: DemoModeBannerProps = {}) {
 
 	if (variant === "sidebar-pill") {
 		return (
-			<span
-				className="inline-flex items-center rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-700 dark:text-amber-400"
-				title="Read-only demo — edits will fail"
-			>
-				Demo
-			</span>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<span className="inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-700 dark:text-amber-400">
+						<IconInfoCircle className="size-3" />
+						Demo
+					</span>
+				</TooltipTrigger>
+				<TooltipContent>
+					This is a read-only demo. Any edits will fail.
+				</TooltipContent>
+			</Tooltip>
 		);
 	}
 

--- a/apps/web/src/components/demo-mode-pill.tsx
+++ b/apps/web/src/components/demo-mode-pill.tsx
@@ -3,7 +3,7 @@ import { IconInfoCircle } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
 import type { ClientConfig } from "@workspace/config/types";
 
-export function DemoModeBanner() {
+export function DemoModePill() {
 	const context = useRouteContext({ strict: false }) as { clientConfig?: ClientConfig };
 	const isReadOnly = context.clientConfig?.features.readOnly ?? false;
 

--- a/apps/web/src/components/nav-app-info.tsx
+++ b/apps/web/src/components/nav-app-info.tsx
@@ -1,4 +1,4 @@
-import { IconBrandGithub, IconLink } from "@tabler/icons-react";
+import { IconBrandGithub, IconWorld } from "@tabler/icons-react";
 import { useRouteContext } from "@tanstack/react-router";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
 import type { ClientConfig } from "@workspace/config/types";
@@ -12,28 +12,31 @@ export function NavAppInfo() {
 	if (mode !== "local" && mode !== "demo") return null;
 
 	const linkClass =
-		"text-muted-foreground hover:text-foreground inline-flex size-6 items-center justify-center rounded-md transition-colors";
+		"text-muted-foreground hover:text-foreground inline-flex size-7 items-center justify-center rounded-md transition-colors";
 
 	return (
-		<div className="flex items-center justify-center gap-2 px-2 pt-1 pb-0.5 text-[11px] text-muted-foreground">
-			<span className="font-mono">v{__APP_VERSION__}</span>
-			<span className="text-muted-foreground/50">·</span>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<a href="https://www.elmohq.com/" target="_blank" rel="noreferrer" className={linkClass}>
-						<IconLink className="size-3.5" />
-					</a>
-				</TooltipTrigger>
-				<TooltipContent>elmohq.com</TooltipContent>
-			</Tooltip>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<a href="https://github.com/elmohq/elmo" target="_blank" rel="noreferrer" className={linkClass}>
-						<IconBrandGithub className="size-3.5" />
-					</a>
-				</TooltipTrigger>
-				<TooltipContent>View on GitHub</TooltipContent>
-			</Tooltip>
+		<div className="mx-2 mt-1 flex items-center gap-2 border-t border-sidebar-border/60 px-1 pt-2">
+			<span className="flex-1 text-xs font-medium text-muted-foreground">
+				v{__APP_VERSION__}
+			</span>
+			<div className="flex items-center gap-1">
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<a href="https://www.elmohq.com/" target="_blank" rel="noreferrer" className={linkClass}>
+							<IconWorld className="size-4" />
+						</a>
+					</TooltipTrigger>
+					<TooltipContent>elmohq.com</TooltipContent>
+				</Tooltip>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<a href="https://github.com/elmohq/elmo" target="_blank" rel="noreferrer" className={linkClass}>
+							<IconBrandGithub className="size-4" />
+						</a>
+					</TooltipTrigger>
+					<TooltipContent>View on GitHub</TooltipContent>
+				</Tooltip>
+			</div>
 		</div>
 	);
 }

--- a/apps/web/src/components/nav-app-info.tsx
+++ b/apps/web/src/components/nav-app-info.tsx
@@ -1,4 +1,6 @@
+import { IconBrandGithub, IconLink } from "@tabler/icons-react";
 import { useRouteContext } from "@tanstack/react-router";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
 import type { ClientConfig } from "@workspace/config/types";
 
 export function NavAppInfo() {
@@ -9,19 +11,29 @@ export function NavAppInfo() {
 	// and the public demo — whitelabel/cloud deployments hide them.
 	if (mode !== "local" && mode !== "demo") return null;
 
-	const linkClass = "text-muted-foreground hover:text-foreground transition-colors";
+	const linkClass =
+		"text-muted-foreground hover:text-foreground inline-flex size-6 items-center justify-center rounded-md transition-colors";
 
 	return (
-		<div className="flex items-center justify-center gap-1.5 px-2 pt-1 pb-0.5 text-[11px] text-muted-foreground">
+		<div className="flex items-center justify-center gap-2 px-2 pt-1 pb-0.5 text-[11px] text-muted-foreground">
 			<span className="font-mono">v{__APP_VERSION__}</span>
 			<span className="text-muted-foreground/50">·</span>
-			<a href="https://www.elmohq.com/" target="_blank" rel="noreferrer" className={linkClass}>
-				elmohq.com
-			</a>
-			<span className="text-muted-foreground/50">·</span>
-			<a href="https://github.com/elmohq/elmo" target="_blank" rel="noreferrer" className={linkClass}>
-				GitHub
-			</a>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<a href="https://www.elmohq.com/" target="_blank" rel="noreferrer" className={linkClass}>
+						<IconLink className="size-3.5" />
+					</a>
+				</TooltipTrigger>
+				<TooltipContent>elmohq.com</TooltipContent>
+			</Tooltip>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<a href="https://github.com/elmohq/elmo" target="_blank" rel="noreferrer" className={linkClass}>
+						<IconBrandGithub className="size-3.5" />
+					</a>
+				</TooltipTrigger>
+				<TooltipContent>View on GitHub</TooltipContent>
+			</Tooltip>
 		</div>
 	);
 }

--- a/apps/web/src/components/nav-app-info.tsx
+++ b/apps/web/src/components/nav-app-info.tsx
@@ -16,9 +16,14 @@ export function NavAppInfo() {
 
 	return (
 		<div className="mx-2 mt-1 flex items-center gap-2 border-t border-sidebar-border/60 px-1 pt-2">
-			<span className="flex-1 text-xs font-medium text-muted-foreground">
+			<a
+				href={`https://github.com/elmohq/elmo/releases/tag/v${__APP_VERSION__}`}
+				target="_blank"
+				rel="noreferrer"
+				className="flex-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+			>
 				v{__APP_VERSION__}
-			</span>
+			</a>
 			<div className="flex items-center gap-1">
 				<Tooltip>
 					<TooltipTrigger asChild>

--- a/apps/web/src/components/nav-app-info.tsx
+++ b/apps/web/src/components/nav-app-info.tsx
@@ -26,7 +26,7 @@ export function NavAppInfo() {
 			<div className="flex items-center gap-1">
 				<Tooltip>
 					<TooltipTrigger asChild>
-						<a href="https://www.elmohq.com/" target="_blank" rel="noreferrer" className={linkClass}>
+						<a href="https://www.elmohq.com/" target="_blank" className={linkClass}>
 							<IconWorld className="size-4" />
 						</a>
 					</TooltipTrigger>

--- a/apps/web/src/components/nav-app-info.tsx
+++ b/apps/web/src/components/nav-app-info.tsx
@@ -7,9 +7,9 @@ export function NavAppInfo() {
 	const context = useRouteContext({ strict: false }) as { clientConfig?: ClientConfig };
 	const mode = context.clientConfig?.mode;
 
-	// Version/website/github links are only meaningful for open-source self-host
-	// and the public demo — whitelabel/cloud deployments hide them.
-	if (mode !== "local" && mode !== "demo") return null;
+	// Version/website/github links are only meaningful for open-source
+	// deployments — whitelabel and cloud hide them.
+	if (mode === "whitelabel" || mode === "cloud") return null;
 
 	const linkClass =
 		"text-muted-foreground hover:text-foreground inline-flex size-7 items-center justify-center rounded-md transition-colors";

--- a/apps/web/src/components/nav-app-info.tsx
+++ b/apps/web/src/components/nav-app-info.tsx
@@ -1,6 +1,4 @@
-import { IconBrandGithub, IconLink } from "@tabler/icons-react";
 import { useRouteContext } from "@tanstack/react-router";
-import { SidebarMenu, SidebarMenuItem } from "@workspace/ui/components/sidebar";
 import type { ClientConfig } from "@workspace/config/types";
 
 export function NavAppInfo() {
@@ -11,37 +9,19 @@ export function NavAppInfo() {
 	// and the public demo — whitelabel/cloud deployments hide them.
 	if (mode !== "local" && mode !== "demo") return null;
 
+	const linkClass = "text-muted-foreground hover:text-foreground transition-colors";
+
 	return (
-		<SidebarMenu>
-			<SidebarMenuItem>
-				<div className="flex w-full items-center gap-2 rounded-md px-2 py-2 pb-0 mb-0">
-					<div className="grid flex-1 text-left text-xs leading-tight">
-						<span className="text-muted-foreground font-medium">
-							v{__APP_VERSION__}
-						</span>
-					</div>
-					<div className="flex items-center gap-1">
-						<a
-							href="https://www.elmohq.com/"
-							target="_blank"
-							rel="noreferrer"
-							className="text-muted-foreground hover:text-foreground inline-flex size-7 items-center justify-center rounded-md transition-colors"
-							title="elmohq.com"
-						>
-							<IconLink className="size-4" />
-						</a>
-						<a
-							href="https://github.com/elmohq/elmo"
-							target="_blank"
-							rel="noreferrer"
-							className="text-muted-foreground hover:text-foreground inline-flex size-7 items-center justify-center rounded-md transition-colors"
-							title="View on GitHub"
-						>
-							<IconBrandGithub className="size-4" />
-						</a>
-					</div>
-				</div>
-			</SidebarMenuItem>
-		</SidebarMenu>
+		<div className="flex items-center justify-center gap-1.5 px-2 pt-1 pb-0.5 text-[11px] text-muted-foreground">
+			<span className="font-mono">v{__APP_VERSION__}</span>
+			<span className="text-muted-foreground/50">·</span>
+			<a href="https://www.elmohq.com/" target="_blank" rel="noreferrer" className={linkClass}>
+				elmohq.com
+			</a>
+			<span className="text-muted-foreground/50">·</span>
+			<a href="https://github.com/elmohq/elmo" target="_blank" rel="noreferrer" className={linkClass}>
+				GitHub
+			</a>
+		</div>
 	);
 }

--- a/apps/web/src/components/nav-app-info.tsx
+++ b/apps/web/src/components/nav-app-info.tsx
@@ -7,9 +7,8 @@ export function NavAppInfo() {
 	const context = useRouteContext({ strict: false }) as { clientConfig?: ClientConfig };
 	const mode = context.clientConfig?.mode;
 
-	// Version/website/github links are only meaningful for open-source
-	// deployments — whitelabel and cloud hide them.
-	if (mode === "whitelabel" || mode === "cloud") return null;
+	// Whitelabel deployments hide the version/website/github links.
+	if (mode === "whitelabel") return null;
 
 	const linkClass =
 		"text-muted-foreground hover:text-foreground inline-flex size-7 items-center justify-center rounded-md transition-colors";

--- a/apps/web/src/components/nav-app-info.tsx
+++ b/apps/web/src/components/nav-app-info.tsx
@@ -1,7 +1,16 @@
 import { IconBrandGithub, IconLink } from "@tabler/icons-react";
+import { useRouteContext } from "@tanstack/react-router";
 import { SidebarMenu, SidebarMenuItem } from "@workspace/ui/components/sidebar";
+import type { ClientConfig } from "@workspace/config/types";
 
 export function NavAppInfo() {
+	const context = useRouteContext({ strict: false }) as { clientConfig?: ClientConfig };
+	const mode = context.clientConfig?.mode;
+
+	// Version/website/github links are only meaningful for open-source self-host
+	// and the public demo — whitelabel/cloud deployments hide them.
+	if (mode !== "local" && mode !== "demo") return null;
+
 	return (
 		<SidebarMenu>
 			<SidebarMenuItem>

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -22,7 +22,6 @@ import { Link, useRouteContext } from "@tanstack/react-router";
 import type { ClientConfig } from "@workspace/config/types";
 import { authClient } from "@workspace/lib/auth/client";
 import { useAuth } from "@/hooks/use-auth";
-import { NavAppInfo } from "@/components/nav-app-info";
 import { resetPostHog } from "@/lib/posthog";
 
 export function NavUser() {
@@ -33,9 +32,10 @@ export function NavUser() {
 	const isNameEmailSame =
 		user?.name?.trim().toLowerCase() === user?.email?.trim().toLowerCase();
 
-	// In local/demo mode, there's no auth system — show app info instead
+	// In local/demo mode there's no auth — AppSidebar renders NavAppInfo separately,
+	// so render nothing here.
 	if (!loginUrl && !logoutUrl) {
-		return <NavAppInfo />;
+		return null;
 	}
 
 	if (isLoading) {
@@ -58,10 +58,7 @@ export function NavUser() {
 	}
 
 	if (!user) {
-		// If no login URL (local/demo mode), show app info instead
-		if (!loginUrl) {
-			return <NavAppInfo />;
-		}
+		if (!loginUrl) return null;
 		return (
 			<SidebarMenu>
 				<SidebarMenuItem>

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -25,59 +25,17 @@ import { useAuth } from "@/hooks/use-auth";
 import { resetPostHog } from "@/lib/posthog";
 
 export function NavUser() {
-	const { user, isLoading, loginUrl, logoutUrl } = useAuth();
+	const { user } = useAuth();
 	const { isMobile, setOpenMobile } = useSidebar();
 	const context = useRouteContext({ strict: false }) as { clientConfig?: ClientConfig };
 	const clientConfig = context.clientConfig;
+
+	// NavUser only renders inside _authed routes, which redirect to /auth/login
+	// when there's no session — so `user` is always present at this point.
+	if (!user) return null;
+
 	const isNameEmailSame =
-		user?.name?.trim().toLowerCase() === user?.email?.trim().toLowerCase();
-
-	// In local/demo mode there's no auth — AppSidebar renders NavAppInfo separately,
-	// so render nothing here.
-	if (!loginUrl && !logoutUrl) {
-		return null;
-	}
-
-	if (isLoading) {
-		return (
-			<SidebarMenu>
-				<SidebarMenuItem>
-					<SidebarMenuButton size="lg" disabled>
-						<Avatar className="h-8 w-8 rounded-lg grayscale">
-							<AvatarFallback className="rounded-lg bg-muted text-muted-foreground">
-								<IconUser className="size-4" />
-							</AvatarFallback>
-						</Avatar>
-						<div className="grid flex-1 text-left text-sm leading-tight">
-							<span className="truncate font-medium">Loading...</span>
-						</div>
-					</SidebarMenuButton>
-				</SidebarMenuItem>
-			</SidebarMenu>
-		);
-	}
-
-	if (!user) {
-		if (!loginUrl) return null;
-		return (
-			<SidebarMenu>
-				<SidebarMenuItem>
-					<SidebarMenuButton size="lg" asChild>
-						<a href={loginUrl}>
-							<Avatar className="h-8 w-8 rounded-lg">
-								<AvatarFallback className="rounded-lg bg-primary/10 text-primary">
-									<IconUser className="size-4" />
-								</AvatarFallback>
-							</Avatar>
-							<div className="grid flex-1 text-left text-sm leading-tight">
-								<span className="truncate font-medium">Sign In</span>
-							</div>
-						</a>
-					</SidebarMenuButton>
-				</SidebarMenuItem>
-			</SidebarMenu>
-		);
-	}
+		user.name?.trim().toLowerCase() === user.email?.trim().toLowerCase();
 
 	return (
 		<SidebarMenu>
@@ -138,27 +96,23 @@ export function NavUser() {
 								</DropdownMenuItem>
 							)}
 						</DropdownMenuGroup>
-					{logoutUrl && (
-						<>
-							<DropdownMenuSeparator />
-							<DropdownMenuItem
-								className="cursor-pointer"
-								onClick={() => {
-									authClient.signOut({
-										fetchOptions: {
-											onSuccess: () => {
-												resetPostHog();
-												window.location.href = "/auth/logout";
-											},
-										},
-									});
-								}}
-							>
-								<IconLogout />
-								Log out
-							</DropdownMenuItem>
-						</>
-					)}
+					<DropdownMenuSeparator />
+					<DropdownMenuItem
+						className="cursor-pointer"
+						onClick={() => {
+							authClient.signOut({
+								fetchOptions: {
+									onSuccess: () => {
+										resetPostHog();
+										window.location.href = "/auth/logout";
+									},
+								},
+							});
+						}}
+					>
+						<IconLogout />
+						Log out
+					</DropdownMenuItem>
 					</DropdownMenuContent>
 				</DropdownMenu>
 			</SidebarMenuItem>

--- a/apps/web/src/hooks/use-auth.tsx
+++ b/apps/web/src/hooks/use-auth.tsx
@@ -29,7 +29,7 @@ export interface UseAuthResult {
 export function useAuth(): UseAuthResult {
 	const context = useRouteContext({ strict: false }) as {
 		session?: {
-			user: { id: string; name?: string; email?: string; image?: string | null; picture?: string };
+			user: { id: string; name?: string; email?: string; image?: string | null };
 		} | null;
 	};
 	const session = context.session;
@@ -39,7 +39,7 @@ export function useAuth(): UseAuthResult {
 					id: session.user.id,
 					name: session.user.name,
 					email: session.user.email,
-					picture: session.user.image ?? session.user.picture ?? undefined,
+					picture: session.user.image ?? undefined,
 				}
 			: null,
 		isLoading: false,

--- a/apps/web/src/hooks/use-auth.tsx
+++ b/apps/web/src/hooks/use-auth.tsx
@@ -28,7 +28,9 @@ export interface UseAuthResult {
  */
 export function useAuth(): UseAuthResult {
 	const context = useRouteContext({ strict: false }) as {
-		session?: { user: { id: string; name?: string; email?: string; picture?: string } } | null;
+		session?: {
+			user: { id: string; name?: string; email?: string; image?: string | null; picture?: string };
+		} | null;
 	};
 	const session = context.session;
 	return {
@@ -37,7 +39,7 @@ export function useAuth(): UseAuthResult {
 					id: session.user.id,
 					name: session.user.name,
 					email: session.user.email,
-					picture: session.user.picture,
+					picture: session.user.image ?? session.user.picture ?? undefined,
 				}
 			: null,
 		isLoading: false,

--- a/apps/web/src/routes/_authed/app/$brand.tsx
+++ b/apps/web/src/routes/_authed/app/$brand.tsx
@@ -18,7 +18,6 @@ import { SidebarInset, SidebarProvider } from "@workspace/ui/components/sidebar"
 import { Skeleton } from "@workspace/ui/components/skeleton";
 import { AppSidebar } from "@/components/app-sidebar";
 import { SiteHeader } from "@/components/site-header";
-import { DemoModeBanner } from "@/components/demo-mode-banner";
 import BrandOnboarding from "@/components/brand-onboarding";
 
 const getBrandData = createServerFn({ method: "GET" })
@@ -166,7 +165,6 @@ function BrandLayout() {
 		<SidebarProvider>
 			<AppSidebar isAdmin={isAdmin} hasReportAccess={hasReportAccess} brand={brand} />
 			<SidebarInset className="md:border md:border-border/60 md:rounded-xl overflow-hidden">
-				<DemoModeBanner />
 				<SiteHeader />
 				<div className="flex flex-1 flex-col">
 					<div className="@container/main flex flex-1 flex-col gap-2">

--- a/apps/web/src/stories/app-sidebar.stories.tsx
+++ b/apps/web/src/stories/app-sidebar.stories.tsx
@@ -128,14 +128,6 @@ const authedUser = (name: string, email: string, seed: string) => ({
 	logoutUrl: "/auth/logout",
 });
 
-const noAuth = {
-	user: null,
-	isLoading: false,
-	isAuthenticated: false,
-	loginUrl: undefined,
-	logoutUrl: undefined,
-};
-
 /**
  * Wrapper that contains the sidebar within a bounded box.
  *
@@ -191,12 +183,16 @@ export default {
 	title: "App Sidebar",
 } satisfies Meta;
 
-/** Local (self-hosted) — all nav visible, admin access, no auth */
+/** Local (self-hosted) — all nav visible, admin access, self-registered user */
 export const Local = () => {
-	configureMocks(localConfig, onboardedBrand, noAuth);
+	configureMocks(
+		localConfig,
+		onboardedBrand,
+		authedUser("Local Admin", "admin@localhost", "local-admin"),
+	);
 
 	return (
-		<SidebarFrame label="Local — Self-hosted, full admin, no auth">
+		<SidebarFrame label="Local — Self-hosted, full admin">
 			<AppSidebar isAdmin={true} hasReportAccess={true} />
 		</SidebarFrame>
 	);

--- a/apps/web/src/stories/app-sidebar.stories.tsx
+++ b/apps/web/src/stories/app-sidebar.stories.tsx
@@ -204,7 +204,10 @@ export const Local = () => {
 
 /** Demo — read-only preview, seeded user, no admin */
 export const Demo = () => {
-	configureMocks(demoConfig, onboardedBrand, authedUser("Demo User", "demo@elmohq.com", "demo"));
+	const demoUser = authedUser("Demo User", "demo@elmohq.com", "demo");
+	demoUser.user.picture =
+		"https://api.dicebear.com/9.x/avataaars-neutral/svg?eyebrows=default&eyes=surprised,default&mouth=smile,default&seed=Liam";
+	configureMocks(demoConfig, onboardedBrand, demoUser);
 
 	return (
 		<SidebarFrame label="Demo — Read-only, seeded user">

--- a/apps/web/src/stories/app-sidebar.stories.tsx
+++ b/apps/web/src/stories/app-sidebar.stories.tsx
@@ -205,8 +205,7 @@ export const Local = () => {
 /** Demo — read-only preview, seeded user, no admin */
 export const Demo = () => {
 	const demoUser = authedUser("Demo User", "demo@elmohq.com", "demo");
-	demoUser.user.picture =
-		"https://api.dicebear.com/9.x/avataaars-neutral/svg?eyebrows=default&eyes=default,default&mouth=smile,default&seed=Liam";
+	demoUser.user.picture = "https://api.dicebear.com/9.x/bottts-neutral/svg?seed=Adrian";
 	configureMocks(demoConfig, onboardedBrand, demoUser);
 
 	return (

--- a/apps/web/src/stories/app-sidebar.stories.tsx
+++ b/apps/web/src/stories/app-sidebar.stories.tsx
@@ -202,12 +202,12 @@ export const Local = () => {
 	);
 };
 
-/** Demo — read-only preview, no admin, no auth */
+/** Demo — read-only preview, seeded user, no admin */
 export const Demo = () => {
-	configureMocks(demoConfig, onboardedBrand, noAuth);
+	configureMocks(demoConfig, onboardedBrand, authedUser("Demo User", "demo@elmohq.com", "demo"));
 
 	return (
-		<SidebarFrame label="Demo — Read-only, no admin">
+		<SidebarFrame label="Demo — Read-only, seeded user">
 			<AppSidebar isAdmin={false} hasReportAccess={false} />
 		</SidebarFrame>
 	);

--- a/apps/web/src/stories/app-sidebar.stories.tsx
+++ b/apps/web/src/stories/app-sidebar.stories.tsx
@@ -206,7 +206,7 @@ export const Local = () => {
 export const Demo = () => {
 	const demoUser = authedUser("Demo User", "demo@elmohq.com", "demo");
 	demoUser.user.picture =
-		"https://api.dicebear.com/9.x/avataaars-neutral/svg?eyebrows=default&eyes=surprised,default&mouth=smile,default&seed=Liam";
+		"https://api.dicebear.com/9.x/avataaars-neutral/svg?eyebrows=default&eyes=default,default&mouth=smile,default&seed=Liam";
 	configureMocks(demoConfig, onboardedBrand, demoUser);
 
 	return (


### PR DESCRIPTION
## Summary
- Render the demo-mode warning as a sidebar nav group (label + callout) so it shows up in Storybook sidebar previews and alongside the authenticated user row, not just at the top of the page.
- Show version / website / GitHub links below the user row on `local` and `demo` deployments — they were previously hidden whenever a user was signed in. Whitelabel and cloud deployments remain unchanged (links stay hidden).
- Fix the Demo sidebar story to use an authenticated user; demo deployments have a seeded user with password \`demo\`, not anonymous access.