### PR TITLE
Fix OG image generation across www and web

### DIFF
--- a/.changeset/og-image-generation.md
+++ b/.changeset/og-image-generation.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Fix OG image generation: `og:image` is now an absolute URL and renders the current page's title/description. Adds `og:url`, `og:site_name`, `og:locale`, and `og:logo` to the document head.

--- a/apps/web/src/lib/route-head.ts
+++ b/apps/web/src/lib/route-head.ts
@@ -3,14 +3,32 @@
  * Respects white-label / deployment branding configuration.
  */
 
+const DEFAULT_DESCRIPTION =
+	"Track and optimize your brand's visibility across AI models.";
+
+interface RouteMatchContext {
+	context?: {
+		clientConfig?: {
+			branding?: { name?: string; url?: string; icon?: string };
+		};
+	};
+}
+
 /**
  * Get the app display name from route match context.
  * Returns the white-label branding name if configured, otherwise "Elmo".
  */
-export function getAppName(match: {
-	context?: { clientConfig?: { branding?: { name?: string } } };
-}): string {
+export function getAppName(match: RouteMatchContext): string {
 	return match.context?.clientConfig?.branding?.name || "Elmo";
+}
+
+/**
+ * Get the absolute base URL for the deployment, with no trailing slash.
+ * Used to build canonical / og:url / og:image absolute URLs.
+ */
+export function getAppUrl(match: RouteMatchContext): string | undefined {
+	const url = match.context?.clientConfig?.branding?.url;
+	return url ? url.replace(/\/$/, "") : undefined;
 }
 
 /**
@@ -43,20 +61,34 @@ export function buildTitle(
 	return `${pageName} · ${opts.appName}`;
 }
 
+function toAbsolute(appUrl: string | undefined, path: string): string {
+	if (path.startsWith("http")) return path;
+	if (!appUrl) return path;
+	return `${appUrl}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
 /**
  * Build OG / Twitter Card meta tags for a page.
- * Points og:image at the dynamic /api/og endpoint which renders a brand-aware PNG.
+ *
+ * Points og:image at the dynamic /api/og endpoint which renders a brand-aware
+ * PNG. The endpoint accepts ?title=…&description=… so each page can render its
+ * own social card. URLs are absolute when an appUrl is supplied — required by
+ * crawlers like Facebook, Twitter, and Slack.
  */
 export function buildOgMeta(opts: {
 	title: string;
 	description?: string;
+	path?: string;
+	appUrl?: string;
 }): Array<Record<string, string>> {
-	const description =
-		opts.description ||
-		"Track and optimize your brand's visibility across AI models.";
-	const ogImageUrl = "/api/og";
+	const description = opts.description || DEFAULT_DESCRIPTION;
 
-	return [
+	const ogImageParams = new URLSearchParams();
+	ogImageParams.set("title", opts.title);
+	ogImageParams.set("description", description);
+	const ogImageUrl = toAbsolute(opts.appUrl, `/api/og?${ogImageParams.toString()}`);
+
+	const meta: Array<Record<string, string>> = [
 		{ property: "og:title", content: opts.title },
 		{ property: "og:description", content: description },
 		{ property: "og:image", content: ogImageUrl },
@@ -68,4 +100,13 @@ export function buildOgMeta(opts: {
 		{ name: "twitter:description", content: description },
 		{ name: "twitter:image", content: ogImageUrl },
 	];
+
+	if (opts.path && opts.appUrl) {
+		meta.push({
+			property: "og:url",
+			content: toAbsolute(opts.appUrl, opts.path),
+		});
+	}
+
+	return meta;
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -59,12 +59,20 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 		const hasCustomIcon = Boolean(branding?.icon && branding.icon !== DEFAULT_APP_ICON);
 		const appName = branding?.name || "Elmo";
 		const themeColor = hasCustomIcon ? "#000000" : ELMO_THEME_COLOR;
+		const appUrl = branding?.url ? branding.url.replace(/\/$/, "") : undefined;
 
-		const title = branding?.name
-			? `${branding.name} - AI Search Optimization`
-			: "Elmo - AI Search Optimization";
+		const title = `${appName} - AI Search Optimization`;
 		const description = "Track and optimize your brand's visibility across AI models.";
-		const ogImage = "/api/og";
+		const ogImageParams = new URLSearchParams({ title, description });
+		const ogImagePath = `/api/og?${ogImageParams.toString()}`;
+		const ogImage = appUrl ? `${appUrl}${ogImagePath}` : ogImagePath;
+		// og:logo is non-standard but used by some unfurlers (LinkedIn). Falls back
+		// to the absolute branding icon URL when available.
+		const ogLogo = (() => {
+			if (!branding?.icon) return undefined;
+			if (branding.icon.startsWith("http")) return branding.icon;
+			return appUrl ? `${appUrl}${branding.icon}` : undefined;
+		})();
 
 		return {
 			meta: [
@@ -74,12 +82,16 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 				{ name: "viewport", content: "width=device-width, initial-scale=1" },
 				{ name: "theme-color", content: themeColor },
 				{ name: "apple-mobile-web-app-title", content: appName },
+				{ property: "og:site_name", content: appName },
+				{ property: "og:locale", content: "en_US" },
 				{ property: "og:title", content: title },
 				{ property: "og:description", content: description },
 				{ property: "og:image", content: ogImage },
 				{ property: "og:image:width", content: "1200" },
 				{ property: "og:image:height", content: "630" },
 				{ property: "og:type", content: "website" },
+				...(appUrl ? [{ property: "og:url", content: appUrl }] : []),
+				...(ogLogo ? [{ property: "og:logo", content: ogLogo }] : []),
 				{ name: "twitter:card", content: "summary_large_image" },
 				{ name: "twitter:title", content: title },
 				{ name: "twitter:description", content: description },

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -63,7 +63,11 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 
 		const title = `${appName} - AI Search Optimization`;
 		const description = "Track and optimize your brand's visibility across AI models.";
-		const ogImageParams = new URLSearchParams({ title, description });
+		// Don't pass `title` to /api/og — the renderer already shows the brand
+		// (Elmo logo or whitelabel icon + name), so a "Brand - AI Search Optimization"
+		// title would render redundantly. Pages that override og:image can supply
+		// a page-specific title via the query param.
+		const ogImageParams = new URLSearchParams({ description });
 		const ogImagePath = `/api/og?${ogImageParams.toString()}`;
 		const ogImage = appUrl ? `${appUrl}${ogImagePath}` : ogImagePath;
 		// og:logo is non-standard but used by some unfurlers (LinkedIn). Falls back

--- a/apps/web/src/routes/api/og/index.ts
+++ b/apps/web/src/routes/api/og/index.ts
@@ -75,6 +75,9 @@ export const Route = createFileRoute("/api/og/")({
 				const url = new URL(request.url);
 				const forceDefault =
 					url.searchParams.get("defaultBranding") === "true";
+				const title = url.searchParams.get("title") ?? undefined;
+				const description =
+					url.searchParams.get("description") ?? undefined;
 
 				const deployment = getDeployment();
 				const { branding } = deployment;
@@ -97,6 +100,8 @@ export const Route = createFileRoute("/api/og/")({
 				const response = new ImageResponse(
 					renderOgImage({
 						appName,
+						title,
+						description,
 						accentColors: forceDefault
 							? undefined
 							: branding.chartColors.slice(0, 4),

--- a/apps/www/src/lib/og.ts
+++ b/apps/www/src/lib/og.ts
@@ -6,3 +6,13 @@ export function getPageImage(slugs: string[]) {
 		url: `/og/docs/${segments.join("/")}`,
 	};
 }
+
+export function getMarketingOgImage(opts: {
+	title: string;
+	description?: string;
+}): string {
+	const params = new URLSearchParams();
+	params.set("title", opts.title);
+	if (opts.description) params.set("description", opts.description);
+	return `/og.png?${params.toString()}`;
+}

--- a/apps/www/src/lib/seo.ts
+++ b/apps/www/src/lib/seo.ts
@@ -1,7 +1,10 @@
+import { getMarketingOgImage } from "./og";
+
 export const SITE_URL = "https://www.elmohq.com";
 export const SITE_NAME = "Elmo";
 export const SITE_DESCRIPTION =
 	"Track how ChatGPT, Claude, and Google AI Overviews talk about your brand. Self-hosted, transparent, and free.";
+export const SITE_LOGO_URL = `${SITE_URL}/brand/icons/elmo-icon-512.png`;
 
 export function canonicalUrl(path: string): string {
 	return `${SITE_URL}${path}`;
@@ -21,25 +24,27 @@ export function ogMeta({
 	type?: "website" | "article";
 }) {
 	const url = canonicalUrl(path);
-	const meta = [
+	const resolvedImage = image ?? getMarketingOgImage({ title, description });
+	const absoluteImage = resolvedImage.startsWith("http")
+		? resolvedImage
+		: canonicalUrl(resolvedImage);
+
+	return [
 		{ property: "og:title", content: title },
 		{ property: "og:description", content: description },
 		{ property: "og:url", content: url },
 		{ property: "og:site_name", content: SITE_NAME },
 		{ property: "og:type", content: type },
+		{ property: "og:locale", content: "en_US" },
+		{ property: "og:image", content: absoluteImage },
+		{ property: "og:image:width", content: "1200" },
+		{ property: "og:image:height", content: "630" },
+		{ property: "og:logo", content: SITE_LOGO_URL },
 		{ name: "twitter:card", content: "summary_large_image" },
 		{ name: "twitter:title", content: title },
 		{ name: "twitter:description", content: description },
+		{ name: "twitter:image", content: absoluteImage },
 	];
-
-	if (image) {
-		meta.push(
-			{ property: "og:image", content: image.startsWith("http") ? image : canonicalUrl(image) },
-			{ name: "twitter:image", content: image.startsWith("http") ? image : canonicalUrl(image) },
-		);
-	}
-
-	return meta;
 }
 
 export function jsonLd(data: Record<string, unknown>): {
@@ -66,7 +71,7 @@ export function organizationJsonLd() {
 		"@type": "Organization",
 		name: SITE_NAME,
 		url: SITE_URL,
-		logo: `${SITE_URL}/brand/icons/elmo-icon-512.png`,
+		logo: SITE_LOGO_URL,
 		sameAs: ["https://github.com/elmohq/elmo"],
 	});
 }

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
 import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
 import { Route as RoadmapRouteImport } from './routes/roadmap'
 import { Route as PricingRouteImport } from './routes/pricing'
+import { Route as OgDotpngRouteImport } from './routes/og[.]png'
 import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
 import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
 import { Route as FeaturesRouteImport } from './routes/features'
@@ -60,6 +61,11 @@ const RoadmapRoute = RoadmapRouteImport.update({
 const PricingRoute = PricingRouteImport.update({
   id: '/pricing',
   path: '/pricing',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OgDotpngRoute = OgDotpngRouteImport.update({
+  id: '/og.png',
+  path: '/og.png',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LlmsDottxtRoute = LlmsDottxtRouteImport.update({
@@ -151,6 +157,7 @@ export interface FileRoutesByFullPath {
   '/features': typeof FeaturesRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
   '/llms.txt': typeof LlmsDottxtRoute
+  '/og.png': typeof OgDotpngRoute
   '/pricing': typeof PricingRoute
   '/roadmap': typeof RoadmapRoute
   '/robots.txt': typeof RobotsDottxtRoute
@@ -175,6 +182,7 @@ export interface FileRoutesByTo {
   '/features': typeof FeaturesRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
   '/llms.txt': typeof LlmsDottxtRoute
+  '/og.png': typeof OgDotpngRoute
   '/pricing': typeof PricingRoute
   '/roadmap': typeof RoadmapRoute
   '/robots.txt': typeof RobotsDottxtRoute
@@ -200,6 +208,7 @@ export interface FileRoutesById {
   '/features': typeof FeaturesRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
   '/llms.txt': typeof LlmsDottxtRoute
+  '/og.png': typeof OgDotpngRoute
   '/pricing': typeof PricingRoute
   '/roadmap': typeof RoadmapRoute
   '/robots.txt': typeof RobotsDottxtRoute
@@ -226,6 +235,7 @@ export interface FileRouteTypes {
     | '/features'
     | '/llms-full.txt'
     | '/llms.txt'
+    | '/og.png'
     | '/pricing'
     | '/roadmap'
     | '/robots.txt'
@@ -250,6 +260,7 @@ export interface FileRouteTypes {
     | '/features'
     | '/llms-full.txt'
     | '/llms.txt'
+    | '/og.png'
     | '/pricing'
     | '/roadmap'
     | '/robots.txt'
@@ -274,6 +285,7 @@ export interface FileRouteTypes {
     | '/features'
     | '/llms-full.txt'
     | '/llms.txt'
+    | '/og.png'
     | '/pricing'
     | '/roadmap'
     | '/robots.txt'
@@ -299,6 +311,7 @@ export interface RootRouteChildren {
   FeaturesRoute: typeof FeaturesRoute
   LlmsFullDottxtRoute: typeof LlmsFullDottxtRoute
   LlmsDottxtRoute: typeof LlmsDottxtRoute
+  OgDotpngRoute: typeof OgDotpngRoute
   PricingRoute: typeof PricingRoute
   RoadmapRoute: typeof RoadmapRoute
   RobotsDottxtRoute: typeof RobotsDottxtRoute
@@ -359,6 +372,13 @@ declare module '@tanstack/react-router' {
       path: '/pricing'
       fullPath: '/pricing'
       preLoaderRoute: typeof PricingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/og.png': {
+      id: '/og.png'
+      path: '/og.png'
+      fullPath: '/og.png'
+      preLoaderRoute: typeof OgDotpngRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/llms.txt': {
@@ -483,6 +503,7 @@ const rootRouteChildren: RootRouteChildren = {
   FeaturesRoute: FeaturesRoute,
   LlmsFullDottxtRoute: LlmsFullDottxtRoute,
   LlmsDottxtRoute: LlmsDottxtRoute,
+  OgDotpngRoute: OgDotpngRoute,
   PricingRoute: PricingRoute,
   RoadmapRoute: RoadmapRoute,
   RobotsDottxtRoute: RobotsDottxtRoute,

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -12,10 +12,15 @@ import {
 	SITE_URL,
 	SITE_NAME,
 	SITE_DESCRIPTION,
+	SITE_LOGO_URL,
 	websiteJsonLd,
 	organizationJsonLd,
 } from "@/lib/seo";
+import { getMarketingOgImage } from "@/lib/og";
 import appCss from "../styles.css?url";
+
+const ROOT_TITLE = `${SITE_NAME} · Open Source AI Visibility Platform`;
+const ROOT_OG_IMAGE = `${SITE_URL}${getMarketingOgImage({ title: ROOT_TITLE, description: SITE_DESCRIPTION })}`;
 
 export const Route = createRootRoute({
 	head: () => ({
@@ -25,11 +30,22 @@ export const Route = createRootRoute({
 				name: "viewport",
 				content: "width=device-width, initial-scale=1",
 			},
-			{ title: `${SITE_NAME} · Open Source AI Visibility Platform` },
+			{ title: ROOT_TITLE },
 			{ name: "description", content: SITE_DESCRIPTION },
 			{ property: "og:site_name", content: SITE_NAME },
 			{ property: "og:locale", content: "en_US" },
+			{ property: "og:type", content: "website" },
+			{ property: "og:url", content: SITE_URL },
+			{ property: "og:title", content: ROOT_TITLE },
+			{ property: "og:description", content: SITE_DESCRIPTION },
+			{ property: "og:image", content: ROOT_OG_IMAGE },
+			{ property: "og:image:width", content: "1200" },
+			{ property: "og:image:height", content: "630" },
+			{ property: "og:logo", content: SITE_LOGO_URL },
 			{ name: "twitter:card", content: "summary_large_image" },
+			{ name: "twitter:title", content: ROOT_TITLE },
+			{ name: "twitter:description", content: SITE_DESCRIPTION },
+			{ name: "twitter:image", content: ROOT_OG_IMAGE },
 			{ name: "theme-color", content: "#2563eb" },
 			{ name: "apple-mobile-web-app-title", content: SITE_NAME },
 		],

--- a/apps/www/src/routes/og[.]png.ts
+++ b/apps/www/src/routes/og[.]png.ts
@@ -1,0 +1,61 @@
+import { createFileRoute } from "@tanstack/react-router";
+import ImageResponse from "@takumi-rs/image-response/wasm";
+import takumiWasm from "virtual:takumi-wasm";
+import titanOne400Data from "virtual:font/titan-one-400";
+import geistSans400Data from "virtual:font/geist-sans-400";
+import geistSans500Data from "virtual:font/geist-sans-500";
+import { DEFAULT_APP_NAME } from "@workspace/config/constants";
+import { renderOgImage } from "@workspace/og/render";
+
+export const Route = createFileRoute("/og.png")({
+	server: {
+		handlers: {
+			GET: async ({ request }) => {
+				const url = new URL(request.url);
+				const title = url.searchParams.get("title") ?? undefined;
+				const description = url.searchParams.get("description") ?? undefined;
+
+				const response = new ImageResponse(
+					renderOgImage({
+						appName: DEFAULT_APP_NAME,
+						title,
+						description,
+					}),
+					{
+						width: 1200,
+						height: 630,
+						module: takumiWasm,
+						fonts: [
+							{
+								name: "Titan One",
+								data: titanOne400Data,
+								style: "normal" as const,
+								weight: 400 as const,
+							},
+							{
+								name: "Geist Sans",
+								data: geistSans400Data,
+								style: "normal" as const,
+								weight: 400 as const,
+							},
+							{
+								name: "Geist Sans",
+								data: geistSans500Data,
+								style: "normal" as const,
+								weight: 500 as const,
+							},
+						],
+					},
+				);
+
+				return new Response(response.body, {
+					headers: {
+						"Content-Type": "image/png",
+						"Cache-Control":
+							"public, max-age=86400, s-maxage=604800",
+					},
+				});
+			},
+		},
+	},
+});


### PR DESCRIPTION
## Summary

OG image generation was broken in both apps:

- **apps/www**: only `/docs/*` pages emitted an `og:image`. The homepage and every marketing/comparison page had no social card.
- **apps/web**: `og:image` was set to the relative path `/api/og` — crawlers (Facebook, Twitter, Slack, LinkedIn) can't resolve relative URLs — and every page got the same generic image regardless of which page was shared.

### apps/www

- New `/og.png?title=…&description=…` route renders the marketing OG image via the same Takumi pipeline that already powers `/og/docs/$`.
- `ogMeta()` now defaults `og:image` to a generated marketing card when no explicit image is supplied, so the homepage, pricing, features, changelog, comparison pages, etc. all get a real social card.
- Adds `og:locale`, `og:image:width/height`, and `og:logo` to the page-level meta and to the root defaults.

### apps/web

- `__root.tsx` now resolves `og:image` to an absolute URL using `branding.url`, and threads the page title/description into `/api/og` as query params so each route renders a differentiated card.
- `/api/og` accepts `?title=` and `?description=`, passing them to `renderOgImage`.
- Adds `og:site_name`, `og:locale`, `og:url`, and `og:logo` to the root document head (whitelabel-aware: `og:logo` and `og:url` are emitted only when `branding.url` is configured).
- `buildOgMeta` helper is updated to emit absolute URLs and accept `appUrl` + `path` for future use.