### PR TITLE
serve docs pages as markdown for LLMs

### DIFF
--- a/apps/www/src/components/docs-page-layout.tsx
+++ b/apps/www/src/components/docs-page-layout.tsx
@@ -25,6 +25,12 @@ import type { LoaderData } from "@/routes/docs/$";
 const REPO = "elmohq/elmo";
 const BRANCH = "main";
 
+// /docs/foo → /docs/foo.md  (/docs index → /docs.md). The same markdown the
+// .md/.mdx routes and the Accept-header negotiation serve (see server.ts).
+function docsMarkdownPath(slugs: string[]): string {
+	return slugs.length ? `/docs/${slugs.join("/")}.md` : "/docs.md";
+}
+
 async function onFeedback(feedback: PageFeedback): Promise<ActionResponse> {
 	const { trackEvent } = await import("@/lib/posthog");
 	trackEvent("docs_page_feedback", {
@@ -64,7 +70,13 @@ export const clientLoader = browserCollections.docs.createClientLoader({
 	},
 });
 
-function DocsPageActions({ filePath }: { filePath: string }) {
+function DocsPageActions({
+	filePath,
+	mdUrl,
+}: {
+	filePath: string;
+	mdUrl: string;
+}) {
 	const editUrl = `https://github.com/${REPO}/edit/${BRANCH}/${filePath}`;
 	const issueUrl = `https://github.com/${REPO}/issues/new?labels=docs&title=Docs+issue:+`;
 	const discordUrl = "https://discord.gg/s24nubCtKz";
@@ -81,6 +93,18 @@ function DocsPageActions({ filePath }: { filePath: string }) {
 					<path d="M12 20h9" /><path d="M16.376 3.622a1 1 0 0 1 3.002 3.002L7.368 18.635a2 2 0 0 1-.855.506l-2.872.838a.5.5 0 0 1-.62-.62l.838-2.872a2 2 0 0 1 .506-.855z" />
 				</svg>
 				Edit this page
+			</a>
+			<span className="text-border">·</span>
+			<a
+				href={mdUrl}
+				target="_blank"
+				rel="noopener"
+				className="inline-flex items-center gap-1.5 transition-colors hover:text-foreground"
+			>
+				<svg className="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+					<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7z" /><path d="M14 2v5h5" /><path d="M9 13h6" /><path d="M9 17h6" />
+				</svg>
+				View as Markdown
 			</a>
 			<span className="text-border">·</span>
 			<a
@@ -157,7 +181,10 @@ export function DocsPageLayout({ loaderData }: { loaderData: LoaderData }) {
 							) : (
 								<>
 									<Suspense>{clientLoader.useContent(data.path)}</Suspense>
-									<DocsPageActions filePath={data.filePath} />
+									<DocsPageActions
+										filePath={data.filePath}
+										mdUrl={docsMarkdownPath(data.slugs)}
+									/>
 								</>
 							)}
 						</main>

--- a/apps/www/src/server.ts
+++ b/apps/www/src/server.ts
@@ -1,4 +1,5 @@
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
+import { isMarkdownPreferred, rewritePath } from "fumadocs-core/negotiation";
 
 const SECURITY_HEADERS: Record<string, string> = {
 	"Content-Security-Policy": [
@@ -29,9 +30,51 @@ function addSecurityHeaders(response: Response): Response {
 	return response;
 }
 
+// Serve the raw markdown for a docs page from the existing /llms.mdx/docs/*
+// route. Three things resolve to the same markdown, all via an internal rewrite
+// (the URL the client sees never changes — no redirect):
+//   • /docs/foo.md  and  /docs/foo.mdx  — explicit suffix, always markdown
+//   • /docs/foo  with `Accept: text/markdown` — content negotiation for agents
+// Pages are resolved by slug, so the `.md` suffix works even though every
+// source file is `.mdx`. See https://fumadocs.dev/docs/integrations/llms#accept
+const { rewrite: stripMdSuffix } = rewritePath(
+	"/docs{/*path}.md",
+	"/llms.mdx/docs{/*path}",
+);
+const { rewrite: stripMdxSuffix } = rewritePath(
+	"/docs{/*path}.mdx",
+	"/llms.mdx/docs{/*path}",
+);
+const { rewrite: toMarkdownRoute } = rewritePath(
+	"/docs{/*path}",
+	"/llms.mdx/docs{/*path}",
+);
+
 export default createServerEntry({
 	async fetch(request) {
-		const response = await handler.fetch(request);
+		const url = new URL(request.url);
+		const path = url.pathname;
+
+		// An explicit .md / .mdx suffix always serves markdown, ignoring Accept.
+		let target = stripMdSuffix(path) || stripMdxSuffix(path);
+
+		// A bare docs page negotiates HTML vs. markdown on the Accept header.
+		const negotiable =
+			!target && (path === "/docs" || path.startsWith("/docs/"));
+		if (negotiable && isMarkdownPreferred(request)) {
+			target = toMarkdownRoute(path);
+		}
+
+		let req = request;
+		if (target) {
+			url.pathname = target;
+			req = new Request(url, request);
+		}
+
+		const response = await handler.fetch(req);
+		// A bare docs URL can resolve to either HTML or markdown depending on
+		// the Accept header, so shared caches must key on it.
+		if (negotiable) response.headers.set("Vary", "Accept");
 		return addSecurityHeaders(response);
 	},
 });

--- a/apps/www/src/start.ts
+++ b/apps/www/src/start.ts
@@ -1,25 +1,10 @@
-import { createMiddleware, createStart } from "@tanstack/react-start";
-import { rewritePath } from "fumadocs-core/negotiation";
-import { redirect } from "@tanstack/react-router";
+import { createStart } from "@tanstack/react-start";
 
-const { rewrite: rewriteLLM } = rewritePath(
-	"/docs{/*path}.mdx",
-	"/llms.mdx/docs{/*path}",
-);
-
-const llmMiddleware = createMiddleware().server(({ next, request }) => {
-	const url = new URL(request.url);
-	const path = rewriteLLM(url.pathname);
-
-	if (path) {
-		throw redirect(new URL(path, url));
-	}
-
-	return next();
-});
-
+// Global TanStack Start configuration. Markdown content negotiation for docs
+// pages — the `.md`/`.mdx` URL suffix and the `Accept: text/markdown` header —
+// is handled in server.ts, where a request can be rewritten to the markdown
+// route at the *same* URL. Request middleware here can only redirect, not
+// rewrite, so it isn't the right place for that.
 export const startInstance = createStart(() => {
-	return {
-		requestMiddleware: [llmMiddleware],
-	};
+	return {};
 });


### PR DESCRIPTION
## What

Serve every docs page as raw markdown to LLMs/agents, via content negotiation in `server.ts`.

Three entry points now resolve to the page's markdown, all via an **internal rewrite** to the existing `/llms.mdx/docs/*` route — the URL the client sees never changes, and there's **no redirect**:

| Request | Result |
|---|---|
| `GET /docs/getting-started.md` | `200` markdown |
| `GET /docs/getting-started.mdx` | `200` markdown |
| `GET /docs/getting-started` + `Accept: text/markdown` | `200` markdown (same URL) |
| `GET /docs/getting-started` (browser) | `200` HTML, as before |

Pages resolve by **slug**, so `.md` works even though every source file is `.mdx`. A `Vary: Accept` header is set on the negotiable docs URLs so shared caches key on it.

This moves the old `.mdx`-suffix redirect out of `start.ts` (now a stub): TanStack request middleware can only `redirect`, whereas the server entry can rewrite and keep the URL — which is what fumadocs' [`#accept`](https://www.fumadocs.dev/docs/integrations/llms#accept) calls for.

Also adds a **"View as Markdown"** link to the docs footer (alongside Edit / Report / Discord).

## Files

- `apps/www/src/server.ts` — `.md`/`.mdx`/`Accept` → in-place markdown rewrite
- `apps/www/src/start.ts` — slimmed to a stub (negotiation moved to the server entry)
- `apps/www/src/components/docs-page-layout.tsx` — footer "View as Markdown" link + shared `docsMarkdownPath` helper

## Verify

```bash
curl -sS -D - -o /dev/null https://<host>/docs/getting-started.md   # 200 + content-type: text/markdown, no Location
curl -H "Accept: text/markdown" https://<host>/docs/getting-started # markdown at the same URL
```

## Notes

- Content files are unchanged; this is all routing + a footer link.
- No changeset included (per discussion).