### PR TITLE
bulk select prompts for enable/disable

### DIFF
--- a/.changeset/prompts-bulk-enable-disable.md
+++ b/.changeset/prompts-bulk-enable-disable.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Bulk-select prompts in the editor (settings and onboarding) to enable or disable many at once.

--- a/apps/web/src/components/prompts-list-editor.tsx
+++ b/apps/web/src/components/prompts-list-editor.tsx
@@ -88,17 +88,16 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 
 	const validCount = prompts.filter((p) => p.enabled && p.value.trim().length > 0).length;
 
-	// Mobile drops the System column and tightens tag/text minimums; desktop
-	// (md and up) restores the wider layout. Column order is:
-	// [select] [text] [system?] [tags] [enable switch]
+	// Desktop layout only — column order is [select] [text] [system?] [tags] [switch].
+	// Mobile renders a stacked per-prompt block instead (no selection, no bulk).
 	const gridCols = showSystemTags
-		? "grid-cols-[2.25rem_minmax(0,1fr)_minmax(7rem,1fr)_2.75rem] md:grid-cols-[2.25rem_minmax(0,1fr)_6rem_minmax(14rem,1fr)_2.75rem]"
-		: "grid-cols-[2.25rem_minmax(0,1fr)_minmax(7rem,1fr)_2.75rem] md:grid-cols-[2.25rem_minmax(0,1fr)_minmax(14rem,1fr)_2.75rem]";
+		? "md:grid-cols-[2.25rem_minmax(0,1fr)_6rem_minmax(14rem,1fr)_2.75rem]"
+		: "md:grid-cols-[2.25rem_minmax(0,1fr)_minmax(14rem,1fr)_2.75rem]";
 
 	return (
 		<div className="space-y-4">
 			{liveSelectedCount > 0 && (
-				<div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
+				<div className="hidden md:flex flex-wrap items-center justify-between gap-x-2 gap-y-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
 					<span className="text-muted-foreground">
 						<strong className="text-foreground">{liveSelectedCount}</strong> selected
 					</span>
@@ -134,7 +133,7 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 				</div>
 			)}
 
-			<div className={`grid ${gridCols} gap-2 text-sm font-medium text-muted-foreground border-b pb-2`}>
+			<div className={`hidden md:grid ${gridCols} gap-2 text-sm font-medium text-muted-foreground border-b pb-2`}>
 				<div className="flex justify-center">
 					<Checkbox
 						checked={allSelected}
@@ -193,46 +192,71 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 			) : (
 				<div className="space-y-3">
 					{prompts.map((prompt, index) => (
-						<div
-							key={prompt._key}
-							className={`grid ${gridCols} gap-2 items-start ${!prompt.enabled ? "opacity-60" : ""}`}
-						>
-							<div className="flex justify-center pt-2">
-								<Checkbox
-									checked={selectedKeys.has(prompt._key)}
-									onCheckedChange={() => toggleSelect(prompt._key)}
-									aria-label="Select prompt"
+						<div key={prompt._key} className={!prompt.enabled ? "opacity-60" : ""}>
+							{/* Mobile: stacked, no selection/bulk */}
+							<div
+								className={`md:hidden flex flex-col gap-2 pb-3 ${
+									index < prompts.length - 1 ? "border-b" : ""
+								}`}
+							>
+								<div className="flex items-start gap-2">
+									<Input
+										value={prompt.value}
+										onChange={(e) => update(index, { value: e.target.value })}
+										placeholder="Enter prompt text..."
+										className="min-w-0 flex-1"
+									/>
+									<div className="pt-2">
+										<Switch
+											checked={prompt.enabled}
+											onCheckedChange={(checked) => update(index, { enabled: checked })}
+											aria-label={prompt.enabled ? "Disable prompt" : "Enable prompt"}
+										/>
+									</div>
+								</div>
+								<TagsInput
+									value={prompt.tags}
+									onValueChange={(tags) => update(index, { tags })}
+									options={allTagOptions}
+									placeholder="Add tag..."
+									searchPlaceholder="Search or create tag..."
+									normalizeValue={(raw) => raw.toLowerCase().trim()}
 								/>
 							</div>
-							<Input
-								value={prompt.value}
-								onChange={(e) => update(index, { value: e.target.value })}
-								placeholder="Enter prompt text..."
-								className="min-w-0"
-							/>
-							{showSystemTags && (
+
+							{/* Desktop (md+): single-line grid */}
+							<div className={`hidden md:grid ${gridCols} gap-2 items-start`}>
+								<div className="flex justify-center pt-2">
+									<Checkbox
+										checked={selectedKeys.has(prompt._key)}
+										onCheckedChange={() => toggleSelect(prompt._key)}
+										aria-label="Select prompt"
+									/>
+								</div>
+								<Input
+									value={prompt.value}
+									onChange={(e) => update(index, { value: e.target.value })}
+									placeholder="Enter prompt text..."
+									className="min-w-0"
+								/>
+								{showSystemTags && (
+									<TagsInput value={prompt.systemTags} onValueChange={() => {}} disabled placeholder="—" />
+								)}
 								<TagsInput
-									value={prompt.systemTags}
-									onValueChange={() => {}}
-									disabled
-									placeholder="—"
-									className="hidden md:flex"
+									value={prompt.tags}
+									onValueChange={(tags) => update(index, { tags })}
+									options={allTagOptions}
+									placeholder="Add tag..."
+									searchPlaceholder="Search or create tag..."
+									normalizeValue={(raw) => raw.toLowerCase().trim()}
 								/>
-							)}
-							<TagsInput
-								value={prompt.tags}
-								onValueChange={(tags) => update(index, { tags })}
-								options={allTagOptions}
-								placeholder="Add tag..."
-								searchPlaceholder="Search or create tag..."
-								normalizeValue={(raw) => raw.toLowerCase().trim()}
-							/>
-							<div className="flex justify-center pt-2">
-								<Switch
-									checked={prompt.enabled}
-									onCheckedChange={(checked) => update(index, { enabled: checked })}
-									aria-label={prompt.enabled ? "Disable prompt" : "Enable prompt"}
-								/>
+								<div className="flex justify-center pt-2">
+									<Switch
+										checked={prompt.enabled}
+										onCheckedChange={(checked) => update(index, { enabled: checked })}
+										aria-label={prompt.enabled ? "Disable prompt" : "Enable prompt"}
+									/>
+								</div>
 							</div>
 						</div>
 					))}

--- a/apps/web/src/components/prompts-list-editor.tsx
+++ b/apps/web/src/components/prompts-list-editor.tsx
@@ -8,7 +8,7 @@
  * keeps it inline. The `showSystemTags` prop hides the System Tags column
  * in the wizard since onboarding hasn't yet computed any system tags.
  */
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@workspace/ui/components/button";
 import { Input } from "@workspace/ui/components/input";
 import { Checkbox } from "@workspace/ui/components/checkbox";
@@ -46,6 +46,8 @@ interface PromptsListEditorProps {
 }
 
 export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: PromptsListEditorProps) {
+	const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+
 	const allTagOptions = useMemo(() => {
 		const set = new Set<string>();
 		for (const p of prompts) for (const t of p.tags) set.add(t);
@@ -60,15 +62,83 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 		onChange([...prompts, newPromptEntry()]);
 	};
 
+	// Count selection against current prompts so stale keys (e.g. after the
+	// wizard regenerates suggestions) don't linger.
+	const liveSelectedCount = prompts.reduce((n, p) => (selectedKeys.has(p._key) ? n + 1 : n), 0);
+	const allSelected = prompts.length > 0 && liveSelectedCount === prompts.length;
+
+	const toggleSelect = (key: string) => {
+		setSelectedKeys((prev) => {
+			const next = new Set(prev);
+			if (next.has(key)) next.delete(key);
+			else next.add(key);
+			return next;
+		});
+	};
+	const toggleSelectAll = () => {
+		if (allSelected) setSelectedKeys(new Set());
+		else setSelectedKeys(new Set(prompts.map((p) => p._key)));
+	};
+	const applyEnabledToSelection = (enabled: boolean) => {
+		if (liveSelectedCount === 0) return;
+		onChange(prompts.map((p) => (selectedKeys.has(p._key) ? { ...p, enabled } : p)));
+	};
+	const clearSelection = () => setSelectedKeys(new Set());
+
 	const validCount = prompts.filter((p) => p.enabled && p.value.trim().length > 0).length;
 
 	const gridCols = showSystemTags
-		? "grid-cols-[3rem_1fr_6rem_minmax(14rem,1fr)]"
-		: "grid-cols-[3rem_1fr_minmax(14rem,1fr)]";
+		? "grid-cols-[2.5rem_3rem_1fr_6rem_minmax(14rem,1fr)]"
+		: "grid-cols-[2.5rem_3rem_1fr_minmax(14rem,1fr)]";
 
 	return (
 		<div className="space-y-4">
+			{liveSelectedCount > 0 && (
+				<div className="flex items-center justify-between gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
+					<span className="text-muted-foreground">
+						<strong className="text-foreground">{liveSelectedCount}</strong> selected
+					</span>
+					<div className="flex items-center gap-2">
+						<Button
+							type="button"
+							size="sm"
+							variant="outline"
+							onClick={() => applyEnabledToSelection(true)}
+							className="cursor-pointer"
+						>
+							Enable
+						</Button>
+						<Button
+							type="button"
+							size="sm"
+							variant="outline"
+							onClick={() => applyEnabledToSelection(false)}
+							className="cursor-pointer"
+						>
+							Disable
+						</Button>
+						<Button
+							type="button"
+							size="sm"
+							variant="ghost"
+							onClick={clearSelection}
+							className="cursor-pointer"
+						>
+							Clear
+						</Button>
+					</div>
+				</div>
+			)}
+
 			<div className={`grid ${gridCols} gap-2 text-sm font-medium text-muted-foreground border-b pb-2`}>
+				<div className="flex justify-center">
+					<Checkbox
+						checked={allSelected}
+						onCheckedChange={toggleSelectAll}
+						disabled={prompts.length === 0}
+						aria-label={allSelected ? "Deselect all prompts" : "Select all prompts"}
+					/>
+				</div>
 				<div className="flex justify-center">
 					<Check className="h-4 w-4" />
 				</div>
@@ -123,6 +193,13 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 							key={prompt._key}
 							className={`grid ${gridCols} gap-2 items-start ${!prompt.enabled ? "opacity-60" : ""}`}
 						>
+							<div className="flex justify-center pt-2">
+								<Checkbox
+									checked={selectedKeys.has(prompt._key)}
+									onCheckedChange={() => toggleSelect(prompt._key)}
+									aria-label="Select prompt"
+								/>
+							</div>
 							<div className="flex justify-center pt-2">
 								<Checkbox
 									checked={prompt.enabled}

--- a/apps/web/src/components/prompts-list-editor.tsx
+++ b/apps/web/src/components/prompts-list-editor.tsx
@@ -12,9 +12,10 @@ import { useMemo, useState } from "react";
 import { Button } from "@workspace/ui/components/button";
 import { Input } from "@workspace/ui/components/input";
 import { Checkbox } from "@workspace/ui/components/checkbox";
+import { Switch } from "@workspace/ui/components/switch";
 import { TagsInput } from "@workspace/ui/components/tags-input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
-import { Plus, Inbox, Check } from "lucide-react";
+import { Plus, Inbox } from "lucide-react";
 import { IconInfoCircle } from "@tabler/icons-react";
 import { MAX_PROMPTS } from "@workspace/lib/constants";
 
@@ -87,14 +88,17 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 
 	const validCount = prompts.filter((p) => p.enabled && p.value.trim().length > 0).length;
 
+	// Mobile drops the System column and tightens tag/text minimums; desktop
+	// (md and up) restores the wider layout. Column order is:
+	// [select] [text] [system?] [tags] [enable switch]
 	const gridCols = showSystemTags
-		? "grid-cols-[2.5rem_3rem_1fr_6rem_minmax(14rem,1fr)]"
-		: "grid-cols-[2.5rem_3rem_1fr_minmax(14rem,1fr)]";
+		? "grid-cols-[2.25rem_minmax(0,1fr)_minmax(7rem,1fr)_2.75rem] md:grid-cols-[2.25rem_minmax(0,1fr)_6rem_minmax(14rem,1fr)_2.75rem]"
+		: "grid-cols-[2.25rem_minmax(0,1fr)_minmax(7rem,1fr)_2.75rem] md:grid-cols-[2.25rem_minmax(0,1fr)_minmax(14rem,1fr)_2.75rem]";
 
 	return (
 		<div className="space-y-4">
 			{liveSelectedCount > 0 && (
-				<div className="flex items-center justify-between gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
+				<div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
 					<span className="text-muted-foreground">
 						<strong className="text-foreground">{liveSelectedCount}</strong> selected
 					</span>
@@ -139,10 +143,7 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 						aria-label={allSelected ? "Deselect all prompts" : "Select all prompts"}
 					/>
 				</div>
-				<div className="flex justify-center">
-					<Check className="h-4 w-4" />
-				</div>
-				<div className="flex items-center gap-1">
+				<div className="flex items-center gap-1 min-w-0">
 					Prompt Text
 					<Tooltip>
 						<TooltipTrigger asChild>
@@ -154,7 +155,7 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 					</Tooltip>
 				</div>
 				{showSystemTags && (
-					<div className="flex items-center gap-1">
+					<div className="hidden md:flex items-center gap-1">
 						System
 						<Tooltip>
 							<TooltipTrigger asChild>
@@ -166,7 +167,7 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 						</Tooltip>
 					</div>
 				)}
-				<div className="flex items-center gap-1">
+				<div className="flex items-center gap-1 min-w-0">
 					Tags
 					<Tooltip>
 						<TooltipTrigger asChild>
@@ -176,6 +177,9 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 							<p className="max-w-xs">Custom labels to organize and filter prompts.</p>
 						</TooltipContent>
 					</Tooltip>
+				</div>
+				<div className="flex justify-center">
+					<span className="sr-only">Enabled</span>
 				</div>
 			</div>
 
@@ -200,19 +204,20 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 									aria-label="Select prompt"
 								/>
 							</div>
-							<div className="flex justify-center pt-2">
-								<Checkbox
-									checked={prompt.enabled}
-									onCheckedChange={(checked) => update(index, { enabled: checked === true })}
-								/>
-							</div>
 							<Input
 								value={prompt.value}
 								onChange={(e) => update(index, { value: e.target.value })}
 								placeholder="Enter prompt text..."
+								className="min-w-0"
 							/>
 							{showSystemTags && (
-								<TagsInput value={prompt.systemTags} onValueChange={() => {}} disabled placeholder="—" />
+								<TagsInput
+									value={prompt.systemTags}
+									onValueChange={() => {}}
+									disabled
+									placeholder="—"
+									className="hidden md:flex"
+								/>
 							)}
 							<TagsInput
 								value={prompt.tags}
@@ -222,6 +227,13 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 								searchPlaceholder="Search or create tag..."
 								normalizeValue={(raw) => raw.toLowerCase().trim()}
 							/>
+							<div className="flex justify-center pt-2">
+								<Switch
+									checked={prompt.enabled}
+									onCheckedChange={(checked) => update(index, { enabled: checked })}
+									aria-label={prompt.enabled ? "Disable prompt" : "Enable prompt"}
+								/>
+							</div>
 						</div>
 					))}
 				</div>

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }


### PR DESCRIPTION
## Summary
- Add a selection column and a bulk-action toolbar to the shared prompts editor (used by both the settings page and the onboarding wizard) so users can enable or disable multiple prompts in one click.