### PR TITLE
Fix marketing-site SEO: canonical, sitemap, OG tags, titles

### DIFF
--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -1,5 +1,10 @@
 import { Link } from "@tanstack/react-router";
 import { Logo } from "./logo";
+import { externalRel } from "@/lib/external-link";
+
+// Our parent company. externalRel keeps the Referer (bluewhale.dev is owned);
+// the ?ref=elmo param is a belt-and-suspenders fallback.
+const BLUEWHALE_URL = "https://bluewhale.dev?ref=elmo";
 
 const cols = [
 	{
@@ -68,7 +73,7 @@ export function Footer() {
 												<a
 													href={link.href}
 													target="_blank"
-													rel="noopener noreferrer"
+													rel={externalRel(link.href)}
 													className="hover:text-zinc-950 hover:underline"
 												>
 													{link.label}
@@ -104,9 +109,9 @@ export function Footer() {
 					<p className="font-mono text-[11px] text-zinc-500">
 						&copy; {new Date().getFullYear()}{" "}
 						<a
-							href="https://bluewhale.dev?ref=elmo"
+							href={BLUEWHALE_URL}
 							target="_blank"
-							rel="noopener noreferrer"
+							rel={externalRel(BLUEWHALE_URL)}
 							className="hover:text-zinc-900 hover:underline"
 						>
 							Blue Whale Software, LLC

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -3,19 +3,7 @@ import { ArrowUpRight, ArrowRight } from "lucide-react";
 import MuxPlayer from "@mux/mux-player-react";
 import { CustomerLogosInline } from "./customer-logos";
 import { QuickstartBlock } from "./quickstart-block";
-
-// Links to our own elmohq.com subdomains (e.g. the demo) keep the Referer so
-// the destination's analytics can attribute the visit — strip it only for
-// third-party domains.
-function externalRel(href: string): string {
-	try {
-		const { hostname } = new URL(href);
-		const sameOrg = hostname === "elmohq.com" || hostname.endsWith(".elmohq.com");
-		return sameOrg ? "noopener" : "noopener noreferrer";
-	} catch {
-		return "noopener noreferrer";
-	}
-}
+import { externalRel } from "@/lib/external-link";
 
 function PrimaryCTA({
 	to,

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -4,6 +4,19 @@ import MuxPlayer from "@mux/mux-player-react";
 import { CustomerLogosInline } from "./customer-logos";
 import { QuickstartBlock } from "./quickstart-block";
 
+// Links to our own elmohq.com subdomains (e.g. the demo) keep the Referer so
+// the destination's analytics can attribute the visit — strip it only for
+// third-party domains.
+function externalRel(href: string): string {
+	try {
+		const { hostname } = new URL(href);
+		const sameOrg = hostname === "elmohq.com" || hostname.endsWith(".elmohq.com");
+		return sameOrg ? "noopener" : "noopener noreferrer";
+	} catch {
+		return "noopener noreferrer";
+	}
+}
+
 function PrimaryCTA({
 	to,
 	href,
@@ -30,7 +43,7 @@ function PrimaryCTA({
 			<a
 				href={href}
 				className={cls}
-				{...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+				{...(external ? { target: "_blank", rel: externalRel(href) } : {})}
 			>
 				{children}
 			</a>
@@ -65,7 +78,7 @@ function GhostCTA({
 			<a
 				href={href}
 				className={cls}
-				{...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+				{...(external ? { target: "_blank", rel: externalRel(href) } : {})}
 			>
 				{children}
 			</a>

--- a/apps/www/src/lib/external-link.ts
+++ b/apps/www/src/lib/external-link.ts
@@ -1,0 +1,23 @@
+// Domains we own or co-own. Outbound links to these keep the Referer header —
+// rel="noopener" only, never "noreferrer" — so the destination's analytics can
+// attribute the visit back to this site. Every other external link gets the
+// full rel="noopener noreferrer". Subdomains count (e.g. demo.elmohq.com).
+const OWNED_DOMAINS = ["elmohq.com", "bluewhale.dev", "jrhizor.dev"];
+
+function isOwnedHost(hostname: string): boolean {
+	return OWNED_DOMAINS.some(
+		(domain) => hostname === domain || hostname.endsWith(`.${domain}`),
+	);
+}
+
+/**
+ * `rel` value for an outbound link. Owned domains keep the Referer (so their
+ * analytics can attribute the traffic); everything else is fully isolated.
+ */
+export function externalRel(href: string): string {
+	try {
+		return isOwnedHost(new URL(href).hostname) ? "noopener" : "noopener noreferrer";
+	} catch {
+		return "noopener noreferrer";
+	}
+}

--- a/apps/www/src/lib/seo.ts
+++ b/apps/www/src/lib/seo.ts
@@ -36,7 +36,7 @@ export function ogMeta({
 		{ property: "og:image", content: absoluteImage },
 		{ property: "og:image:width", content: "1200" },
 		{ property: "og:image:height", content: "630" },
-		{ property: "og:logo", content: SITE_LOGO_URL },
+		{ property: "og:image:alt", content: title },
 		{ name: "twitter:card", content: "summary_large_image" },
 		{ name: "twitter:title", content: title },
 		{ name: "twitter:description", content: description },

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -11,7 +11,6 @@ import {
 	SITE_URL,
 	SITE_NAME,
 	SITE_DESCRIPTION,
-	SITE_LOGO_URL,
 	websiteJsonLd,
 	organizationJsonLd,
 } from "@/lib/seo";
@@ -49,7 +48,7 @@ export const Route = createRootRoute({
 			{ property: "og:image", content: ROOT_OG_IMAGE },
 			{ property: "og:image:width", content: "1200" },
 			{ property: "og:image:height", content: "630" },
-			{ property: "og:logo", content: SITE_LOGO_URL },
+			{ property: "og:image:alt", content: ROOT_TITLE },
 			{ name: "twitter:card", content: "summary_large_image" },
 			{ name: "twitter:title", content: ROOT_TITLE },
 			{ name: "twitter:description", content: SITE_DESCRIPTION },
@@ -84,7 +83,6 @@ export const Route = createRootRoute({
 			{ rel: "icon", type: "image/x-icon", href: "/favicon.ico" },
 			{ rel: "apple-touch-icon", href: "/apple-touch-icon.png" },
 			{ rel: "manifest", href: "/site.webmanifest" },
-			{ rel: "canonical", href: SITE_URL },
 			{ rel: "stylesheet", href: appCss },
 		],
 		scripts: [

--- a/apps/www/src/routes/features.tsx
+++ b/apps/www/src/routes/features.tsx
@@ -5,7 +5,7 @@ import { CTA } from "@/components/cta";
 import { Footer } from "@/components/footer";
 import { ogMeta, canonicalUrl, breadcrumbJsonLd } from "@/lib/seo";
 
-const title = "Features · Elmo";
+const title = "Features — AI Visibility & Citation Tracking · Elmo";
 const description =
 	"AI visibility tracking, citation analysis, competitor intelligence, and more. Everything you need to monitor your brand in AI search.";
 

--- a/apps/www/src/routes/pricing.tsx
+++ b/apps/www/src/routes/pricing.tsx
@@ -5,7 +5,7 @@ import { CTA } from "@/components/cta";
 import { Footer } from "@/components/footer";
 import { ogMeta, canonicalUrl, breadcrumbJsonLd } from "@/lib/seo";
 
-const title = "Pricing · Elmo";
+const title = "Pricing — Free & Open-Source AI Visibility · Elmo";
 const description =
 	"Elmo is free and open source to self-host. Managed cloud hosting coming soon. White-label available for agencies.";
 

--- a/apps/www/src/routes/sitemap[.]xml.ts
+++ b/apps/www/src/routes/sitemap[.]xml.ts
@@ -5,7 +5,19 @@ import { competitors, getComparisonSlug, isLowDR } from "@/lib/competitors";
 
 const SITE_URL = "https://www.elmohq.com";
 
-const staticPages = [
+interface SitemapEntry {
+	path: string;
+	changefreq: string;
+	priority: number;
+	/**
+	 * W3C date (YYYY-MM-DD). Only set when we have a real per-page date. A faked
+	 * uniform lastmod (e.g. "today" on every URL) is an unreliable signal that
+	 * Google discards, so pages without a genuine date omit it entirely.
+	 */
+	lastmod?: string;
+}
+
+const staticPages: SitemapEntry[] = [
 	{ path: "/", changefreq: "weekly", priority: 1.0 },
 	{ path: "/features", changefreq: "monthly", priority: 0.8 },
 	{ path: "/pricing", changefreq: "monthly", priority: 0.8 },
@@ -14,6 +26,7 @@ const staticPages = [
 	{ path: "/docs", changefreq: "weekly", priority: 0.9 },
 	{ path: "/blog", changefreq: "weekly", priority: 0.7 },
 	{ path: "/ai-visibility-tools", changefreq: "weekly", priority: 0.8 },
+	{ path: "/vision", changefreq: "monthly", priority: 0.6 },
 	{ path: "/brand", changefreq: "monthly", priority: 0.5 },
 	{ path: "/status", changefreq: "daily", priority: 0.5 },
 ];
@@ -22,19 +35,21 @@ export const Route = createFileRoute("/sitemap.xml")({
 	server: {
 		handlers: {
 			GET: async () => {
-			const docsPages = source.getPages().map((page) => ({
+			const docsPages: SitemapEntry[] = source.getPages().map((page) => ({
 				path: page.url,
 				changefreq: "weekly",
 				priority: 0.7,
 			}));
 
-			const blogPages = blogSource.getPages().map((page) => ({
+			const blogPages: SitemapEntry[] = blogSource.getPages().map((page) => ({
 				path: page.url,
 				changefreq: "monthly",
 				priority: 0.7,
+				// Real published date from frontmatter (schema normalizes to YYYY-MM-DD).
+				lastmod: page.data.date,
 			}));
 
-			const comparisonPages = competitors
+			const comparisonPages: SitemapEntry[] = competitors
 				.filter((c) => c.status !== "shutting-down" && c.category !== "other" && !isLowDR(c))
 				.map((c) => ({
 					path: `/ai-visibility-tools/${getComparisonSlug(c)}`,
@@ -42,21 +57,19 @@ export const Route = createFileRoute("/sitemap.xml")({
 					priority: 0.6,
 				}));
 
-			const allPages = [
+			const allPages: SitemapEntry[] = [
 				...staticPages,
 				...docsPages,
 				...blogPages,
 				...comparisonPages,
 			];
-				const now = new Date().toISOString().split("T")[0];
 
 				const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${allPages
 	.map(
 		(page) => `  <url>
-    <loc>${SITE_URL}${page.path}</loc>
-    <lastmod>${now}</lastmod>
+    <loc>${SITE_URL}${page.path}</loc>${page.lastmod ? `\n    <lastmod>${page.lastmod}</lastmod>` : ""}
     <changefreq>${page.changefreq}</changefreq>
     <priority>${page.priority}</priority>
   </url>`,


### PR DESCRIPTION
## Summary

Fixes a set of SEO issues on the `www` marketing site, surfaced by an SEO audit. The headline item is a duplicate-canonical bug affecting every page.

## What changed

### 🔴 Duplicate canonical on every page — `__root.tsx`
The root layout hard-set `<link rel="canonical" href="https://www.elmohq.com">`. TanStack Router dedupes `meta` (by name/property) but **concatenates `links`**, so this leaked onto every page *in addition* to each route's own canonical — every page emitted two conflicting canonicals, the first wrongly pointing at the homepage. Verified against live HTML:

```
/features (before):
  <link rel="canonical" href="https://www.elmohq.com"/>           <- root, wrong
  <link rel="canonical" href="https://www.elmohq.com/features"/>  <- correct
```

Every HTML route already self-canonicals, so the root one is removed. Each page now emits exactly one.

### 🟠 Fake sitemap `lastmod` — `sitemap[.]xml.ts`
All URLs reported `<lastmod>` = today, regenerated each request — an unreliable signal Google discards. Now only blog posts carry `<lastmod>` (from frontmatter `date`); everything else omits it (docs file-mtimes reset to deploy-time in CI, so they'd only recreate the same fake-uniform value). Also added `/vision`, which was missing from the sitemap.

### og:logo → og:image:alt — `seo.ts`, `__root.tsx`
Dropped the non-standard `og:logo`; added descriptive `og:image:alt` on every page.

### Richer titles — `features.tsx`, `pricing.tsx`
- `Features · Elmo` → `Features — AI Visibility & Citation Tracking · Elmo`
- `Pricing · Elmo` → `Pricing — Free & Open-Source AI Visibility · Elmo`

### Demo link referrer — `hero.tsx`
The "Live demo" link to `demo.elmohq.com` rendered `rel="noopener noreferrer"`, stripping the Referer so the demo's analytics counted it as direct traffic. Added an `externalRel()` helper: elmohq-owned hosts get `noopener` (referrer preserved), third parties keep `noopener noreferrer`.