### PR TITLE
pin compose image tags to CLI version

### DIFF
--- a/.changeset/cli-pin-image-versions.md
+++ b/.changeset/cli-pin-image-versions.md
@@ -1,0 +1,5 @@
+---
+"@elmohq/cli": patch
+---
+
+Pin generated `docker-compose.yml` image tags to the CLI's version (e.g. `elmohq/elmo-web:0.2.10`) instead of `latest`, so stacks stay on the version they were initialized with until the user upgrades.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -949,6 +949,7 @@ function buildComposeYaml(options: {
 				dev: options.dev,
 				dockerfilePath,
 				repoRoot: options.repoRoot,
+				version: options.version,
 			}),
 		);
 		dependsOnWeb.push("db-migrate");
@@ -964,6 +965,7 @@ function buildComposeYaml(options: {
 			repoRoot: options.repoRoot,
 			dockerfilePath,
 			port: options.port,
+			version: options.version,
 		}),
 	);
 	services.push(
@@ -973,6 +975,7 @@ function buildComposeYaml(options: {
 			dependencyConditions,
 			repoRoot: options.repoRoot,
 			dockerfilePath,
+			version: options.version,
 		}),
 	);
 
@@ -1010,7 +1013,12 @@ function buildPostgresService(): string {
 	].join("\n");
 }
 
-function buildDbMigrateService(options: { dev: boolean; dockerfilePath: string; repoRoot: string }): string {
+function buildDbMigrateService(options: {
+	dev: boolean;
+	dockerfilePath: string;
+	repoRoot: string;
+	version: string;
+}): string {
 	const lines = ["db-migrate:"];
 	if (options.dev) {
 		lines.push(
@@ -1020,7 +1028,7 @@ function buildDbMigrateService(options: { dev: boolean; dockerfilePath: string; 
 			"    target: migrate",
 		);
 	} else {
-		lines.push("  image: elmohq/elmo-db-migrate:latest");
+		lines.push(`  image: elmohq/elmo-db-migrate:${options.version}`);
 	}
 
 	lines.push(
@@ -1041,6 +1049,7 @@ function buildWebService(options: {
 	repoRoot: string;
 	dockerfilePath: string;
 	port: number;
+	version: string;
 }): string {
 	const lines = ["web:"];
 	if (options.dev) {
@@ -1053,7 +1062,7 @@ function buildWebService(options: {
 			"      DEPLOYMENT_MODE: local",
 		);
 	} else {
-		lines.push("  image: elmohq/elmo-web:latest");
+		lines.push(`  image: elmohq/elmo-web:${options.version}`);
 	}
 
 	lines.push("  env_file:", "    - path: .env", "      required: true", "  ports:", `    - "${options.port}:3000"`);
@@ -1075,6 +1084,7 @@ function buildWorkerService(options: {
 	dependencyConditions: Record<string, string>;
 	repoRoot: string;
 	dockerfilePath: string;
+	version: string;
 }): string {
 	const lines = ["worker:"];
 	if (options.dev) {
@@ -1087,7 +1097,7 @@ function buildWorkerService(options: {
 			"      DEPLOYMENT_MODE: local",
 		);
 	} else {
-		lines.push("  image: elmohq/elmo-worker:latest");
+		lines.push(`  image: elmohq/elmo-worker:${options.version}`);
 	}
 
 	lines.push("  env_file:", "    - path: .env", "      required: true");


### PR DESCRIPTION
## Summary
- Generated `docker-compose.yml` now pins `elmohq/elmo-web`, `elmohq/elmo-worker`, and `elmohq/elmo-db-migrate` to the CLI's own version instead of `:latest`.
- The release workflow already pushes both `:latest` and `:${VERSION}` for each image (`.github/workflows/publish.yaml`), so the version-pinned tag is guaranteed to exist for any released CLI.
- Stacks initialized with a given CLI version stay on that image version across `docker compose pull` / restarts until the user reinitializes with a newer CLI.

In the future we'll add an `upgrade` command.