### PR TITLE
accept bare domains for brand website

### DIFF
--- a/.changeset/brand-website-accept-domain.md
+++ b/.changeset/brand-website-accept-domain.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Accept bare domains (e.g. `example.com`) in the brand website field, not just full URLs.

--- a/.changeset/brand-website-accept-domain.md
+++ b/.changeset/brand-website-accept-domain.md
@@ -2,4 +2,4 @@
 "@workspace/web": patch
 ---
 
-Accept bare domains (e.g. `example.com`) in the brand website field, not just full URLs.
+Accept bare domains (e.g. `example.com`) in the brand website field and normalize the stored value to the origin (`https://example.com/products` is saved as `https://example.com/`).

--- a/apps/web/src/components/brand-onboarding.tsx
+++ b/apps/web/src/components/brand-onboarding.tsx
@@ -56,7 +56,7 @@ export default function BrandOnboarding({ brandId, brandName }: BrandOnboardingP
 						required
 						disabled={isLoading}
 					/>
-					<p className="text-xs text-muted-foreground">Enter your brand's website &mdash; a domain or full URL works</p>
+					<p className="text-xs text-muted-foreground">Enter your brand's website</p>
 				</div>
 
 				{error && <p className="text-sm text-destructive">{error}</p>}

--- a/apps/web/src/components/brand-onboarding.tsx
+++ b/apps/web/src/components/brand-onboarding.tsx
@@ -47,16 +47,16 @@ export default function BrandOnboarding({ brandId, brandName }: BrandOnboardingP
 				<input type="hidden" name="brandName" value={brandName} />
 
 				<div className="space-y-2">
-					<Label htmlFor="website">Website URL</Label>
+					<Label htmlFor="website">Website</Label>
 					<Input
 						id="website"
 						name="website"
-						type="url"
-						placeholder="https://example.com"
+						type="text"
+						placeholder="example.com"
 						required
 						disabled={isLoading}
 					/>
-					<p className="text-xs text-muted-foreground">Enter your brand's website URL</p>
+					<p className="text-xs text-muted-foreground">Enter your brand's website &mdash; a domain or full URL works</p>
 				</div>
 
 				{error && <p className="text-sm text-destructive">{error}</p>}

--- a/apps/web/src/lib/__tests__/brand-website.test.ts
+++ b/apps/web/src/lib/__tests__/brand-website.test.ts
@@ -24,13 +24,6 @@ describe("validateWebsiteUrl", () => {
 		});
 	});
 
-	it("accepts a full https URL with a trailing slash", () => {
-		expect(validateWebsiteUrl("https://example.com/")).toEqual({
-			isValid: true,
-			formattedUrl: "https://example.com/",
-		});
-	});
-
 	it("strips the path from a URL with a path", () => {
 		expect(validateWebsiteUrl("https://example.com/products")).toEqual({
 			isValid: true,
@@ -63,13 +56,6 @@ describe("validateWebsiteUrl", () => {
 		expect(validateWebsiteUrl("https://blog.example.com/posts/1")).toEqual({
 			isValid: true,
 			formattedUrl: "https://blog.example.com/",
-		});
-	});
-
-	it("trims leading and trailing whitespace", () => {
-		expect(validateWebsiteUrl("  example.com  ")).toEqual({
-			isValid: true,
-			formattedUrl: "https://example.com/",
 		});
 	});
 

--- a/apps/web/src/lib/__tests__/brand-website.test.ts
+++ b/apps/web/src/lib/__tests__/brand-website.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { validateWebsiteUrl } from "@/lib/brand-website";
+
+describe("validateWebsiteUrl", () => {
+	it("rejects empty input", () => {
+		expect(validateWebsiteUrl("")).toEqual({ isValid: false, error: "Website URL is required" });
+	});
+
+	it("rejects whitespace-only input", () => {
+		expect(validateWebsiteUrl("   ")).toEqual({ isValid: false, error: "Website URL is required" });
+	});
+
+	it("accepts a bare domain and prepends https", () => {
+		expect(validateWebsiteUrl("example.com")).toEqual({
+			isValid: true,
+			formattedUrl: "https://example.com/",
+		});
+	});
+
+	it("accepts a full https URL with no path", () => {
+		expect(validateWebsiteUrl("https://example.com")).toEqual({
+			isValid: true,
+			formattedUrl: "https://example.com/",
+		});
+	});
+
+	it("accepts a full https URL with a trailing slash", () => {
+		expect(validateWebsiteUrl("https://example.com/")).toEqual({
+			isValid: true,
+			formattedUrl: "https://example.com/",
+		});
+	});
+
+	it("strips the path from a URL with a path", () => {
+		expect(validateWebsiteUrl("https://example.com/products")).toEqual({
+			isValid: true,
+			formattedUrl: "https://example.com/",
+		});
+	});
+
+	it("strips path, query, and hash", () => {
+		expect(validateWebsiteUrl("https://example.com/products?ref=foo#section")).toEqual({
+			isValid: true,
+			formattedUrl: "https://example.com/",
+		});
+	});
+
+	it("strips path from a bare domain input", () => {
+		expect(validateWebsiteUrl("example.com/products")).toEqual({
+			isValid: true,
+			formattedUrl: "https://example.com/",
+		});
+	});
+
+	it("preserves http protocol when explicitly provided", () => {
+		expect(validateWebsiteUrl("http://example.com/path")).toEqual({
+			isValid: true,
+			formattedUrl: "http://example.com/",
+		});
+	});
+
+	it("preserves subdomains", () => {
+		expect(validateWebsiteUrl("https://blog.example.com/posts/1")).toEqual({
+			isValid: true,
+			formattedUrl: "https://blog.example.com/",
+		});
+	});
+
+	it("trims leading and trailing whitespace", () => {
+		expect(validateWebsiteUrl("  example.com  ")).toEqual({
+			isValid: true,
+			formattedUrl: "https://example.com/",
+		});
+	});
+
+	it("rejects hostnames without a TLD", () => {
+		const result = validateWebsiteUrl("foo");
+		expect(result.isValid).toBe(false);
+	});
+
+	it("rejects input that doesn't parse as a URL", () => {
+		const result = validateWebsiteUrl("not a url with spaces");
+		expect(result.isValid).toBe(false);
+	});
+});

--- a/apps/web/src/lib/brand-website.ts
+++ b/apps/web/src/lib/brand-website.ts
@@ -1,0 +1,31 @@
+import { cleanAndValidateDomain } from "@/lib/domain-categories";
+
+export type WebsiteValidationResult =
+	| { isValid: true; formattedUrl: string }
+	| { isValid: false; error: string };
+
+/**
+ * Validate a user-entered brand website. Accepts either a bare domain
+ * (`example.com`) or a full URL, and normalizes the result to an
+ * origin-only URL (path, query, and hash are stripped) so we always
+ * store `https://example.com/` rather than `https://example.com/products`.
+ */
+export function validateWebsiteUrl(input: string): WebsiteValidationResult {
+	if (!input || input.trim() === "") {
+		return { isValid: false, error: "Website URL is required" };
+	}
+	let candidate = input.trim();
+	if (!candidate.startsWith("http://") && !candidate.startsWith("https://")) {
+		candidate = `https://${candidate}`;
+	}
+	let urlObj: URL;
+	try {
+		urlObj = new URL(candidate);
+	} catch {
+		return { isValid: false, error: "Please enter a valid website URL or domain" };
+	}
+	if (!cleanAndValidateDomain(urlObj.hostname)) {
+		return { isValid: false, error: "Website URL must have a valid domain name" };
+	}
+	return { isValid: true, formattedUrl: `${urlObj.origin}/` };
+}

--- a/apps/web/src/routes/_authed/app/$brand/settings/brand.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/settings/brand.tsx
@@ -144,7 +144,7 @@ function BrandSettingsPage() {
 							required
 							disabled={isSubmitting}
 						/>
-						<p className="text-xs text-muted-foreground">Your brand&apos;s primary website &mdash; a domain or full URL works</p>
+						<p className="text-xs text-muted-foreground">Your brand&apos;s primary website</p>
 					</div>
 
 					<div className="space-y-2">

--- a/apps/web/src/routes/_authed/app/$brand/settings/brand.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/settings/brand.tsx
@@ -134,17 +134,17 @@ function BrandSettingsPage() {
 					</div>
 
 					<div className="space-y-2">
-						<Label htmlFor="website">Website URL</Label>
+						<Label htmlFor="website">Website</Label>
 						<Input
 							id="website"
 							name="website"
-							type="url"
-							placeholder="https://example.com"
+							type="text"
+							placeholder="example.com"
 							defaultValue={brand.website}
 							required
 							disabled={isSubmitting}
 						/>
-						<p className="text-xs text-muted-foreground">Your brand&apos;s primary website URL</p>
+						<p className="text-xs text-muted-foreground">Your brand&apos;s primary website &mdash; a domain or full URL works</p>
 					</div>
 
 					<div className="space-y-2">

--- a/apps/web/src/server/brands.ts
+++ b/apps/web/src/server/brands.ts
@@ -102,12 +102,12 @@ function validateWebsiteUrl(url: string): { isValid: boolean; formattedUrl?: str
 		if (!["http:", "https:"].includes(urlObj.protocol)) {
 			return { isValid: false, error: "Website URL must use http or https protocol" };
 		}
-		if (!urlObj.hostname || urlObj.hostname.length === 0) {
+		if (!cleanAndValidateDomain(urlObj.hostname)) {
 			return { isValid: false, error: "Website URL must have a valid domain name" };
 		}
 		return { isValid: true, formattedUrl };
 	} catch {
-		return { isValid: false, error: "Please enter a valid website URL" };
+		return { isValid: false, error: "Please enter a valid website URL or domain" };
 	}
 }
 

--- a/apps/web/src/server/brands.ts
+++ b/apps/web/src/server/brands.ts
@@ -10,6 +10,7 @@ import { brands, prompts, competitors, type BrandWithPrompts, type Brand } from 
 import { eq, and, count, sql } from "drizzle-orm";
 import { MAX_COMPETITORS } from "@workspace/lib/constants";
 import { cleanAndValidateDomain } from "@/lib/domain-categories";
+import { validateWebsiteUrl } from "@/lib/brand-website";
 import { parseScrapeTargets, selectTargetsForBrand } from "@workspace/lib/providers";
 import type { ModelConfig } from "@workspace/lib/providers";
 
@@ -89,28 +90,6 @@ async function getBrandWithPromptsFromDb(
 	}
 }
 
-function validateWebsiteUrl(url: string): { isValid: boolean; formattedUrl?: string; error?: string } {
-	if (!url || url.trim() === "") {
-		return { isValid: false, error: "Website URL is required" };
-	}
-	let formattedUrl = url.trim();
-	if (!formattedUrl.startsWith("http://") && !formattedUrl.startsWith("https://")) {
-		formattedUrl = `https://${formattedUrl}`;
-	}
-	try {
-		const urlObj = new URL(formattedUrl);
-		if (!["http:", "https:"].includes(urlObj.protocol)) {
-			return { isValid: false, error: "Website URL must use http or https protocol" };
-		}
-		if (!cleanAndValidateDomain(urlObj.hostname)) {
-			return { isValid: false, error: "Website URL must have a valid domain name" };
-		}
-		return { isValid: true, formattedUrl };
-	} catch {
-		return { isValid: false, error: "Please enter a valid website URL or domain" };
-	}
-}
-
 // ============================================================================
 // Server Functions
 // ============================================================================
@@ -183,7 +162,7 @@ export const createBrandFn = createServerFn({ method: "POST" })
 			.values({
 				id: data.brandId,
 				name: data.brandName,
-				website: urlValidation.formattedUrl!,
+				website: urlValidation.formattedUrl,
 				enabled: true,
 				...(defaultDomains.length > 0 && { additionalDomains: defaultDomains }),
 			})


### PR DESCRIPTION
Brand website field accepts a bare domain (`example.com`) in addition to a full URL — the frontend `Input` is `type="text"` so the browser stops blocking URL-only entries. The stored value is always normalized to origin + `/` (e.g. `https://example.com/products` and `https://example.com/cart?ref=foo#x` both save as `https://example.com/`).