### PR TITLE
recommended elmo init: scrape ChatGPT + Google AI Mode, skip direct-API query target

### DIFF
--- a/.changeset/cli-recommended-scraping-only-queries.md
+++ b/.changeset/cli-recommended-scraping-only-queries.md
@@ -1,0 +1,5 @@
+---
+"@elmohq/cli": patch
+---
+
+Recommended `elmo init` setup no longer adds direct-API query targets — only scraping tracks ChatGPT and Google AI Mode.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -566,7 +566,7 @@ async function configureProvidersRecommended(env: EnvMap): Promise<void> {
 		initialValue: "openrouter" as const,
 	});
 	assertNotCancelled(direct);
-	await collectDirectApiQuick(direct, env, targets);
+	await collectDirectApiQuick(direct, env);
 
 	await finalizeScrapeTargets(env, targets, { skipEdit: true });
 }
@@ -624,7 +624,6 @@ async function collectScraperKey(scraper: "brightdata" | "olostep", env: EnvMap)
 async function collectDirectApiQuick(
 	kind: "openrouter" | "anthropic" | "openai" | "mistral",
 	env: EnvMap,
-	targets: string[],
 ): Promise<void> {
 	if (kind === "openrouter") {
 		const key = await p.password({
@@ -633,7 +632,6 @@ async function collectDirectApiQuick(
 		});
 		assertNotCancelled(key);
 		env.OPENROUTER_API_KEY = key;
-		targets.push(`claude:openrouter:${DEFAULT_OPENROUTER_MODEL}:online`);
 	} else if (kind === "anthropic") {
 		const key = await p.password({
 			message: "Anthropic API key",
@@ -641,7 +639,6 @@ async function collectDirectApiQuick(
 		});
 		assertNotCancelled(key);
 		env.ANTHROPIC_API_KEY = key;
-		targets.push(`claude:anthropic-api:${DEFAULT_ANTHROPIC_MODEL}:online`);
 	} else if (kind === "openai") {
 		const key = await p.password({
 			message: "OpenAI API key",
@@ -649,7 +646,6 @@ async function collectDirectApiQuick(
 		});
 		assertNotCancelled(key);
 		env.OPENAI_API_KEY = key;
-		targets.push(`chatgpt:openai-api:${DEFAULT_OPENAI_MODEL}:online`);
 	} else {
 		const key = await p.password({
 			message: "Mistral API key",
@@ -657,7 +653,6 @@ async function collectDirectApiQuick(
 		});
 		assertNotCancelled(key);
 		env.MISTRAL_API_KEY = key;
-		targets.push(`mistral:mistral-api:${DEFAULT_MISTRAL_MODEL}:online`);
 	}
 }
 


### PR DESCRIPTION
## Summary
- Recommended `elmo init` no longer adds a direct-API target to `SCRAPE_TARGETS`; the scraper is the sole query target for ChatGPT and Google AI Mode.
- The direct API key is still captured (for onboarding analysis + sentiment scoring), matching the wording already shown in the prompt.