### PR TITLE
link demo prominently from marketing site and READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 <p align="center">
   <a href="https://www.elmohq.com/docs"><img src="https://img.shields.io/badge/Docs-2563eb?style=flat&logo=readthedocs&logoColor=white" alt="Docs"></a>&nbsp;
+  <a href="https://demo.elmohq.com"><img src="https://img.shields.io/badge/Demo-22c55e?style=flat&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwYXRoIGQ9Ik0xNSAxNGMuMi0xIC43LTEuNyAxLjUtMi41IDEtLjkgMS41LTIuMiAxLjUtMy41QTYgNiAwIDAgMCA2IDhjMCAxIC4yIDIuMiAxLjUgMy41LjcuNyAxLjMgMS41IDEuNSAyLjUiLz48cGF0aCBkPSJNOSAxOGg2Ii8+PHBhdGggZD0iTTEwIDIyaDQiLz48L3N2Zz4%3D" alt="Demo"></a>&nbsp;
   <a href="https://github.com/elmohq/elmo/issues"><img src="https://img.shields.io/badge/Issues-f95738?style=flat&logo=github&logoColor=white" alt="Issues"></a>&nbsp;
   <a href="https://github.com/orgs/elmohq/projects/3/views/1"><img src="https://img.shields.io/badge/Roadmap-ee964b?style=flat&logo=github&logoColor=white" alt="Roadmap"></a>&nbsp;
   <a href="https://discord.gg/s24nubCtKz"><img src="https://img.shields.io/badge/Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord"></a>

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -16,6 +16,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@elmohq/cli"><img src="https://img.shields.io/npm/v/@elmohq/cli?color=2563eb&label=npm" alt="npm version"></a>&nbsp;
   <a href="https://www.elmohq.com/docs"><img src="https://img.shields.io/badge/Docs-2563eb?style=flat&logo=readthedocs&logoColor=white" alt="Docs"></a>&nbsp;
+  <a href="https://demo.elmohq.com"><img src="https://img.shields.io/badge/Demo-22c55e?style=flat&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwYXRoIGQ9Ik0xNSAxNGMuMi0xIC43LTEuNyAxLjUtMi41IDEtLjkgMS41LTIuMiAxLjUtMy41QTYgNiAwIDAgMCA2IDhjMCAxIC4yIDIuMiAxLjUgMy41LjcuNyAxLjMgMS41IDEuNSAyLjUiLz48cGF0aCBkPSJNOSAxOGg2Ii8+PHBhdGggZD0iTTEwIDIyaDQiLz48L3N2Zz4%3D" alt="Demo"></a>&nbsp;
   <a href="https://github.com/elmohq/elmo"><img src="https://img.shields.io/github/stars/elmohq/elmo?style=flat&logo=github&color=ee964b&label=Star" alt="GitHub stars"></a>&nbsp;
   <a href="https://discord.gg/s24nubCtKz"><img src="https://img.shields.io/badge/Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord"></a>
 </p>

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -30,7 +30,7 @@ export function Hero() {
 								<a
 									href="https://demo.elmohq.com"
 									target="_blank"
-									rel="noopener noreferrer"
+									rel="noopener"
 								>
 									Try the Live Demo
 									<ArrowUpRight />

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -22,9 +22,19 @@ export function Hero() {
 							AI Overviews. Monitor mentions, analyze citations, and benchmark
 							competitors — all self-hosted and open source.
 						</p>
-						<div className="flex justify-center gap-2">
+						<div className="flex flex-wrap justify-center gap-2 lg:justify-start">
 							<Button asChild>
 								<Link to="/docs">Get Started</Link>
+							</Button>
+							<Button asChild variant="outline">
+								<a
+									href="https://demo.elmohq.com"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									Try the Live Demo
+									<ArrowUpRight />
+								</a>
 							</Button>
 							<Button asChild variant="outline">
 								<a

--- a/apps/www/src/components/navbar.tsx
+++ b/apps/www/src/components/navbar.tsx
@@ -134,7 +134,7 @@ export function Navbar() {
 						<a
 							href="https://demo.elmohq.com"
 							target="_blank"
-							rel="noopener noreferrer"
+							rel="noopener"
 						>
 							Try Demo
 						</a>

--- a/apps/www/src/components/navbar.tsx
+++ b/apps/www/src/components/navbar.tsx
@@ -130,6 +130,15 @@ export function Navbar() {
 							<span className="sr-only">GitHub</span>
 						</a>
 					</Button>
+					<Button asChild variant="outline" size="sm" className="text-sm">
+						<a
+							href="https://demo.elmohq.com"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Try Demo
+						</a>
+					</Button>
 					<Button asChild size="sm" className="text-sm">
 						<Link to="/docs">Get Started</Link>
 					</Button>


### PR DESCRIPTION
## Summary
- Add **Try the Live Demo** as a secondary CTA on the marketing hero (`apps/www/src/components/hero.tsx`) next to the existing **Get Started** primary, plus a **Try Demo** outline button in the navbar (`apps/www/src/components/navbar.tsx`).
- Add a **Demo** badge linking to `https://demo.elmohq.com` in the root `README.md` and `apps/cli/README.md`, between the Docs and Issues badges (Docs only on the CLI README). Uses an inline lightbulb SVG so it stays brand-neutral.