### PR TITLE
dedupe citation URL variants in top cited list

### DIFF
--- a/apps/web/src/lib/domain-categories.ts
+++ b/apps/web/src/lib/domain-categories.ts
@@ -75,9 +75,13 @@ export function normalizeUrl(url: string): string {
 			urlObj.searchParams.delete("utm_source");
 		}
 		urlObj.search = urlObj.searchParams.toString();
-		// Strip scroll-to-text fragments (#:~:text=...) — these don't identify distinct pages
 		urlObj.hash = urlObj.hash.replace(/:~:text=[^&]*/, "");
 		if (urlObj.hash === "#") urlObj.hash = "";
+		urlObj.protocol = "https:";
+		urlObj.hostname = urlObj.hostname.replace(/^www\./, "").toLowerCase();
+		if (urlObj.pathname.length > 1 && urlObj.pathname.endsWith("/")) {
+			urlObj.pathname = urlObj.pathname.slice(0, -1);
+		}
 		return urlObj.toString();
 	} catch {
 		return url;

--- a/apps/web/src/server/citations.ts
+++ b/apps/web/src/server/citations.ts
@@ -178,32 +178,39 @@ export const getCitationsFn = createServerFn({ method: "GET" })
 		}
 
 		// Categorize and normalize specific URLs with new fields
-		const urlCounts = new Map<string, { count: number; title?: string; domain: string; avgPosition: number | null; promptCount: number }>();
+		const urlCounts = new Map<string, { count: number; title?: string; domain: string; positionSum: number; positionCount: number; promptCount: number }>();
 		for (const { url, domain, title, count, avg_position, prompt_count } of urlStats) {
 			const normalizedUrl = normalizeUrl(url);
+			const c = Number(count);
+			const positionSum = avg_position != null ? Number(avg_position) * c : 0;
+			const positionCount = avg_position != null ? c : 0;
 			const existing = urlCounts.get(normalizedUrl);
 			if (existing) {
-				existing.count += Number(count);
+				existing.count += c;
+				existing.positionSum += positionSum;
+				existing.positionCount += positionCount;
+				existing.promptCount = Math.max(existing.promptCount, Number(prompt_count));
 				if (!existing.title && title) existing.title = title;
 			} else {
 				urlCounts.set(normalizedUrl, {
-					count: Number(count),
+					count: c,
 					title: title || undefined,
 					domain,
-					avgPosition: avg_position != null ? Number(avg_position) : null,
+					positionSum,
+					positionCount,
 					promptCount: Number(prompt_count),
 				});
 			}
 		}
 
 		const specificUrls = Array.from(urlCounts.entries())
-			.map(([url, { count, title, domain, avgPosition, promptCount }]) => ({
+			.map(([url, { count, title, domain, positionSum, positionCount, promptCount }]) => ({
 				url,
 				title,
 				domain,
 				count,
 				category: categorizeDomain(domain),
-				avgPosition,
+				avgPosition: positionCount > 0 ? Math.round((positionSum / positionCount) * 10) / 10 : null,
 				promptCount,
 				isNew: !prevUrlMap.has(url),
 			}))


### PR DESCRIPTION
## Summary
- Some top-cited URLs render as duplicate rows on the citations page because the same article is stored under multiple URL variants (`http`/`https`, `www.`/no-`www.`, trailing slash). `getCitationUrlStats` groups by raw URL in SQL, and the server-side `normalizeUrl` merge wasn't collapsing those variants — so after `formatUrlForDisplay` strips scheme/`www.`, two rows look identical (e.g. `getairefs.com/blog/best-aeo-tools/` appearing twice in Other).
- `normalizeUrl` now forces `https`, lowercases the host, strips a leading `www.`, and drops a trailing `/` so equivalent variants collapse to one key.
- The merge in `citations.ts` now computes a count-weighted `avgPosition` across variants (previously it kept only the first-seen value — that's why the duplicate rows showed different `avg` numbers) and takes `max(promptCount)`.
- Addresses #173: raw citations storage is unchanged (URLs with `www.` are still written verbatim) — this is consumption-layer dedup, as the issue prescribes.