### PR TITLE
add onboarding flow logs

### DIFF
--- a/.changeset/analyze-brand-logs.md
+++ b/.changeset/analyze-brand-logs.md
@@ -1,0 +1,5 @@
+---
+"@workspace/lib": patch
+---
+
+Log start/done (with duration and result counts) for `analyzeBrand`, so the onboarding analyze step is visible in the web server logs.

--- a/packages/lib/src/onboarding/analyze.ts
+++ b/packages/lib/src/onboarding/analyze.ts
@@ -179,9 +179,15 @@ export function normalizeAnalysisResult(raw: RawSuggestion, ctx: AnalysisContext
 }
 
 export async function analyzeBrand(options: AnalyzeBrandOptions): Promise<OnboardingSuggestion> {
+	const start = Date.now();
+	console.log(`[onboarding] analyzeBrand start: ${options.website}`);
 	const ctx = await buildAnalysisContext(options);
 	const raw = await runStructuredResearchPrompt(ctx.prompt, ctx.schema);
-	return normalizeAnalysisResult(raw, ctx);
+	const result = normalizeAnalysisResult(raw, ctx);
+	console.log(
+		`[onboarding] analyzeBrand done: ${options.website} in ${Date.now() - start}ms (brand="${result.brandName}", competitors=${result.competitors.length}, prompts=${result.suggestedPrompts.length})`,
+	);
+	return result;
 }
 
 /** Normalize an LLM-supplied tag to lowercase kebab-case. */


### PR DESCRIPTION
## Summary
- The onboarding "analyze brand" step runs as a synchronous TanStack server function — not a pg-boss job — so neither the worker nor the frontend produces any logs for it. Without logs in the web server either, the step was effectively invisible.
- Add two `console.log` lines in `analyzeBrand` (start + done with duration, brand name, and competitor/prompt counts) to make the call observable in the web dev server terminal.