### PR TITLE
unify website + additionalDomains into single domains list in the admin api

### DIFF
--- a/.changeset/brand-api-domains-list.md
+++ b/.changeset/brand-api-domains-list.md
@@ -1,0 +1,6 @@
+---
+"@workspace/web": patch
+"@workspace/api-spec": patch
+---
+
+Admin `/api/v1/brands` endpoints (POST, GET, PATCH) now accept and return a single `domains` list instead of `website` + `additionalDomains`. This future-proofs against a future db model change.

--- a/apps/web/src/routes/api/v1/brands/$brandId.ts
+++ b/apps/web/src/routes/api/v1/brands/$brandId.ts
@@ -11,7 +11,14 @@ import { db } from "@workspace/lib/db/db";
 import { brands } from "@workspace/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { validateApiKeyFromRequest as validateApiKey } from "@/lib/auth/policies";
-import { updateBrand, updateBrandBodySchema, buildBrandResult, BrandNotFoundError } from "@/server/onboarding-core";
+import {
+	updateBrand,
+	updateBrandBodySchema,
+	apiUpdateInputToInternal,
+	buildBrandResult,
+	BrandNotFoundError,
+	InvalidDomainsError,
+} from "@/server/onboarding-core";
 
 export const Route = createFileRoute("/api/v1/brands/$brandId")({
 	server: {
@@ -64,9 +71,13 @@ export const Route = createFileRoute("/api/v1/brands/$brandId")({
 				}
 
 				try {
-					const result = await updateBrand({ brandId, ...parsed.data });
+					const internal = apiUpdateInputToInternal(brandId, parsed.data);
+					const result = await updateBrand(internal);
 					return Response.json(result, { status: 200 });
 				} catch (err) {
+					if (err instanceof InvalidDomainsError) {
+						return Response.json({ error: "Validation Error", message: err.message }, { status: 400 });
+					}
 					if (err instanceof BrandNotFoundError) {
 						return Response.json({ error: "Not Found", message: err.message }, { status: 404 });
 					}

--- a/apps/web/src/routes/api/v1/brands/index.ts
+++ b/apps/web/src/routes/api/v1/brands/index.ts
@@ -11,7 +11,14 @@ import { db } from "@workspace/lib/db/db";
 import { brands } from "@workspace/lib/db/schema";
 import { count, desc } from "drizzle-orm";
 import { validateApiKeyFromRequest as validateApiKey } from "@/lib/auth/policies";
-import { createBrand, createBrandInputSchema, buildBrandResult, BrandConflictError } from "@/server/onboarding-core";
+import {
+	createBrand,
+	createBrandInputSchema,
+	apiCreateInputToInternal,
+	buildBrandResult,
+	BrandConflictError,
+	InvalidDomainsError,
+} from "@/server/onboarding-core";
 
 export const Route = createFileRoute("/api/v1/brands/")({
 	server: {
@@ -75,9 +82,13 @@ export const Route = createFileRoute("/api/v1/brands/")({
 				}
 
 				try {
-					const result = await createBrand(parsed.data);
+					const internal = apiCreateInputToInternal(parsed.data);
+					const result = await createBrand(internal);
 					return Response.json(result, { status: 201 });
 				} catch (err) {
+					if (err instanceof InvalidDomainsError) {
+						return Response.json({ error: "Validation Error", message: err.message }, { status: 400 });
+					}
 					if (err instanceof BrandConflictError) {
 						return Response.json({ error: "Conflict", message: err.message }, { status: 409 });
 					}

--- a/apps/web/src/server/onboarding-core.ts
+++ b/apps/web/src/server/onboarding-core.ts
@@ -50,12 +50,20 @@ const promptInputSchema = z.object({
 	enabled: z.boolean().optional().default(true),
 });
 
-/** POST /api/v1/brands body. */
+type CompetitorInput = z.infer<typeof competitorInputSchema>;
+type PromptInput = z.infer<typeof promptInputSchema>;
+
+/**
+ * POST /api/v1/brands body.
+ *
+ * The API speaks a single `domains` list to mirror the competitor endpoints.
+ * Internally, the first cleaned entry is stored as the brand's `website`
+ * (`https://<host>`) and the rest are stored in `additionalDomains`.
+ */
 export const createBrandInputSchema = z.object({
 	id: z.string().min(1),
 	name: z.string().min(1),
-	website: z.string().min(1),
-	additionalDomains: z.array(z.string()).optional(),
+	domains: z.array(z.string()).min(1),
 	aliases: z.array(z.string()).optional(),
 	competitors: z.array(competitorInputSchema).optional(),
 	prompts: z.array(promptInputSchema).optional(),
@@ -64,14 +72,9 @@ export const createBrandInputSchema = z.object({
 /** PATCH /api/v1/brands/:brandId body. brandId comes from the URL. */
 export const updateBrandBodySchema = z.object({
 	brandName: z.string().min(1).optional(),
-	website: z.string().min(1).optional(),
-	additionalDomains: z.array(z.string()).optional(),
+	domains: z.array(z.string()).min(1).optional(),
 	aliases: z.array(z.string()).optional(),
 	enabled: z.boolean().optional(),
-});
-
-const updateBrandInputSchema = updateBrandBodySchema.extend({
-	brandId: z.string().min(1),
 });
 
 /** Wizard save: brand-level fields + new prompts/competitors in one shot. */
@@ -85,15 +88,33 @@ export const wizardOnboardingInputSchema = z.object({
 	prompts: z.array(promptInputSchema).optional(),
 });
 
-export type CreateBrandInput = z.infer<typeof createBrandInputSchema>;
-export type UpdateBrandInput = z.infer<typeof updateBrandInputSchema>;
+/** Internal shape for createBrand — matches storage (website + additionalDomains). */
+export interface CreateBrandInput {
+	id: string;
+	name: string;
+	website: string;
+	additionalDomains?: string[];
+	aliases?: string[];
+	competitors?: CompetitorInput[];
+	prompts?: PromptInput[];
+}
+
+/** Internal shape for updateBrand — matches storage. */
+export interface UpdateBrandInput {
+	brandId: string;
+	brandName?: string;
+	website?: string;
+	additionalDomains?: string[];
+	aliases?: string[];
+	enabled?: boolean;
+}
+
 export type WizardOnboardingInput = z.infer<typeof wizardOnboardingInputSchema>;
 
 export interface BrandResult {
 	id: string;
 	name: string;
-	website: string;
-	additionalDomains: string[];
+	domains: string[];
 	aliases: string[];
 	enabled: boolean;
 	onboarded: boolean;
@@ -119,17 +140,69 @@ function validateAndFormatWebsite(url: string): string {
 }
 
 export function buildBrandResult(row: typeof brands.$inferSelect): BrandResult {
+	const websiteHost = new URL(row.website).hostname.replace(/^www\./, "");
 	return {
 		id: row.id,
 		name: row.name,
-		website: row.website,
-		additionalDomains: row.additionalDomains,
+		domains: [websiteHost, ...row.additionalDomains],
 		aliases: row.aliases,
 		enabled: row.enabled,
 		onboarded: row.onboarded,
 		createdAt: row.createdAt,
 		updatedAt: row.updatedAt,
 	};
+}
+
+/**
+ * Validation error thrown by the API → internal converters when the supplied
+ * `domains` array contains no valid entries after cleaning. Callers should
+ * surface this as a 400.
+ */
+export class InvalidDomainsError extends Error {
+	constructor(message = "domains: at least one valid domain is required") {
+		super(message);
+		this.name = "InvalidDomainsError";
+	}
+}
+
+function splitDomainsForStorage(domains: string[]): { website: string; additionalDomains: string[] } {
+	const cleaned = dedupeDomains(domains);
+	if (cleaned.length === 0) throw new InvalidDomainsError();
+	const [primary, ...rest] = cleaned;
+	return { website: `https://${primary}`, additionalDomains: rest };
+}
+
+/** Convert POST /api/v1/brands body into the internal createBrand input. */
+export function apiCreateInputToInternal(input: z.infer<typeof createBrandInputSchema>): CreateBrandInput {
+	const { website, additionalDomains } = splitDomainsForStorage(input.domains);
+	return {
+		id: input.id,
+		name: input.name,
+		website,
+		additionalDomains,
+		aliases: input.aliases,
+		competitors: input.competitors,
+		prompts: input.prompts,
+	};
+}
+
+/** Convert PATCH /api/v1/brands/:brandId body into the internal updateBrand input. */
+export function apiUpdateInputToInternal(
+	brandId: string,
+	input: z.infer<typeof updateBrandBodySchema>,
+): UpdateBrandInput {
+	const result: UpdateBrandInput = {
+		brandId,
+		brandName: input.brandName,
+		aliases: input.aliases,
+		enabled: input.enabled,
+	};
+	if (input.domains !== undefined) {
+		const { website, additionalDomains } = splitDomainsForStorage(input.domains);
+		result.website = website;
+		result.additionalDomains = additionalDomains;
+	}
+	return result;
 }
 
 async function insertCompetitors(args: {

--- a/apps/web/src/stories/_mocks/server-onboarding.ts
+++ b/apps/web/src/stories/_mocks/server-onboarding.ts
@@ -38,8 +38,7 @@ export const updateOnboardedBrandFn = async (_args: { data: unknown }) => {
 	return {
 		id: "mock-brand-id",
 		name: "Mock",
-		website: "mock.com",
-		additionalDomains: [],
+		domains: ["mock.com"],
 		aliases: [],
 		enabled: true,
 		onboarded: true,

--- a/packages/api-spec/src/openapi.json
+++ b/packages/api-spec/src/openapi.json
@@ -352,12 +352,16 @@
 			},
 			"CreateBrandRequest": {
 				"type": "object",
-				"description": "Create a brand. Skips onboarding.",
+				"description": "Create a brand. Skips onboarding. The first entry in `domains` is treated as the brand's primary website; the rest are stored as additional domains.",
 				"properties": {
 					"id": { "type": "string", "minLength": 1 },
 					"name": { "type": "string", "minLength": 1 },
-					"website": { "type": "string", "minLength": 1 },
-					"additionalDomains": { "type": "array", "items": { "type": "string" } },
+					"domains": {
+						"type": "array",
+						"items": { "type": "string" },
+						"minItems": 1,
+						"description": "Brand domains. The first entry is the primary website; remaining entries are additional domains."
+					},
 					"aliases": { "type": "array", "items": { "type": "string" } },
 					"competitors": {
 						"type": "array",
@@ -384,15 +388,19 @@
 						}
 					}
 				},
-				"required": ["id", "name", "website"]
+				"required": ["id", "name", "domains"]
 			},
 			"UpdateBrandRequest": {
 				"type": "object",
-				"description": "Update brand-level fields. Provided arrays replace the stored values verbatim. Prompts and competitors are managed via /prompts and /competitors.",
+				"description": "Update brand-level fields. Provided arrays replace the stored values verbatim. When `domains` is provided, the first entry becomes the primary website and the rest become additional domains. Prompts and competitors are managed via /prompts and /competitors.",
 				"properties": {
 					"brandName": { "type": "string", "minLength": 1 },
-					"website": { "type": "string", "minLength": 1 },
-					"additionalDomains": { "type": "array", "items": { "type": "string" } },
+					"domains": {
+						"type": "array",
+						"items": { "type": "string" },
+						"minItems": 1,
+						"description": "Brand domains. The first entry is the primary website; remaining entries are additional domains."
+					},
 					"aliases": { "type": "array", "items": { "type": "string" } },
 					"enabled": { "type": "boolean" }
 				}
@@ -402,15 +410,18 @@
 				"properties": {
 					"id": { "type": "string", "description": "User-supplied brand identifier (e.g. \"acme\")" },
 					"name": { "type": "string" },
-					"website": { "type": "string" },
-					"additionalDomains": { "type": "array", "items": { "type": "string" } },
+					"domains": {
+						"type": "array",
+						"items": { "type": "string" },
+						"description": "Brand domains. The first entry is the primary website; remaining entries are additional domains."
+					},
 					"aliases": { "type": "array", "items": { "type": "string" } },
 					"enabled": { "type": "boolean" },
 					"onboarded": { "type": "boolean" },
 					"createdAt": { "type": "string", "format": "date-time" },
 					"updatedAt": { "type": "string", "format": "date-time" }
 				},
-				"required": ["id", "name", "website", "additionalDomains", "aliases", "enabled", "onboarded", "createdAt", "updatedAt"]
+				"required": ["id", "name", "domains", "aliases", "enabled", "onboarded", "createdAt", "updatedAt"]
 			},
 			"BrandsList": {
 				"type": "object",


### PR DESCRIPTION
## Summary
- Admin `/api/v1/brands` POST/GET/PATCH now speak a single `domains` list, mirroring the competitor endpoints. First entry is the primary website; rest are additional domains.
- DB model unchanged (`website` + `additionalDomains`) — translation happens at the API boundary via new `apiCreateInputToInternal` / `apiUpdateInputToInternal` helpers in `onboarding-core.ts`.
- OpenAPI schemas updated; wizard / internal flow untouched.