### PR TITLE
brightdata: prefer markdown field over plain text

### DIFF
--- a/.changeset/brightdata-prefer-markdown.md
+++ b/.changeset/brightdata-prefer-markdown.md
@@ -1,0 +1,5 @@
+---
+"@workspace/lib": patch
+---
+
+BrightData: prefer `answer_text_markdown` over `answer_text` when extracting response text, so prompt responses render with markdown formatting in the UI.

--- a/packages/lib/src/providers/registry/brightdata.ts
+++ b/packages/lib/src/providers/registry/brightdata.ts
@@ -26,7 +26,7 @@ function createClient(): bdclient {
 }
 
 function normalizeAnswer(record: Record<string, any>): string {
-	for (const key of ["answer_text", "answer_text_markdown", "answer", "response_raw", "response", "text", "content"]) {
+	for (const key of ["answer_text_markdown", "answer_text", "answer", "response_raw", "response", "text", "content"]) {
 		if (typeof record[key] === "string" && record[key].trim()) return record[key].trim();
 	}
 	return JSON.stringify(record).slice(0, 2000);

--- a/packages/lib/src/text-extraction.ts
+++ b/packages/lib/src/text-extraction.ts
@@ -126,7 +126,7 @@ export function extractTextFromBrightdata(rawOutput: any): string {
 	try {
 		const record = Array.isArray(rawOutput) ? rawOutput[0] : rawOutput;
 		if (!record) return "No content in BrightData output.";
-		for (const key of ["answer_text", "answer_text_markdown", "answer", "response_raw", "response", "text", "content"]) {
+		for (const key of ["answer_text_markdown", "answer_text", "answer", "response_raw", "response", "text", "content"]) {
 			if (typeof record[key] === "string" && record[key].trim()) return record[key].trim();
 		}
 		return "No text content found in BrightData output.";


### PR DESCRIPTION
## Summary
- BrightData returns both `answer_text` (plain) and `answer_text_markdown` for chatbot responses. The lookup order in `normalizeAnswer` and `extractTextFromBrightdata` had `answer_text` first, so the markdown variant was never read and the prompt details page rendered responses without formatting.
- Swap the order in both spots so markdown is preferred. Fixes new runs (provider write path) and historical reads (UI re-extraction from stored `rawOutput`).
- Olostep already prefers `markdown_content` / `answer_markdown` first, so no change needed there.
