### PR TITLE
make `--dir` a global CLI option

### DIFF
--- a/.changeset/cli-dir-global-option.md
+++ b/.changeset/cli-dir-global-option.md
@@ -1,0 +1,5 @@
+---
+"@elmohq/cli": patch
+---
+
+Make `--dir` a global CLI option. It applies to `init`, `compose`, and `edit`, and now shows up in `elmo --help` as well as each subcommand's help.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -101,6 +101,8 @@ async function main() {
 	program
 		.name("elmo")
 		.version(version)
+		.option("--dir <path>", "Config directory")
+		.configureHelp({ showGlobalOptions: true })
 		.action(() => {
 			printBanner();
 			program.outputHelp();
@@ -110,29 +112,26 @@ async function main() {
 		.command("init")
 		.description("set up local Elmo instance")
 		.option("--dev", "Use local build context (repo only)")
-		.option("--dir <path>", "Directory to store config files")
 		.option("--docker-dir <path>", "Path to Docker build context (dev mode)")
-		.action(async (options: InitOptions) => {
-			await withVersionCheck(version, () => runInit(options, version));
+		.action(async (_opts: object, cmd: Command) => {
+			await withVersionCheck(version, () => runInit(cmd.optsWithGlobals<InitOptions>(), version));
 		});
 
 	program
 		.command("compose")
 		.description("run Docker Compose commands using your Elmo config")
 		.allowUnknownOption(true)
-		.option("--dir <path>", "Config directory")
 		.argument("[args...]", "Arguments passed to Docker Compose")
-		.action(async (args: string[], options: DirOption) => {
-			await withVersionCheck(version, () => runCompose(args, options));
+		.action(async (args: string[], _opts: object, cmd: Command) => {
+			await withVersionCheck(version, () => runCompose(args, cmd.optsWithGlobals<DirOption>()));
 		});
 
 	program
 		.command("edit")
 		.description("open .env or elmo.yaml in $VISUAL / $EDITOR (fallback: nano)")
 		.argument("<target>", "`env` or `compose`")
-		.option("--dir <path>", "Config directory")
-		.action(async (target: string, options: DirOption) => {
-			await runEdit(target, options);
+		.action(async (target: string, _opts: object, cmd: Command) => {
+			await runEdit(target, cmd.optsWithGlobals<DirOption>());
 		});
 
 	await program.parseAsync(process.argv);


### PR DESCRIPTION
## Summary

`--dir` was registered separately on `init`, `compose`, and `edit`, so it didn't appear in `elmo --help` even though the README documents it as a flag for any command. Hoist it to a program-level option and turn on `showGlobalOptions` so it shows up in top-level help and under "Global Options" in every subcommand's help. Action handlers now read merged opts via `cmd.optsWithGlobals()`. Commander accepts the flag in either position (`elmo --dir /foo init` or `elmo init --dir /foo`), so no UX change.