### PR TITLE
allow multiple brands in local mode

### DIFF
--- a/.changeset/local-multi-brand.md
+++ b/.changeset/local-multi-brand.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Local-mode deployments now support multiple brands. The brand switcher shows a "Create new brand" option that provisions a new org + admin membership for the user.

--- a/apps/web/src/lib/auth/__tests__/policies.test.ts
+++ b/apps/web/src/lib/auth/__tests__/policies.test.ts
@@ -21,6 +21,7 @@ import {
 	evaluateDeploymentPolicy,
 	evaluateReadOnly,
 	evaluateRequireAdmin,
+	evaluateRequireCanCreateBrands,
 	evaluateRequireOrgAccess,
 	type RequestInfo,
 } from "@/lib/auth/policies";
@@ -418,6 +419,23 @@ describe("evaluateReadOnly", () => {
 
 	it("allows writes when read-only is disabled", () => {
 		expect(evaluateReadOnly(false)).toBe("allow");
+	});
+});
+
+describe("evaluateRequireCanCreateBrands", () => {
+	it("denies when canCreateBrands is false", () => {
+		expect(evaluateRequireCanCreateBrands(false)).toBe("deny");
+	});
+
+	it("allows when canCreateBrands is true", () => {
+		expect(evaluateRequireCanCreateBrands(true)).toBe("allow");
+	});
+
+	it("matches the expected per-mode flag", () => {
+		// Local can create; demo and whitelabel cannot.
+		expect(evaluateRequireCanCreateBrands(LOCAL_FEATURES.canCreateBrands)).toBe("allow");
+		expect(evaluateRequireCanCreateBrands(DEMO_FEATURES.canCreateBrands)).toBe("deny");
+		expect(evaluateRequireCanCreateBrands(WHITELABEL_FEATURES.canCreateBrands)).toBe("deny");
 	});
 });
 

--- a/apps/web/src/lib/auth/policies.ts
+++ b/apps/web/src/lib/auth/policies.ts
@@ -229,6 +229,15 @@ export function evaluateReadOnly(readOnly: boolean): "allow" | "deny" {
 	return readOnly ? "deny" : "allow";
 }
 
+/**
+ * Evaluate whether the deployment allows the user to create brands from the UI.
+ * Used by the create-brand server function. Local mode is the only mode that
+ * allows it — whitelabel orgs come from Auth0, demo is read-only.
+ */
+export function evaluateRequireCanCreateBrands(canCreateBrands: boolean): "allow" | "deny" {
+	return canCreateBrands ? "allow" : "deny";
+}
+
 // ============================================================================
 // Route Guard Policies
 // ============================================================================

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as AuthedReportsIndexRouteImport } from './routes/_authed/reports
 import { Route as AuthedAppIndexRouteImport } from './routes/_authed/app/index'
 import { Route as AuthedAdminIndexRouteImport } from './routes/_authed/admin/index'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
+import { Route as AuthedAppNewRouteImport } from './routes/_authed/app/new'
 import { Route as AuthedAppBrandRouteImport } from './routes/_authed/app/$brand'
 import { Route as AuthedAdminWorkflowsRouteImport } from './routes/_authed/admin/workflows'
 import { Route as AuthedAdminToolsRouteImport } from './routes/_authed/admin/tools'
@@ -127,6 +128,11 @@ const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
   id: '/api/auth/$',
   path: '/api/auth/$',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AuthedAppNewRoute = AuthedAppNewRouteImport.update({
+  id: '/new',
+  path: '/new',
+  getParentRoute: () => AuthedAppRoute,
 } as any)
 const AuthedAppBrandRoute = AuthedAppBrandRouteImport.update({
   id: '/$brand',
@@ -298,6 +304,7 @@ export interface FileRoutesByFullPath {
   '/admin/tools': typeof AuthedAdminToolsRoute
   '/admin/workflows': typeof AuthedAdminWorkflowsRoute
   '/app/$brand': typeof AuthedAppBrandRouteWithChildren
+  '/app/new': typeof AuthedAppNewRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/admin/': typeof AuthedAdminIndexRoute
   '/app/': typeof AuthedAppIndexRoute
@@ -339,6 +346,7 @@ export interface FileRoutesByTo {
   '/auth/register': typeof AuthRegisterRoute
   '/admin/tools': typeof AuthedAdminToolsRoute
   '/admin/workflows': typeof AuthedAdminWorkflowsRoute
+  '/app/new': typeof AuthedAppNewRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/admin': typeof AuthedAdminIndexRoute
   '/app': typeof AuthedAppIndexRoute
@@ -386,6 +394,7 @@ export interface FileRoutesById {
   '/_authed/admin/tools': typeof AuthedAdminToolsRoute
   '/_authed/admin/workflows': typeof AuthedAdminWorkflowsRoute
   '/_authed/app/$brand': typeof AuthedAppBrandRouteWithChildren
+  '/_authed/app/new': typeof AuthedAppNewRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/_authed/admin/': typeof AuthedAdminIndexRoute
   '/_authed/app/': typeof AuthedAppIndexRoute
@@ -433,6 +442,7 @@ export interface FileRouteTypes {
     | '/admin/tools'
     | '/admin/workflows'
     | '/app/$brand'
+    | '/app/new'
     | '/api/auth/$'
     | '/admin/'
     | '/app/'
@@ -474,6 +484,7 @@ export interface FileRouteTypes {
     | '/auth/register'
     | '/admin/tools'
     | '/admin/workflows'
+    | '/app/new'
     | '/api/auth/$'
     | '/admin'
     | '/app'
@@ -520,6 +531,7 @@ export interface FileRouteTypes {
     | '/_authed/admin/tools'
     | '/_authed/admin/workflows'
     | '/_authed/app/$brand'
+    | '/_authed/app/new'
     | '/api/auth/$'
     | '/_authed/admin/'
     | '/_authed/app/'
@@ -685,6 +697,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/auth/$'
       preLoaderRoute: typeof ApiAuthSplatRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/_authed/app/new': {
+      id: '/_authed/app/new'
+      path: '/new'
+      fullPath: '/app/new'
+      preLoaderRoute: typeof AuthedAppNewRouteImport
+      parentRoute: typeof AuthedAppRoute
     }
     '/_authed/app/$brand': {
       id: '/_authed/app/$brand'
@@ -945,11 +964,13 @@ const AuthedAppBrandRouteWithChildren = AuthedAppBrandRoute._addFileChildren(
 
 interface AuthedAppRouteChildren {
   AuthedAppBrandRoute: typeof AuthedAppBrandRouteWithChildren
+  AuthedAppNewRoute: typeof AuthedAppNewRoute
   AuthedAppIndexRoute: typeof AuthedAppIndexRoute
 }
 
 const AuthedAppRouteChildren: AuthedAppRouteChildren = {
   AuthedAppBrandRoute: AuthedAppBrandRouteWithChildren,
+  AuthedAppNewRoute: AuthedAppNewRoute,
   AuthedAppIndexRoute: AuthedAppIndexRoute,
 }
 

--- a/apps/web/src/routes/_authed/app/index.tsx
+++ b/apps/web/src/routes/_authed/app/index.tsx
@@ -18,6 +18,7 @@ const getOrganizations = createServerFn({ method: "GET" }).handler(
 	async (): Promise<{
 		organizations: { id: string; name: string }[];
 		supportsMultiOrg: boolean;
+		canCreateBrands: boolean;
 	}> => {
 		const session = await requireAuthSession();
 		const deployment = getDeployment();
@@ -35,6 +36,7 @@ const getOrganizations = createServerFn({ method: "GET" }).handler(
 		return {
 			organizations,
 			supportsMultiOrg: deployment.features.supportsMultiOrg,
+			canCreateBrands: deployment.features.canCreateBrands,
 		};
 	},
 );
@@ -67,14 +69,14 @@ export const Route = createFileRoute("/_authed/app/")({
 });
 
 function BrandSwitcherPage() {
-	const { organizations } = Route.useLoaderData();
+	const { organizations, canCreateBrands } = Route.useLoaderData();
 
 	return (
 		<FullPageCard title="Brand Switcher" subtitle="Select a brand to get started">
-			<div className="flex flex-col space-y-3">
+			<div className="flex flex-col space-y-3 min-w-[200px]">
 				{organizations.length > 0 ? (
 					organizations.map((org: { id: string; name: string }) => (
-						<Button key={org.id} asChild variant="secondary" className="min-w-[200px]">
+						<Button key={org.id} asChild variant="secondary">
 							<Link to="/app/$brand" params={{ brand: org.id }}>
 								{org.name}
 							</Link>
@@ -82,6 +84,11 @@ function BrandSwitcherPage() {
 					))
 				) : (
 					<p className="text-muted-foreground text-center">No brands available</p>
+				)}
+				{canCreateBrands && (
+					<Button asChild variant="outline">
+						<Link to="/app/new">+ Create new brand</Link>
+					</Button>
 				)}
 			</div>
 		</FullPageCard>

--- a/apps/web/src/routes/_authed/app/new.tsx
+++ b/apps/web/src/routes/_authed/app/new.tsx
@@ -1,0 +1,84 @@
+/**
+ * /app/new - Create a new brand (local mode only).
+ *
+ * Provisions a new organization + admin membership for the current user
+ * and seeds the brand row with the supplied name + website. Whitelabel and
+ * demo are blocked at both the loader (redirect to /app) and the server
+ * function (canCreateBrands policy).
+ */
+import { useState } from "react";
+import { createFileRoute, redirect, useNavigate, useRouter } from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import { Button } from "@workspace/ui/components/button";
+import { Input } from "@workspace/ui/components/input";
+import { Label } from "@workspace/ui/components/label";
+import FullPageCard from "@/components/full-page-card";
+import { trackEvent } from "@/lib/posthog";
+import { createBrandWithOrgFn } from "@/server/brands";
+import { getDeployment } from "@/lib/config/server";
+
+const getCanCreateBrands = createServerFn({ method: "GET" }).handler(async () => {
+	return { canCreateBrands: getDeployment().features.canCreateBrands };
+});
+
+export const Route = createFileRoute("/_authed/app/new")({
+	loader: async () => {
+		const { canCreateBrands } = await getCanCreateBrands();
+		if (!canCreateBrands) {
+			throw redirect({ to: "/app" });
+		}
+		return { canCreateBrands };
+	},
+	component: NewBrandPage,
+});
+
+function NewBrandPage() {
+	const [isLoading, setIsLoading] = useState(false);
+	const [error, setError] = useState("");
+	const navigate = useNavigate();
+	const router = useRouter();
+
+	const handleSubmit = async (formData: FormData) => {
+		setIsLoading(true);
+		setError("");
+
+		try {
+			const brandName = (formData.get("brandName") as string)?.trim() ?? "";
+			const website = (formData.get("website") as string)?.trim() ?? "";
+
+			const { brandId } = await createBrandWithOrgFn({
+				data: { brandName, website },
+			});
+			trackEvent("brand_created", { has_website: Boolean(website) });
+
+			await router.invalidate();
+			await navigate({ to: "/app/$brand", params: { brand: brandId } });
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "An error occurred");
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	return (
+		<FullPageCard title="Create a new brand" subtitle="Set up a brand to start tracking" showBackButton>
+			<form action={handleSubmit} className="space-y-4">
+				<div className="space-y-2">
+					<Label htmlFor="brandName">Brand name</Label>
+					<Input id="brandName" name="brandName" type="text" placeholder="Acme" required disabled={isLoading} />
+				</div>
+
+				<div className="space-y-2">
+					<Label htmlFor="website">Website</Label>
+					<Input id="website" name="website" type="text" placeholder="example.com" required disabled={isLoading} />
+				</div>
+
+				{error && <p className="text-sm text-destructive">{error}</p>}
+
+				<Button type="submit" className="w-full" disabled={isLoading}>
+					{isLoading ? "Creating..." : "Create brand"}
+				</Button>
+			</form>
+		</FullPageCard>
+	);
+}

--- a/apps/web/src/server/brands.ts
+++ b/apps/web/src/server/brands.ts
@@ -5,8 +5,11 @@
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import { requireAuthSession, requireOrgAccess, listUserOrganizations } from "@/lib/auth/helpers";
+import { evaluateRequireCanCreateBrands } from "@/lib/auth/policies";
+import { getDeployment } from "@/lib/config/server";
 import { db } from "@workspace/lib/db/db";
 import { brands, prompts, competitors, type BrandWithPrompts, type Brand } from "@workspace/lib/db/schema";
+import { provisionAdditionalLocalOrg } from "@workspace/lib/db/provisioning";
 import { eq, and, count, sql } from "drizzle-orm";
 import { MAX_COMPETITORS } from "@workspace/lib/constants";
 import { cleanAndValidateDomain } from "@/lib/domain-categories";
@@ -180,6 +183,55 @@ export const createBrandFn = createServerFn({ method: "POST" })
 		}
 
 		return { success: true, brand };
+	});
+
+/**
+ * Create a new organization + admin membership + brand in one shot for the
+ * current user. Used by the local-mode multi-brand "create new brand" flow on
+ * the brand switcher. Gated by the canCreateBrands deployment feature so
+ * whitelabel (orgs come from Auth0) and demo (read-only) reject it.
+ */
+export const createBrandWithOrgFn = createServerFn({ method: "POST" })
+	.inputValidator(
+		z.object({
+			brandName: z.string().min(1).max(100),
+			website: z.string().min(1),
+		}),
+	)
+	.handler(async ({ data }) => {
+		const session = await requireAuthSession();
+		const deployment = getDeployment();
+
+		if (evaluateRequireCanCreateBrands(deployment.features.canCreateBrands) === "deny") {
+			throw new Error("Brand creation is not allowed in this deployment");
+		}
+
+		const urlValidation = validateWebsiteUrl(data.website);
+		if (!urlValidation.isValid) {
+			throw new Error(urlValidation.error);
+		}
+
+		const trimmedName = data.brandName.trim();
+		if (!trimmedName) {
+			throw new Error("Brand name must be a non-empty string");
+		}
+
+		const { orgId } = await provisionAdditionalLocalOrg({
+			userId: session.user.id,
+			name: trimmedName,
+		});
+
+		const defaultDomains = getDefaultBrandDomains();
+
+		await db.insert(brands).values({
+			id: orgId,
+			name: trimmedName,
+			website: urlValidation.formattedUrl,
+			enabled: true,
+			...(defaultDomains.length > 0 && { additionalDomains: defaultDomains }),
+		});
+
+		return { brandId: orgId };
 	});
 
 /**

--- a/apps/web/src/stories/_mocks/config-client.ts
+++ b/apps/web/src/stories/_mocks/config-client.ts
@@ -11,6 +11,7 @@ export interface FeaturesConfig {
 	readOnly: boolean;
 	showOptimizeButton: boolean;
 	supportsMultiOrg: boolean;
+	canCreateBrands: boolean;
 }
 
 export interface BrandingConfig {
@@ -51,6 +52,7 @@ let _config: ClientConfig = {
 		readOnly: false,
 		showOptimizeButton: false,
 		supportsMultiOrg: false,
+		canCreateBrands: false,
 	},
 	branding: {
 		name: "Elmo",

--- a/apps/web/src/stories/app-sidebar.stories.tsx
+++ b/apps/web/src/stories/app-sidebar.stories.tsx
@@ -64,7 +64,8 @@ const localConfig: ClientConfig = {
 	features: {
 		readOnly: false,
 		showOptimizeButton: false,
-		supportsMultiOrg: false,
+		supportsMultiOrg: true,
+		canCreateBrands: true,
 	},
 	branding: { name: "Elmo", chartColors: CHART_COLORS },
 	analytics: {},
@@ -75,7 +76,8 @@ const demoConfig: ClientConfig = {
 	features: {
 		readOnly: true,
 		showOptimizeButton: false,
-		supportsMultiOrg: false,
+		supportsMultiOrg: true,
+		canCreateBrands: false,
 	},
 	branding: { name: "Elmo", chartColors: CHART_COLORS },
 	analytics: {},
@@ -86,7 +88,8 @@ const whitelabelConfig: ClientConfig = {
 	features: {
 		readOnly: false,
 		showOptimizeButton: true,
-		supportsMultiOrg: false,
+		supportsMultiOrg: true,
+		canCreateBrands: false,
 	},
 	branding: {
 		name: "BrandMonitor Pro",

--- a/apps/web/src/stories/brand-kit.stories.tsx
+++ b/apps/web/src/stories/brand-kit.stories.tsx
@@ -32,7 +32,8 @@ const elmoConfig: ClientConfig = {
 	features: {
 		readOnly: false,
 		showOptimizeButton: false,
-		supportsMultiOrg: false,
+		supportsMultiOrg: true,
+		canCreateBrands: true,
 	},
 	branding: {
 		name: "Elmo",
@@ -46,7 +47,8 @@ const whitelabelConfig: ClientConfig = {
 	features: {
 		readOnly: false,
 		showOptimizeButton: true,
-		supportsMultiOrg: false,
+		supportsMultiOrg: true,
+		canCreateBrands: false,
 	},
 	branding: {
 		name: "BrandMonitor Pro",

--- a/apps/web/src/stories/chart-export-preview.stories.tsx
+++ b/apps/web/src/stories/chart-export-preview.stories.tsx
@@ -48,7 +48,7 @@ function generateChartData(days: number) {
 
 const defaultClientConfig: ClientConfig = {
 	mode: "local",
-	features: { readOnly: false, showOptimizeButton: false, supportsMultiOrg: false },
+	features: { readOnly: false, showOptimizeButton: false, supportsMultiOrg: true, canCreateBrands: true },
 	branding: { name: "Elmo", chartColors: CHART_COLORS },
 	analytics: {},
 };

--- a/apps/web/src/stories/prompt-chart.stories.tsx
+++ b/apps/web/src/stories/prompt-chart.stories.tsx
@@ -31,7 +31,8 @@ const defaultClientConfig: ClientConfig = {
 	features: {
 		readOnly: false,
 		showOptimizeButton: false,
-		supportsMultiOrg: false,
+		supportsMultiOrg: true,
+		canCreateBrands: true,
 	},
 	branding: {
 		name: "Elmo",

--- a/apps/web/src/test/mocks/auth.ts
+++ b/apps/web/src/test/mocks/auth.ts
@@ -16,19 +16,22 @@ import type { Deployment, FeaturesConfig } from "@workspace/config/types";
 export const LOCAL_FEATURES: FeaturesConfig = {
 	readOnly: false,
 	showOptimizeButton: false,
-	supportsMultiOrg: false,
+	supportsMultiOrg: true,
+	canCreateBrands: true,
 };
 
 export const DEMO_FEATURES: FeaturesConfig = {
 	readOnly: true,
 	showOptimizeButton: false,
-	supportsMultiOrg: false,
+	supportsMultiOrg: true,
+	canCreateBrands: false,
 };
 
 export const WHITELABEL_FEATURES: FeaturesConfig = {
 	readOnly: false,
 	showOptimizeButton: true,
 	supportsMultiOrg: true,
+	canCreateBrands: false,
 };
 
 // ============================================================================

--- a/e2e/tests/overview.spec.ts
+++ b/e2e/tests/overview.spec.ts
@@ -9,10 +9,15 @@ import { test, expect } from "@playwright/test";
 const BRAND_ID = "default";
 
 test.describe("Overview Page", () => {
-  test("home page redirects to the default brand dashboard", async ({ page }) => {
+  test("home page lands on the brand switcher and the default brand is reachable", async ({ page }) => {
     await page.goto("/");
-    // In local mode with a single org, / -> /app -> /app/default
-    await page.waitForURL(/\/app\/default/, { timeout: 30_000 });
+    // Local mode supports multiple brands, so / -> /app shows the switcher
+    // rather than auto-redirecting through to a brand.
+    await page.waitForURL(/\/app(?:\/)?$/, { timeout: 30_000 });
+    const brandLink = page.locator(`a[href="/app/${BRAND_ID}"]`).first();
+    await expect(brandLink).toBeVisible({ timeout: 15_000 });
+    await brandLink.click();
+    await page.waitForURL(new RegExp(`/app/${BRAND_ID}$`));
     expect(page.url()).toContain(`/app/${BRAND_ID}`);
   });
 

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -24,6 +24,11 @@ export interface FeaturesConfig {
 	showOptimizeButton: boolean;
 	/** Whether multi-org brand switching is supported */
 	supportsMultiOrg: boolean;
+	/**
+	 * Whether the user can create new brands from the UI. True only in local mode —
+	 * whitelabel orgs come from Auth0, demo is read-only.
+	 */
+	canCreateBrands: boolean;
 }
 
 /**

--- a/packages/lib/src/db/provisioning.test.ts
+++ b/packages/lib/src/db/provisioning.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { slugifyOrgName } from "./provisioning";
+
+describe("slugifyOrgName", () => {
+	it("lowercases", () => {
+		expect(slugifyOrgName("Acme")).toBe("acme");
+	});
+
+	it("replaces runs of non-alphanumerics with single hyphens", () => {
+		expect(slugifyOrgName("Acme Co!")).toBe("acme-co");
+		expect(slugifyOrgName("Foo   Bar")).toBe("foo-bar");
+	});
+
+	it("trims leading and trailing hyphens", () => {
+		expect(slugifyOrgName("  hello world  ")).toBe("hello-world");
+		expect(slugifyOrgName("!!!brand!!!")).toBe("brand");
+	});
+
+	it("falls back to 'brand' for empty / non-alphanumeric input", () => {
+		expect(slugifyOrgName("")).toBe("brand");
+		expect(slugifyOrgName("!!!")).toBe("brand");
+	});
+
+	it("preserves digits", () => {
+		expect(slugifyOrgName("Acme 2")).toBe("acme-2");
+	});
+});

--- a/packages/lib/src/db/provisioning.ts
+++ b/packages/lib/src/db/provisioning.ts
@@ -72,12 +72,18 @@ export async function provisionLocalOrg(input: { userId: string }): Promise<{ or
 /**
  * Slugify a brand name into the URL/id form used for new local-mode orgs.
  * Exported so the slug rules can be unit-tested directly without a database.
+ *
+ * Note: leading/trailing hyphens are trimmed via index walks instead of an
+ * `^-+|-+$` alternation regex — the alternation form trips ReDoS scanners
+ * on inputs like `"---"` even though the JS engine handles it linearly.
  */
 export function slugifyOrgName(name: string): string {
-	const slug = name
-		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, "-")
-		.replace(/^-+|-+$/g, "");
+	const cleaned = name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+	let start = 0;
+	while (start < cleaned.length && cleaned[start] === "-") start++;
+	let end = cleaned.length;
+	while (end > start && cleaned[end - 1] === "-") end--;
+	const slug = cleaned.slice(start, end);
 	return slug || "brand";
 }
 

--- a/packages/lib/src/db/provisioning.ts
+++ b/packages/lib/src/db/provisioning.ts
@@ -14,7 +14,7 @@
  * call is a bug and should fail at the database layer rather than
  * silently rewriting rows.
  */
-import { count } from "drizzle-orm";
+import { count, eq, or } from "drizzle-orm";
 import { db } from "./db";
 import { member, organization, user } from "./schema";
 
@@ -67,4 +67,77 @@ export async function provisionLocalOrg(input: { userId: string }): Promise<{ or
 	});
 
 	return { orgId: LOCAL_ORG.id };
+}
+
+/**
+ * Slugify a brand name into the URL/id form used for new local-mode orgs.
+ * Exported so the slug rules can be unit-tested directly without a database.
+ */
+export function slugifyOrgName(name: string): string {
+	const slug = name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return slug || "brand";
+}
+
+/**
+ * Slugs that would collide with sibling routes under `/app/$brand`. A
+ * user-named brand that slugifies to one of these gets a numeric suffix
+ * instead so the URL stays unambiguous.
+ */
+const RESERVED_ORG_SLUGS = new Set(["new"]);
+
+async function findUniqueOrgId(baseSlug: string): Promise<string> {
+	let candidate = baseSlug;
+	let suffix = 2;
+	for (;;) {
+		const isReserved = RESERVED_ORG_SLUGS.has(candidate);
+		const conflict = isReserved
+			? [{ id: candidate }]
+			: await db
+					.select({ id: organization.id })
+					.from(organization)
+					.where(or(eq(organization.id, candidate), eq(organization.slug, candidate)))
+					.limit(1);
+		if (conflict.length === 0) return candidate;
+		candidate = `${baseSlug}-${suffix}`;
+		suffix++;
+	}
+}
+
+/**
+ * Provision an additional organization for an existing local-mode user — used
+ * by the multi-brand "create new brand" flow. The id is a slug derived from
+ * `name`, with a numeric suffix on collision, and is reused as the org slug
+ * so that URLs and the org row stay in sync.
+ *
+ * The brand row itself is the caller's responsibility; provisioning only
+ * handles the auth-level (org + admin membership) bits.
+ */
+export async function provisionAdditionalLocalOrg(input: {
+	userId: string;
+	name: string;
+}): Promise<{ orgId: string }> {
+	const baseSlug = slugifyOrgName(input.name);
+	const orgId = await findUniqueOrgId(baseSlug);
+
+	await db.transaction(async (tx) => {
+		await tx.insert(organization).values({
+			id: orgId,
+			name: input.name,
+			slug: orgId,
+			createdAt: new Date(),
+		});
+
+		await tx.insert(member).values({
+			id: crypto.randomUUID(),
+			organizationId: orgId,
+			userId: input.userId,
+			role: "admin",
+			createdAt: new Date(),
+		});
+	});
+
+	return { orgId };
 }

--- a/packages/local/src/auth-provider.ts
+++ b/packages/local/src/auth-provider.ts
@@ -18,7 +18,8 @@ export function createLocalDeployment(env: Record<string, string | undefined> = 
 		features: {
 			readOnly,
 			showOptimizeButton: false,
-			supportsMultiOrg: readOnly,
+			supportsMultiOrg: true,
+			canCreateBrands: !readOnly,
 		},
 		branding: {
 			name: getEnv("APP_NAME", DEFAULT_APP_NAME, env),

--- a/packages/whitelabel/src/deployment.ts
+++ b/packages/whitelabel/src/deployment.ts
@@ -38,6 +38,7 @@ export function createWhitelabelDeployment(
 			readOnly: false,
 			showOptimizeButton: true,
 			supportsMultiOrg: true,
+			canCreateBrands: false,
 		},
 		branding: {
 			name: requireEnv("VITE_APP_NAME", env),


### PR DESCRIPTION
## Summary
- Flips `supportsMultiOrg` on for local mode and adds a "Create new brand" button on the switcher that routes to a new `/app/new` page (name + website form).
- Introduces a `canCreateBrands` feature flag (local=true, demo/whitelabel=false) and a sibling `evaluateRequireCanCreateBrands` policy so the gate lives next to the other access-control helpers in `policies.ts`.
- New `createBrandWithOrgFn` provisions org + admin membership + brand row via a slug-derived id, with `"new"` reserved to avoid colliding with the route.