### PR TITLE
link llms.txt in the footer and point its docs links at .md versions

### DIFF
--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -31,6 +31,7 @@ const cols = [
 		links: [
 			{ label: "Vision", href: "/vision" },
 			{ label: "Brand Assets", href: "/brand" },
+			{ label: "llms.txt", href: "/llms.txt" },
 		],
 	},
 ];

--- a/apps/www/src/routes/llms[.]txt.ts
+++ b/apps/www/src/routes/llms[.]txt.ts
@@ -19,11 +19,11 @@ Elmo is Answer Engine Optimization (AEO), also called generative engine optimiza
 
 ## Documentation
 
-- [Documentation](https://www.elmohq.com/docs): Introduction to Elmo, the open source AI visibility platform.
-- [Quick Start](https://www.elmohq.com/docs/getting-started): Get Elmo running on your own infrastructure in under 5 minutes using the CLI.
-- [User Guide](https://www.elmohq.com/docs/user-guide): A complete walkthrough, from first login to daily visibility tracking, prompts, citations, competitors, and reports.
-- [Developer Guide](https://www.elmohq.com/docs/developer-guide): Run, configure, integrate with, and contribute to Elmo, including architecture and self-hosting setup.
-- [API Reference](https://www.elmohq.com/docs/api): Complete REST API documentation for Elmo's administrative API.
+- [Documentation](https://www.elmohq.com/docs.md): Introduction to Elmo, the open source AI visibility platform.
+- [Quick Start](https://www.elmohq.com/docs/getting-started.md): Get Elmo running on your own infrastructure in under 5 minutes using the CLI.
+- [User Guide](https://www.elmohq.com/docs/user-guide.md): A complete walkthrough, from first login to daily visibility tracking, prompts, citations, competitors, and reports.
+- [Developer Guide](https://www.elmohq.com/docs/developer-guide.md): Run, configure, integrate with, and contribute to Elmo, including architecture and self-hosting setup.
+- [API Reference](https://www.elmohq.com/docs/api.md): Complete REST API documentation for Elmo's administrative API.
 - [llms-full.txt](https://www.elmohq.com/llms-full.txt): The full text of all Elmo documentation in a single file.
 
 ## Resources


### PR DESCRIPTION
Adds an `llms.txt` link to the **Company** column of the marketing site footer so the curated `/llms.txt` is discoverable from the site.

Updates the **Documentation** links inside `/llms.txt` to point at the raw-markdown (`.md`) variants of each docs page so AI agents fetch clean markdown instead of HTML. The five docs links (`/docs`, `/docs/getting-started`, `/docs/user-guide`, `/docs/developer-guide`, `/docs/api`) resolve via the existing `.md` rewrite in `server.ts`; the `llms-full.txt` link and marketing-page links are left unchanged. Verified with `pnpm --filter @workspace/www build`.