### PR TITLE
Use middle dot separator in page titles

### DIFF
--- a/apps/web/src/lib/route-head.ts
+++ b/apps/web/src/lib/route-head.ts
@@ -30,17 +30,17 @@ export function getBrandName(
 
 /**
  * Build a page title following the convention:
- *   "PageName - BrandName | AppName"  (with brand context)
- *   "PageName | AppName"              (without brand context)
+ *   "PageName | BrandName · AppName"  (with brand context)
+ *   "PageName · AppName"              (without brand context)
  */
 export function buildTitle(
 	pageName: string,
 	opts: { appName: string; brandName?: string },
 ): string {
 	if (opts.brandName) {
-		return `${pageName} - ${opts.brandName} | ${opts.appName}`;
+		return `${pageName} | ${opts.brandName} · ${opts.appName}`;
 	}
-	return `${pageName} | ${opts.appName}`;
+	return `${pageName} · ${opts.appName}`;
 }
 
 /**

--- a/apps/web/src/routes/_authed/admin/index.tsx
+++ b/apps/web/src/routes/_authed/admin/index.tsx
@@ -193,7 +193,7 @@ export const Route = createFileRoute("/_authed/admin/")({
 		const appName = getAppName(match);
 		return {
 			meta: [
-				{ title: `Admin | ${appName}` },
+				{ title: `Admin · ${appName}` },
 				{ name: "description", content: "Monitor and manage brands, prompts, and scheduling." },
 			],
 		};

--- a/apps/web/src/routes/_authed/admin/tools.tsx
+++ b/apps/web/src/routes/_authed/admin/tools.tsx
@@ -386,7 +386,7 @@ export const Route = createFileRoute("/_authed/admin/tools")({
 		const appName = getAppName(match);
 		return {
 			meta: [
-				{ title: `Tools | ${appName}` },
+				{ title: `Tools · ${appName}` },
 				{ name: "description", content: "Domain analysis and prompt generation utilities." },
 			],
 		};

--- a/apps/web/src/routes/_authed/admin/workflows.tsx
+++ b/apps/web/src/routes/_authed/admin/workflows.tsx
@@ -579,7 +579,7 @@ export const Route = createFileRoute("/_authed/admin/workflows")({
 		const appName = getAppName(match);
 		return {
 			meta: [
-				{ title: `Workflows | ${appName}` },
+				{ title: `Workflows · ${appName}` },
 				{ name: "description", content: "Monitor prompt scheduling and job execution." },
 			],
 		};

--- a/apps/web/src/routes/_authed/app/$brand.tsx
+++ b/apps/web/src/routes/_authed/app/$brand.tsx
@@ -136,7 +136,7 @@ export const Route = createFileRoute("/_authed/app/$brand")({
 		const brandName = (loaderData as { brandName?: string | null } | undefined)?.brandName;
 		return {
 			meta: [
-				{ title: brandName ? `${brandName} | ${appName}` : appName },
+				{ title: brandName ? `${brandName} · ${appName}` : appName },
 				{
 					name: "description",
 					content: brandName

--- a/apps/web/src/routes/_authed/reports/index.tsx
+++ b/apps/web/src/routes/_authed/reports/index.tsx
@@ -43,7 +43,7 @@ export const Route = createFileRoute("/_authed/reports/")({
 		const appName = getAppName(match);
 		return {
 			meta: [
-				{ title: `Reports | ${appName}` },
+				{ title: `Reports · ${appName}` },
 				{ name: "description", content: "Generate and view one-time brand reports." },
 			],
 		};

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -25,7 +25,7 @@ export const Route = createRootRoute({
 				name: "viewport",
 				content: "width=device-width, initial-scale=1",
 			},
-			{ title: `${SITE_NAME} — Open Source AI Visibility Platform` },
+			{ title: `${SITE_NAME} · Open Source AI Visibility Platform` },
 			{ name: "description", content: SITE_DESCRIPTION },
 			{ property: "og:site_name", content: SITE_NAME },
 			{ property: "og:locale", content: "en_US" },

--- a/apps/www/src/routes/ai-visibility-tools/$slug.tsx
+++ b/apps/www/src/routes/ai-visibility-tools/$slug.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/ai-visibility-tools/$slug")({
 			(c) => getComparisonSlug(c) === params.slug,
 		);
 		if (!competitor) return {};
-		const title = `Elmo vs ${competitor.name} — AI Visibility Tool Comparison | Elmo`;
+		const title = `Elmo vs ${competitor.name} | AI Visibility Tool Comparison · Elmo`;
 		const description = `Compare Elmo and ${competitor.name} for AI visibility tracking. Feature-by-feature breakdown, pricing, and key differences.`;
 		const path = `/ai-visibility-tools/${params.slug}`;
 		const meta = [

--- a/apps/www/src/routes/ai-visibility-tools/index.tsx
+++ b/apps/www/src/routes/ai-visibility-tools/index.tsx
@@ -4,7 +4,7 @@ import { Footer } from "@/components/footer";
 import { CompetitorDirectory } from "@/components/competitor-directory";
 import { ogMeta, canonicalUrl, breadcrumbJsonLd } from "@/lib/seo";
 
-const title = "AI Visibility Tool Directory — Compare AI Search Tools | Elmo";
+const title = "AI Visibility Tool Directory | Compare AI Search Tools · Elmo";
 const description =
 	"Compare 70+ AI visibility and Answer Engine Optimization tools. Feature matrix, pricing, and head-to-head comparisons with Elmo.";
 

--- a/apps/www/src/routes/brand.tsx
+++ b/apps/www/src/routes/brand.tsx
@@ -6,7 +6,7 @@ import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { ogMeta, canonicalUrl, breadcrumbJsonLd } from "@/lib/seo";
 
-const title = "Brand — Elmo";
+const title = "Brand · Elmo";
 const description =
 	"Download Elmo logos, icons, and brand assets. Everything you need to represent the Elmo brand.";
 

--- a/apps/www/src/routes/changelog.tsx
+++ b/apps/www/src/routes/changelog.tsx
@@ -5,7 +5,7 @@ import { Footer } from "@/components/footer";
 import { ogMeta, canonicalUrl, breadcrumbJsonLd } from "@/lib/seo";
 import type { GitHubIssue, GitHubRelease } from "@/lib/github";
 
-const title = "Changelog — Elmo";
+const title = "Changelog · Elmo";
 const description =
 	"See what's new in Elmo. Track recent improvements, bug fixes, and completed features.";
 

--- a/apps/www/src/routes/docs/$.tsx
+++ b/apps/www/src/routes/docs/$.tsx
@@ -44,7 +44,7 @@ export const Route = createFileRoute("/docs/$")({
 		if (!data) return {};
 
 		const { title, description, slugs } = data;
-		const pageTitle = `${title} — ${SITE_NAME} Docs`;
+		const pageTitle = `${title} · ${SITE_NAME} Docs`;
 		const pageDescription = description || `${title} documentation for ${SITE_NAME}.`;
 		const path = `/docs/${slugs.join("/")}`;
 		const image = getPageImage(slugs).url;

--- a/apps/www/src/routes/docs/index.tsx
+++ b/apps/www/src/routes/docs/index.tsx
@@ -19,7 +19,7 @@ export const Route = createFileRoute("/docs/")({
 		const data = loaderData as DocsLoaderData | undefined;
 		if (!data) return {};
 
-		const pageTitle = `Documentation — ${SITE_NAME}`;
+		const pageTitle = `Documentation · ${SITE_NAME}`;
 		const pageDescription =
 			data.description || `${SITE_NAME} documentation and guides.`;
 		const image = getPageImage([]).url;

--- a/apps/www/src/routes/features.tsx
+++ b/apps/www/src/routes/features.tsx
@@ -5,7 +5,7 @@ import { CTA } from "@/components/cta";
 import { Footer } from "@/components/footer";
 import { ogMeta, canonicalUrl, breadcrumbJsonLd } from "@/lib/seo";
 
-const title = "Features — Elmo";
+const title = "Features · Elmo";
 const description =
 	"AI visibility tracking, citation analysis, competitor intelligence, and more. Everything you need to monitor your brand in AI search.";
 

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -17,10 +17,10 @@ import {
 export const Route = createFileRoute("/")({
 	head: () => ({
 		meta: [
-			{ title: `${SITE_NAME} — Open Source AI Visibility Platform` },
+			{ title: `${SITE_NAME} · Open Source AI Visibility Platform` },
 			{ name: "description", content: SITE_DESCRIPTION },
 			...ogMeta({
-				title: `${SITE_NAME} — Open Source AI Visibility Platform`,
+				title: `${SITE_NAME} · Open Source AI Visibility Platform`,
 				description: SITE_DESCRIPTION,
 				path: "/",
 			}),

--- a/apps/www/src/routes/pricing.tsx
+++ b/apps/www/src/routes/pricing.tsx
@@ -5,7 +5,7 @@ import { CTA } from "@/components/cta";
 import { Footer } from "@/components/footer";
 import { ogMeta, canonicalUrl, breadcrumbJsonLd } from "@/lib/seo";
 
-const title = "Pricing — Elmo";
+const title = "Pricing · Elmo";
 const description =
 	"Elmo is free and open source to self-host. Managed cloud hosting coming soon. White-label available for agencies.";
 

--- a/apps/www/src/routes/roadmap.tsx
+++ b/apps/www/src/routes/roadmap.tsx
@@ -6,7 +6,7 @@ import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { ogMeta, canonicalUrl, breadcrumbJsonLd } from "@/lib/seo";
 
-const title = "Roadmap — Elmo";
+const title = "Roadmap · Elmo";
 const description =
 	"See what's coming next for Elmo. React or comment on GitHub issues to help prioritize.";
 

--- a/apps/www/src/routes/status.tsx
+++ b/apps/www/src/routes/status.tsx
@@ -22,7 +22,7 @@ import {
 	ResponsiveContainer,
 } from "recharts";
 
-const title = "Provider Status — Elmo";
+const title = "Provider Status · Elmo";
 const description =
 	"Real-time status and performance monitoring for AI search provider integrations.";
 

--- a/apps/www/src/routes/vision.tsx
+++ b/apps/www/src/routes/vision.tsx
@@ -4,7 +4,7 @@ import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { ogMeta, canonicalUrl, breadcrumbJsonLd } from "@/lib/seo";
 
-const title = "Our Vision — Elmo";
+const title = "Our Vision · Elmo";
 const description =
 	"AI visibility should be affordable, transparent, and built to last. Here's why we're building Elmo differently.";
 


### PR DESCRIPTION
## Summary
- Replace em-dash and trailing pipe separators in page titles with ` · ` before the app/site name across `apps/web` and `apps/www`
- Em-dashes took up visually disproportionate space (especially in SERP-truncated titles) and the two apps used different conventions
- New convention for both apps: \`PageName · AppName\`, or \`PageName | Subtitle · AppName\` when a subtitle is needed
- Updates \`buildTitle\` helper in \`apps/web\` and all direct title strings that bypassed it