### PR TITLE
remove `elmo status` CLI command

### DIFF
--- a/.changeset/remove-cli-status.md
+++ b/.changeset/remove-cli-status.md
@@ -1,0 +1,6 @@
+---
+"@elmohq/cli": patch
+"@workspace/docs": patch
+---
+
+Remove `elmo status` — use `elmo compose ps` instead.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -58,8 +58,7 @@ For the full self-hosting walkthrough, see the [Elmo docs](https://www.elmohq.co
 | Command | Description |
 | --- | --- |
 | `elmo init` | Interactive wizard to set up a local Elmo instance |
-| `elmo status` | Check the health of running services |
-| `elmo compose <args...>` | Run any `docker compose` command against your Elmo project (e.g. `elmo compose up -d`, `elmo compose down`, `elmo compose logs -f`, `elmo compose build`) |
+| `elmo compose <args...>` | Run any `docker compose` command against your Elmo project (e.g. `elmo compose up -d`, `elmo compose down`, `elmo compose logs -f`, `elmo compose build`, `elmo compose ps`) |
 | `elmo edit <env\|compose>` | Open `.env` or `elmo.yaml` in `$VISUAL` / `$EDITOR` (fallback: `nano`) |
 
 Run `elmo --help` or `elmo <command> --help` for the full list of flags.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -117,14 +117,6 @@ async function main() {
 		});
 
 	program
-		.command("status")
-		.description("check Elmo instance health")
-		.option("--dir <path>", "Config directory")
-		.action(async (options: DirOption) => {
-			await withVersionCheck(version, () => runStatus(options));
-		});
-
-	program
 		.command("compose")
 		.description("run Docker Compose commands using your Elmo config")
 		.allowUnknownOption(true)
@@ -882,34 +874,6 @@ async function doStart(configDir: string): Promise<void> {
 	console.log(`  ${pc.bold("elmo compose down")}`);
 }
 
-// ── Command: status ──────────────────────────────────────────────────────────
-
-async function runStatus(options: DirOption): Promise<void> {
-	const configDir = await resolveConfigDir(options.dir);
-	assertDockerRunning();
-
-	const services = await getComposeServices(configDir);
-	if (services.length === 0) {
-		log.warn("No running services found.");
-		return;
-	}
-
-	let allHealthy = true;
-	for (const service of services) {
-		const status = formatServiceStatus(service);
-		console.log(status);
-		if (!isServiceReady(service)) {
-			allHealthy = false;
-		}
-	}
-
-	if (allHealthy) {
-		log.success("All services are healthy.");
-	} else {
-		log.warn("Some services are not healthy yet.");
-	}
-}
-
 // ── Command: compose ─────────────────────────────────────────────────────────
 
 async function runCompose(args: string[], options: DirOption): Promise<void> {
@@ -1176,21 +1140,6 @@ async function getComposeServices(configDir: string): Promise<ComposeService[]> 
 			return [];
 		}
 	}
-}
-
-function formatServiceStatus(service: ComposeService): string {
-	const health = service.Health ?? "unknown";
-	const state = service.State ?? "unknown";
-	const label = `${service.Service}`.padEnd(16, " ");
-	let color = pc.red;
-
-	if (isServiceReady(service)) {
-		color = pc.green;
-	} else if (health === "starting" || state.includes("starting")) {
-		color = pc.yellow;
-	}
-
-	return color(`${label} ${state} ${service.Health ? `(${health})` : ""}`.trim());
 }
 
 function isServiceReady(service: ComposeService): boolean {

--- a/packages/docs/content/docs/getting-started.mdx
+++ b/packages/docs/content/docs/getting-started.mdx
@@ -69,20 +69,17 @@ This pulls the Docker images and starts all services. Once they report healthy, 
 Once Elmo is running, these commands help you manage it:
 
 ```bash
-# Check service health
-elmo status
-
 # View live logs
 elmo compose logs -f
 
 # View logs for a specific service
 elmo compose logs -f web
 
+# Check service status
+elmo compose ps
+
 # Stop all services
 elmo compose down
-
-# Run any other docker compose command
-elmo compose ps
 ```
 
 ## What's Next


### PR DESCRIPTION
Follow-up to #254. `elmo status` was kept then, but it's not worth carrying — `elmo compose ps` covers the use case. Removes the command and updates the README + getting-started docs.