### PR TITLE
bump artifact actions to v7 to silence Node 20 deprecation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -141,7 +141,7 @@ jobs:
           touch "/tmp/digests/db-migrate/${DB_MIGRATE_DIGEST#sha256:}"
 
       - name: Upload digests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.arch }}
           path: /tmp/digests/*
@@ -154,7 +154,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: /tmp/digests
           pattern: digests-*


### PR DESCRIPTION
## Summary
- Bump `actions/upload-artifact` and `actions/download-artifact` from `@v4` (Node 20) to `@v7` (Node 24) in `publish.yaml`