### PR TITLE
fix Docker image refs and publish multi-arch images

### DIFF
--- a/.changeset/arm64-docker-images.md
+++ b/.changeset/arm64-docker-images.md
@@ -1,0 +1,6 @@
+---
+"@workspace/web": patch
+"@workspace/worker": patch
+---
+
+Publish multi-arch (`linux/amd64` + `linux/arm64`) Docker images for `elmohq/elmo-web` and `elmohq/elmo-worker`, so Apple Silicon and other arm64 hosts can pull them.

--- a/.changeset/cli-docker-image-names.md
+++ b/.changeset/cli-docker-image-names.md
@@ -1,0 +1,5 @@
+---
+"@elmohq/cli": patch
+---
+
+Standardize Docker image naming between the CLI and release process on `elmohq/elmo-web` and `elmohq/elmo-worker`.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,6 +17,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,6 +23,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -67,6 +69,24 @@ jobs:
           node scripts/generate-release-notes.mjs "$VERSION" > release-notes.md
           gh release create "v$VERSION" --title "v$VERSION" --notes-file release-notes.md
 
+  docker-build:
+    name: Build images (${{ matrix.arch }})
+    needs: release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: blacksmith-4vcpu-ubuntu-2404
+            arch: amd64
+          - platform: linux/arm64
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v1
 
@@ -76,24 +96,80 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push web image
+      - name: Build and push web image by digest
+        id: build-web
         uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: docker/Dockerfile
           target: web
-          push: true
-          tags: |
-            elmohq/elmo-web:${{ steps.version.outputs.version }}
-            elmohq/elmo-web:latest
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=elmohq/elmo-web,push-by-digest=true,name-canonical=true,push=true
 
-      - name: Build and push worker image
+      - name: Build and push worker image by digest
+        id: build-worker
         uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: docker/Dockerfile
           target: worker
-          push: true
-          tags: |
-            elmohq/elmo-worker:${{ steps.version.outputs.version }}
-            elmohq/elmo-worker:latest
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=elmohq/elmo-worker,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digests
+        env:
+          WEB_DIGEST: ${{ steps.build-web.outputs.digest }}
+          WORKER_DIGEST: ${{ steps.build-worker.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests/web /tmp/digests/worker
+          touch "/tmp/digests/web/${WEB_DIGEST#sha256:}"
+          touch "/tmp/digests/worker/${WORKER_DIGEST#sha256:}"
+
+      - name: Upload digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-manifest:
+    name: Publish multi-arch manifests
+    needs: [release, docker-build]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create multi-arch web manifest
+        working-directory: /tmp/digests/web
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          docker buildx imagetools create \
+            -t "elmohq/elmo-web:${VERSION}" \
+            -t "elmohq/elmo-web:latest" \
+            $(printf 'elmohq/elmo-web@sha256:%s ' *)
+
+      - name: Create multi-arch worker manifest
+        working-directory: /tmp/digests/worker
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          docker buildx imagetools create \
+            -t "elmohq/elmo-worker:${VERSION}" \
+            -t "elmohq/elmo-worker:latest" \
+            $(printf 'elmohq/elmo-worker@sha256:%s ' *)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,6 +16,9 @@ name: Release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1233,7 +1233,7 @@ function buildWebService(options: {
 			"      DEPLOYMENT_MODE: local",
 		);
 	} else {
-		lines.push("  image: elmohq/web:latest");
+		lines.push("  image: elmohq/elmo-web:latest");
 	}
 
 	lines.push("  env_file:", "    - path: .env", "      required: true", "  ports:", '    - "1515:3000"');
@@ -1267,7 +1267,7 @@ function buildWorkerService(options: {
 			"      DEPLOYMENT_MODE: local",
 		);
 	} else {
-		lines.push("  image: elmohq/worker:latest");
+		lines.push("  image: elmohq/elmo-worker:latest");
 	}
 
 	lines.push("  env_file:", "    - path: .env", "      required: true");

--- a/packages/docs/content/docs/developer-guide/releases.mdx
+++ b/packages/docs/content/docs/developer-guide/releases.mdx
@@ -56,8 +56,8 @@ When ready to release a new version:
 | Artifact | Registry | Description |
 |----------|----------|-------------|
 | `@elmohq/cli` | npm | The Elmo CLI package |
-| `elmohq/web` | Docker Hub | Web app Docker image |
-| `elmohq/worker` | Docker Hub | Worker Docker image |
+| `elmohq/elmo-web` | Docker Hub | Web app Docker image |
+| `elmohq/elmo-worker` | Docker Hub | Worker Docker image |
 
 ## Versioning Strategy
 


### PR DESCRIPTION
## Summary
- Fixes `docker compose up` failing with `pull access denied for elmohq/web` — the CLI generated compose pointing at `elmohq/web` / `elmohq/worker`, but the release workflow has been publishing them as `elmohq/elmo-web` / `elmohq/elmo-worker`. Standardized on the `elmo-*` names in the CLI and docs.
- Fixes `no matching manifest for linux/arm64/v8` on Apple Silicon: the publish workflow built only the runner's native arch. Split docker steps into a matrix that builds on native amd64 + arm64 Blacksmith runners, pushes by digest, and merges into multi-arch `:latest` / `:version` tags. Npm publish + GitHub release stay in a single job and run only once.