### PR TITLE
fix table headers and table spacing in docs

### DIFF
--- a/apps/www/src/styles.css
+++ b/apps/www/src/styles.css
@@ -123,3 +123,13 @@
 .prose h6 a:hover {
 	text-decoration: underline !important;
 }
+
+.prose thead th {
+	font-weight: 700;
+}
+
+.prose thead th:first-child,
+.prose tbody td:first-child,
+.prose tfoot td:first-child {
+	padding-inline-start: 0.571429em;
+}


### PR DESCRIPTION
## Summary
- Tables on the docs site (e.g. [/docs/contributing/architecture](https://www.elmohq.com/docs/contributing/architecture), [/docs/deployment/configuration](https://www.elmohq.com/docs/deployment/configuration)) had two styling issues:
  - First-column cells (both `<th>` and `<td>`) were flush against the cell's left edge — text touched the muted background border with no breathing room.
  - Headers were `font-weight: 600`, but first-column body cells often wrap content in markdown `**bold**` (700), so headers looked *less* bold than the body.
- Both come from Tailwind Typography's defaults (`thead th:first-child { padding-inline-start: 0 }`, `thead th { font-weight: 600 }`) interacting with Fumadocs UI's muted-background cells.
- Fix adds two prose overrides in `apps/www/src/styles.css`: bump header weight to 700 and restore `padding-inline-start: 0.571429em` (the same value Typography uses for non-edge cells) on first-column `th`/`td`/`tfoot td`.
