### PR TITLE
embed the video walkthrough atop the first blog post and fix a typo

### DIFF
--- a/apps/www/src/components/mdx.tsx
+++ b/apps/www/src/components/mdx.tsx
@@ -2,6 +2,7 @@ import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
 import { FeedbackBlock } from "@workspace/docs/components/feedback/client";
 import type { ActionResponse, BlockFeedback } from "@workspace/docs/components/feedback/schema";
+import { YouTubeEmbed } from "@/components/youtube-embed";
 
 async function onBlockFeedback(
 	feedback: BlockFeedback,
@@ -22,6 +23,7 @@ export function getMDXComponents(components?: MDXComponents) {
 		FeedbackBlock: (props: { id: string; body?: string; children: React.ReactNode }) => (
 			<FeedbackBlock {...props} onSendAction={onBlockFeedback} />
 		),
+		YouTube: YouTubeEmbed,
 		...components,
 	} satisfies MDXComponents;
 }

--- a/apps/www/src/components/youtube-embed.tsx
+++ b/apps/www/src/components/youtube-embed.tsx
@@ -1,0 +1,28 @@
+interface YouTubeEmbedProps {
+	/** YouTube video ID — the `v` query param of a watch URL (e.g. "4-9kJG6CL6U"). */
+	id: string;
+	/** Accessible title for the player iframe. */
+	title?: string;
+}
+
+// Responsive 16:9 YouTube player, registered as the `YouTube` MDX component in
+// @/components/mdx so posts can embed a video with <YouTube id="..." />. Mirrors
+// the bordered media frame used by the homepage feature graphics (Frame in
+// feature-graphics.tsx). Uses the privacy-enhanced youtube-nocookie host and
+// lazy-loads the iframe so it doesn't block initial render; `not-prose` opts the
+// frame out of the typography plugin's spacing so its own margin applies.
+export function YouTubeEmbed({ id, title = "YouTube video player" }: YouTubeEmbedProps) {
+	return (
+		<div className="not-prose relative mb-8 aspect-video w-full overflow-hidden rounded-md border border-zinc-200 bg-zinc-950">
+			<iframe
+				className="absolute inset-0 size-full"
+				src={`https://www.youtube-nocookie.com/embed/${id}`}
+				title={title}
+				loading="lazy"
+				allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+				referrerPolicy="strict-origin-when-cross-origin"
+				allowFullScreen
+			/>
+		</div>
+	);
+}

--- a/apps/www/src/server.ts
+++ b/apps/www/src/server.ts
@@ -11,6 +11,8 @@ const SECURITY_HEADERS: Record<string, string> = {
 		"connect-src 'self' https://var.elmohq.com https://*.mux.com https://*.litix.io",
 		"media-src 'self' blob: https://*.mux.com",
 		"worker-src 'self' blob:",
+		// YouTube embeds in blog posts (privacy-enhanced youtube-nocookie host).
+		"frame-src 'self' https://www.youtube-nocookie.com https://www.youtube.com",
 		"object-src 'none'",
 		"frame-ancestors 'none'",
 		"base-uri 'self'",

--- a/packages/docs/content/blog/do-llms-txt-files-matter-for-aeo.mdx
+++ b/packages/docs/content/blog/do-llms-txt-files-matter-for-aeo.mdx
@@ -8,6 +8,8 @@ tags:
   - llms-txt
 ---
 
+<YouTube id="4-9kJG6CL6U" title="Do llms.txt files matter for AEO?" />
+
 The intention of [llms.txt](https://llmstxt.org/) files is to provide a guide to the site's contents in LLM-friendly plain text (typically markdown).
 
 However, there are some common misunderstandings about these files and how they are used. For example, Google's recent [AI SEO guide](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide) mentions that you don't need an llms.txt file, while Google Chrome's Agentic Browsing audit actually [checks for an llms.txt](https://developer.chrome.com/docs/lighthouse/agentic-browsing/llms-txt). The server logs for many websites show no hits on llms.txt files at all.
@@ -34,7 +36,7 @@ Most up-to-date LLMs are "aware" that llms.txt files exist (you can test this by
 
 ## 3. Agentic harness (nope)
 
-Most tools like Claude Code or Codex do not contain instructions to look at llms.txt. You can look at the leaked Claude Code source code and leaked system prompts for these types of tools. Typically they include guidance and tooling around performing web searches or a sequence of searches, but they usually do not mention llms.txt at all.
+Most tools like Claude Code or Codex do not contain instructions to look at llms.txt. You can look at the leaked Claude Code source code and leaked system prompts for these types of tools. Typically they include guidance and tooling around performing web searches for a sequence of searches, but they usually do not mention llms.txt at all.
 
 ## 4. AGENTS.md / skills / etc. (sometimes)
 


### PR DESCRIPTION
Embeds the [YouTube video version](https://www.youtube.com/watch?v=4-9kJG6CL6U) at the top of the first blog post ("Do llms.txt files matter for AEO?") and fixes a typo.