### PR TITLE
remove CLI docker command aliases

### DIFF
--- a/.changeset/remove-cli-docker-aliases.md
+++ b/.changeset/remove-cli-docker-aliases.md
@@ -1,0 +1,6 @@
+---
+"@elmohq/cli": patch
+"@workspace/docs": patch
+---
+
+Remove `elmo start`, `elmo stop`, `elmo logs`, and `elmo build` aliases — use `elmo compose <args>` directly (e.g. `elmo compose up -d`, `elmo compose down`, `elmo compose logs -f`, `elmo compose build`).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm install -g @elmohq/cli
 elmo init
 
 # Start the stack
-elmo start
+elmo compose up -d
 ```
 
 > [!TIP]

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -44,7 +44,7 @@ Requires [Docker](https://docs.docker.com/get-docker/) and Docker Compose.
 elmo init
 
 # 2. Start the stack
-elmo start
+elmo compose up -d
 
 # 3. Open the app at http://localhost:1515
 ```
@@ -58,13 +58,9 @@ For the full self-hosting walkthrough, see the [Elmo docs](https://www.elmohq.co
 | Command | Description |
 | --- | --- |
 | `elmo init` | Interactive wizard to set up a local Elmo instance |
-| `elmo start` | Start the Elmo stack |
-| `elmo stop` | Stop the Elmo stack |
 | `elmo status` | Check the health of running services |
-| `elmo logs [service]` | Tail container logs (pass `-f` to follow) |
 | `elmo regen` | Regenerate `elmo.yaml` / `.env` from your saved config |
-| `elmo compose <args...>` | Run any `docker compose` command against your Elmo project |
-| `elmo build` | Build Docker images locally (for `--dev` installs) |
+| `elmo compose <args...>` | Run any `docker compose` command against your Elmo project (e.g. `elmo compose up -d`, `elmo compose down`, `elmo compose logs -f`, `elmo compose build`) |
 
 Run `elmo --help` or `elmo <command> --help` for the full list of flags.
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -134,22 +134,6 @@ async function main() {
 		});
 
 	program
-		.command("start")
-		.description("start Elmo instance")
-		.option("--dir <path>", "Config directory")
-		.action(async (options: DirOption) => {
-			await withVersionCheck(version, () => runStart(options));
-		});
-
-	program
-		.command("stop")
-		.description("stop Elmo instance")
-		.option("--dir <path>", "Config directory")
-		.action(async (options: DirOption) => {
-			await withVersionCheck(version, () => runStop(options));
-		});
-
-	program
 		.command("status")
 		.description("check Elmo instance health")
 		.option("--dir <path>", "Config directory")
@@ -166,35 +150,6 @@ async function main() {
 		.action(async (args: string[], options: DirOption) => {
 			await withVersionCheck(version, () => runCompose(args, options));
 		});
-
-	program
-		.command("logs")
-		.description("view Elmo instance logs")
-		.allowUnknownOption(true)
-		.option("--dir <path>", "Config directory")
-		.argument("[args...]", "Arguments passed to Docker Compose logs")
-		.action(async (args: string[], options: DirOption) => {
-			await withVersionCheck(version, () => runCompose(["logs", ...args], options));
-		});
-
-	program
-		.command("build")
-		.description("build Docker images locally for development")
-		.option("--dir <path>", "Config directory")
-		.option("--web-only", "Only build the web image")
-		.option("--worker-only", "Only build the worker image")
-		.option("--no-cache", "Build without Docker cache")
-		.action(
-			async (
-				options: DirOption & {
-					webOnly?: boolean;
-					workerOnly?: boolean;
-					cache?: boolean;
-				},
-			) => {
-				await withVersionCheck(version, () => runBuild(options));
-			},
-		);
 
 	const telemetry = program.command("telemetry").description("manage CLI + local-deployment telemetry");
 
@@ -213,7 +168,7 @@ async function main() {
 			const updated = await updateDeploymentEnvTelemetry(true);
 			log.success("Telemetry enabled.");
 			if (updated) {
-				log.info(`Updated ${updated}. Restart the stack with \`elmo start\` to apply.`);
+				log.info(`Updated ${updated}. Restart the stack with \`elmo compose up -d\` to apply.`);
 			}
 			console.log(`  Details: ${link(pc.cyan(TELEMETRY_DOC_URL), TELEMETRY_DOC_URL)}`);
 		});
@@ -226,7 +181,7 @@ async function main() {
 			const updated = await updateDeploymentEnvTelemetry(false);
 			log.success("Telemetry disabled. No further events will be sent.");
 			if (updated) {
-				log.info(`Updated ${updated}. Restart the stack with \`elmo start\` to apply.`);
+				log.info(`Updated ${updated}. Restart the stack with \`elmo compose up -d\` to apply.`);
 			}
 		});
 
@@ -444,7 +399,7 @@ async function runInit(options: InitOptions, version: string): Promise<void> {
 	if (shouldStart) {
 		await doStart(configDir);
 	} else {
-		p.log.info("You can start later with `elmo start`.");
+		p.log.info("You can start later with `elmo compose up -d`.");
 	}
 
 	// CLI telemetry — silently dropped if the user opted out above.
@@ -1000,12 +955,7 @@ async function runRegen(options: DirOption): Promise<void> {
 	log.info("The .env file was not modified.");
 }
 
-// ── Command: start ───────────────────────────────────────────────────────────
-
-async function runStart(options: DirOption): Promise<void> {
-	const configDir = await resolveConfigDir(options.dir);
-	await doStart(configDir);
-}
+// ── Start helper (used by init) ──────────────────────────────────────────────
 
 async function doStart(configDir: string): Promise<void> {
 	assertDockerRunning();
@@ -1024,20 +974,10 @@ async function doStart(configDir: string): Promise<void> {
 	}
 
 	log.info("Examples:");
-	console.log(`  ${pc.bold("elmo logs -f")}`);
+	console.log(`  ${pc.bold("elmo compose logs -f")}`);
 	console.log(`  ${pc.bold("elmo compose logs -f web")}`);
 	console.log(`  ${pc.bold("elmo compose ps")}`);
-}
-
-// ── Command: stop ────────────────────────────────────────────────────────────
-
-async function runStop(options: DirOption): Promise<void> {
-	const configDir = await resolveConfigDir(options.dir);
-	assertDockerRunning();
-
-	log.step("Stopping Docker Compose stack...");
-	await runDockerCompose(configDir, ["down"]);
-	log.success("Stack stopped.");
+	console.log(`  ${pc.bold("elmo compose down")}`);
 }
 
 // ── Command: status ──────────────────────────────────────────────────────────
@@ -1074,41 +1014,6 @@ async function runCompose(args: string[], options: DirOption): Promise<void> {
 	const configDir = await resolveConfigDir(options.dir);
 	assertDockerRunning();
 	await runDockerCompose(configDir, args);
-}
-
-// ── Command: build ───────────────────────────────────────────────────────────
-
-async function runBuild(
-	options: DirOption & {
-		webOnly?: boolean;
-		workerOnly?: boolean;
-		cache?: boolean;
-	},
-): Promise<void> {
-	const configDir = await resolveConfigDir(options.dir);
-	assertDockerRunning();
-
-	const buildWeb = !options.workerOnly;
-	const buildWorker = !options.webOnly;
-	const noCache = options.cache === false;
-
-	const targets: string[] = [];
-	if (buildWeb) targets.push("web");
-	if (buildWorker) targets.push("worker");
-
-	log.step(`Building Docker images: ${targets.join(", ")}${noCache ? " (no cache)" : ""}...`);
-
-	const buildArgs: string[] = ["build"];
-	if (noCache) buildArgs.push("--no-cache");
-
-	for (const target of targets) {
-		log.step(`Building ${target}...`);
-		await runDockerCompose(configDir, [...buildArgs, target]);
-		log.success(`${target} image built successfully.`);
-	}
-
-	log.success("All images built.");
-	console.log(`  Run ${pc.bold("elmo start")} to start the stack.`);
 }
 
 // ── Compose YAML Builder ─────────────────────────────────────────────────────

--- a/packages/docs/content/docs/developer-guide/commands.mdx
+++ b/packages/docs/content/docs/developer-guide/commands.mdx
@@ -88,16 +88,17 @@ pnpm cli:unlink
 
 ```bash
 # Build Docker images locally
-elmo build
+elmo compose build
 
 # Build without cache
-elmo build --no-cache
+elmo compose build --no-cache
 
 # Build only web or worker
-elmo build --web-only
-elmo build --worker-only
+elmo compose build web
+elmo compose build worker
 
-# Run docker compose commands
+# Run other docker compose commands
+elmo compose up -d
 elmo compose ps
 elmo compose logs -f web
 elmo compose down

--- a/packages/docs/content/docs/developer-guide/configuration.mdx
+++ b/packages/docs/content/docs/developer-guide/configuration.mdx
@@ -50,8 +50,8 @@ To change environment variables after initial setup:
 nano ./elmo/.env
 
 # Restart services to pick up changes
-elmo stop
-elmo start
+elmo compose down
+elmo compose up -d
 ```
 
 ## Regenerating Docker Compose
@@ -71,6 +71,6 @@ By default, `elmo init` provisions a PostgreSQL container. To use an existing da
 1. Choose "Use existing Postgres" during `elmo init`, or
 2. Edit `.env` to set `DATABASE_URL` to your connection string
 3. Run `elmo regen` to update `elmo.yaml` (removes the Postgres container)
-4. Restart with `elmo stop && elmo start`
+4. Restart with `elmo compose down && elmo compose up -d`
 
 Your database must be PostgreSQL 15 or later.

--- a/packages/docs/content/docs/developer-guide/telemetry.mdx
+++ b/packages/docs/content/docs/developer-guide/telemetry.mdx
@@ -9,7 +9,7 @@ and the same opt-out covers both:
 
 1. **The CLI** — events fired by `elmo` commands you run on your machine.
 2. **Your local deployment** — events fired by the web app and worker
-   containers when you run `elmo start`.
+   containers when you run `elmo compose up -d`.
 
 ## What is collected
 
@@ -65,7 +65,7 @@ elmo telemetry enable     # turn back on
 `elmo telemetry disable` writes `telemetryDisabled: true` to
 `~/.config/elmo/config.json` (used by the CLI) and adds `DISABLE_TELEMETRY=1`
 to your deployment's `.env` (used by the web app and worker). Restart the
-stack with `elmo start` to apply the deployment-side change. Setting
+stack with `elmo compose up -d` to apply the deployment-side change. Setting
 `DISABLE_TELEMETRY=1` in any environment also disables telemetry there
 unconditionally.
 

--- a/packages/docs/content/docs/getting-started.mdx
+++ b/packages/docs/content/docs/getting-started.mdx
@@ -42,10 +42,10 @@ Once complete, Elmo generates two files in your config directory:
 If you didn't start during init, bring everything up with:
 
 ```bash
-elmo start
+elmo compose up -d
 ```
 
-This pulls the Docker images, starts all services, and waits for them to become healthy. Once ready, open **http://localhost:1515** in your browser.
+This pulls the Docker images and starts all services. Once they report healthy, open **http://localhost:1515** in your browser.
 
 ## System Architecture
 
@@ -73,17 +73,16 @@ Once Elmo is running, these commands help you manage it:
 elmo status
 
 # View live logs
-elmo logs -f
+elmo compose logs -f
 
 # View logs for a specific service
 elmo compose logs -f web
 
 # Stop all services
-elmo stop
-
-# Run any docker compose command
-elmo compose ps
 elmo compose down
+
+# Run any other docker compose command
+elmo compose ps
 ```
 
 ## What's Next

--- a/packages/docs/content/docs/user-guide/settings.mdx
+++ b/packages/docs/content/docs/user-guide/settings.mdx
@@ -60,8 +60,8 @@ Some settings (like API keys) are configured via environment variables rather th
 nano ./elmo/.env
 
 # Restart to pick up changes
-elmo stop
-elmo start
+elmo compose down
+elmo compose up -d
 ```
 
 See the [Configuration](/docs/developer-guide/configuration) page for a complete reference of environment variables.


### PR DESCRIPTION
## Summary
- Drop `elmo start`, `elmo stop`, `elmo logs`, and `elmo build` — use `elmo compose <args>` directly (e.g. `elmo compose up -d`, `elmo compose down`, `elmo compose logs -f`, `elmo compose build`).
- Update README, CLI README, docs, and the init flow's printed examples to match.