### PR TITLE
Optimize the www site for AI answer engines (FAQ schema, comparison verdicts, entity markup)

### DIFF
--- a/apps/www/src/components/competitor-comparison.tsx
+++ b/apps/www/src/components/competitor-comparison.tsx
@@ -10,9 +10,12 @@ import {
 	isLowDR,
 	getPopularityGrade,
 	getScreenshotUrl,
+	getComparisonFaqs,
+	getComparisonVerdict,
 	type Competitor,
 	type FeatureKey,
 } from "@/lib/competitors";
+import { Faq } from "./faq";
 
 function FeatureRow({
 	label,
@@ -94,8 +97,7 @@ export function CompetitorComparison({
 						Elmo vs {competitor.name}
 					</h1>
 					<p className="mt-4 max-w-3xl text-lg text-balance text-zinc-600">
-						How Elmo's open-source AEO platform compares to{" "}
-						{competitor.name} for AI visibility tracking.
+						{getComparisonVerdict(competitor)}
 					</p>
 				{competitor.status === "shutting-down" && (
 					<div className="mt-4 rounded-md border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
@@ -381,6 +383,9 @@ export function CompetitorComparison({
 					</div>
 				</div>
 			</section>
+
+			{/* FAQ */}
+			<Faq items={getComparisonFaqs(competitor)} eyebrow="/ FAQ" />
 
 			{/* CTA */}
 			<section className="border-b border-zinc-200 bg-white py-16 lg:py-24">

--- a/apps/www/src/components/faq.tsx
+++ b/apps/www/src/components/faq.tsx
@@ -1,0 +1,45 @@
+import type { FaqItem } from "@/lib/faqs";
+
+/**
+ * Renders an FAQ as a semantic definition list. Pair it with `faqJsonLd(items)`
+ * in the route head, passing the same `items`, so the visible Q&A and the
+ * FAQPage structured data stay in sync.
+ */
+export function Faq({
+	items,
+	title = "Frequently Asked Questions",
+	eyebrow,
+}: {
+	items: FaqItem[];
+	title?: string;
+	eyebrow?: string;
+}) {
+	if (items.length === 0) return null;
+
+	return (
+		<section className="border-b border-zinc-200 bg-white py-12 lg:py-16">
+			<div className="mx-auto max-w-6xl px-4 md:px-6">
+				{eyebrow ? (
+					<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">
+						{eyebrow}
+					</p>
+				) : null}
+				<h2 className="font-heading mt-2 text-2xl text-zinc-950 md:text-3xl">
+					{title}
+				</h2>
+				<dl className="mt-8 divide-y divide-zinc-200 border-t border-zinc-200">
+					{items.map((item) => (
+						<div key={item.question} className="py-5">
+							<dt className="text-base font-semibold text-zinc-950">
+								{item.question}
+							</dt>
+							<dd className="mt-2 max-w-3xl leading-relaxed text-zinc-600">
+								{item.answer}
+							</dd>
+						</div>
+					))}
+				</dl>
+			</div>
+		</section>
+	);
+}

--- a/apps/www/src/lib/competitors/content.ts
+++ b/apps/www/src/lib/competitors/content.ts
@@ -1,0 +1,81 @@
+import type { FaqItem } from "@/lib/faqs";
+import type { Competitor, CompetitorCategory } from "./types";
+
+// Prose-friendly category nouns (acronyms kept uppercase, descriptive words
+// lowercased) so they read naturally mid-sentence — e.g. "an AI visibility
+// tracking tool", "a traditional SEO tool".
+const CATEGORY_NOUN: Record<CompetitorCategory, string> = {
+	tracking: "AI visibility tracking",
+	content: "content generation",
+	"api-developer": "developer API",
+	ecommerce: "e-commerce",
+	"seo-traditional": "traditional SEO",
+	"open-source": "open-source",
+	other: "AI visibility",
+};
+
+function indefiniteArticle(phrase: string): "a" | "an" {
+	return /^[aeiou]/i.test(phrase) ? "an" : "a";
+}
+
+function isOpenSource(competitor: Competitor): boolean {
+	return (
+		(competitor.features.openSource ?? false) ||
+		competitor.category === "open-source"
+	);
+}
+
+/**
+ * A 40–60 word lead "answer block" for a comparison page, written to be lifted
+ * verbatim into an AI answer for "Elmo vs {competitor}" style queries. Branches
+ * on whether the competitor is itself open source so the claim stays accurate.
+ */
+export function getComparisonVerdict(competitor: Competitor): string {
+	const name = competitor.name;
+
+	if (isOpenSource(competitor)) {
+		return `Elmo and ${name} are both open-source AI visibility tools you can self-host and audit. Elmo's focus is transparent, independently verifiable tracking across ChatGPT, Claude, Perplexity, and Google AI Overviews — with white-label support for agencies and a documented methodology behind every number.`;
+	}
+
+	const noun = CATEGORY_NOUN[competitor.category];
+	return `Elmo is an open-source, self-hostable alternative to ${name}, ${indefiniteArticle(noun)} ${noun} tool. Both measure how AI answer engines describe your brand, but Elmo ships every line of code, runs on your own infrastructure, and is free to self-host — so your data stays yours and each metric is independently verifiable.`;
+}
+
+/**
+ * Per-competitor FAQ generated from the competitor dataset. The same items are
+ * rendered visibly on the page and emitted as FAQPage JSON-LD, so the structured
+ * data always matches what a reader (or an AI crawler) sees. Every answer is
+ * derived from fields we actually store, so it stays truthful per competitor.
+ */
+export function getComparisonFaqs(competitor: Competitor): FaqItem[] {
+	const name = competitor.name;
+	const openSource = isOpenSource(competitor);
+	const noun = CATEGORY_NOUN[competitor.category];
+	const faqs: FaqItem[] = [];
+
+	faqs.push({
+		question: `What is the difference between Elmo and ${name}?`,
+		answer: openSource
+			? `Both Elmo and ${name} are open source, so you can self-host either one and inspect the code. Elmo focuses specifically on transparent, independently verifiable AI visibility tracking across every major answer engine, with white-label support for agencies and a fully documented methodology behind each number.`
+			: `Elmo is an open-source, self-hostable AI visibility platform, while ${name} is a closed-source ${noun} tool. Both track how AI answer engines describe your brand, but Elmo gives you the full source code and runs on your own infrastructure, so you can verify every metric and keep your data in-house.`,
+	});
+
+	faqs.push({
+		question: `Is Elmo a free, open-source alternative to ${name}?`,
+		answer: `Yes. Elmo is a free, open-source alternative to ${name}. You can self-host the full platform at no cost, read every line of code, and track your AI visibility across ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews without per-seat or per-prompt fees.`,
+	});
+
+	faqs.push({
+		question: `Is ${name} open source?`,
+		answer: openSource
+			? `Yes, ${name} is open source. Elmo is open source as well and is built specifically for self-hosted, independently verifiable AI visibility tracking, so you can audit exactly how each metric is calculated.`
+			: `No, ${name} is a closed-source, hosted product, so you cannot inspect how its metrics are calculated. Elmo is fully open source — you can audit the code, self-host it on your own infrastructure, and avoid vendor lock-in.`,
+	});
+
+	faqs.push({
+		question: `Can I self-host Elmo instead of ${name}?`,
+		answer: `Yes. Elmo is designed to be self-hosted — deploy it on your own infrastructure in minutes with the CLI. You keep full ownership of your data and prompts, with no per-seat pricing and no third-party dashboard holding your visibility history.`,
+	});
+
+	return faqs;
+}

--- a/apps/www/src/lib/competitors/index.ts
+++ b/apps/www/src/lib/competitors/index.ts
@@ -23,3 +23,5 @@ export {
 	getPopularityRank,
 	getPopularityGrade,
 } from "./data";
+
+export { getComparisonFaqs, getComparisonVerdict } from "./content";

--- a/apps/www/src/lib/faqs.ts
+++ b/apps/www/src/lib/faqs.ts
@@ -1,0 +1,88 @@
+export interface FaqItem {
+	question: string;
+	answer: string;
+}
+
+// Homepage FAQ. Rendered visibly on "/" and emitted as FAQPage JSON-LD from the
+// same route, so the structured data always matches what a reader (or an AI
+// crawler) sees on the page.
+export const HOME_FAQS: FaqItem[] = [
+	{
+		question: "What is Elmo?",
+		answer:
+			"Elmo is an open-source AI visibility platform for Answer Engine Optimization (AEO). It tracks how AI answer engines — including ChatGPT, Google AI Overviews, Perplexity, Gemini, Copilot, and Grok — mention your brand, which competitors appear alongside you, and which sources each model cites.",
+	},
+	{
+		question: "What is Answer Engine Optimization (AEO)?",
+		answer:
+			"Answer Engine Optimization (AEO), also called generative engine optimization (GEO), is the practice of measuring and improving how often AI answer engines mention and cite your brand. Instead of ranking in a list of blue links, the goal is to be the source an AI quotes in its answer.",
+	},
+	{
+		question: "Which AI models does Elmo track?",
+		answer:
+			"Elmo runs your prompts across every major AI answer engine, including ChatGPT, Google AI Overviews, Perplexity, Gemini, Copilot, and Grok. It records how often your brand appears, which competitors show up alongside it, and which sources the models cite.",
+	},
+	{
+		question: "Is Elmo really open source?",
+		answer:
+			"Yes. Every line of Elmo is open source and available on GitHub. You can read the code, self-host the platform on your own infrastructure for free, and verify exactly how each visibility metric is collected and calculated.",
+	},
+	{
+		question: "Is Elmo free?",
+		answer:
+			"Elmo is free and open source to self-host — there is no license fee and no per-seat pricing. You only pay for your own infrastructure and any AI provider API keys you choose to use. Managed cloud hosting and white-label plans are also available.",
+	},
+];
+
+// Pricing page FAQ.
+export const PRICING_FAQS: FaqItem[] = [
+	{
+		question: "Is Elmo free?",
+		answer:
+			"Yes. Elmo is free and open source to self-host, forever. There is no license fee and no per-seat pricing — you only pay for your own infrastructure and the AI provider API keys you choose to use.",
+	},
+	{
+		question: "Is there a hosted or cloud version of Elmo?",
+		answer:
+			"Managed cloud hosting is coming soon for teams that would rather not run their own infrastructure. Until then, you can self-host Elmo for free or get in touch about early access and managed deployments.",
+	},
+	{
+		question: "Can agencies white-label Elmo?",
+		answer:
+			"White-label deployments are available for agencies that want to offer AI visibility tracking under their own brand, with multi-client dashboards and custom branding. Get in touch about setting up a white-label instance for your agency.",
+	},
+	{
+		question: "What do I need to run Elmo myself?",
+		answer:
+			"Elmo runs as a Docker Compose stack, all managed with a simple CLI — install it, run the interactive init, and bring everything up in a couple of commands. You can use the bundled database or connect Elmo to your own PostgreSQL database.",
+	},
+	{
+		question: "Do I need a credit card to get started?",
+		answer:
+			"No. Self-hosting Elmo does not require an account or a credit card. Clone the open-source repository, deploy with the CLI, and start tracking your AI visibility.",
+	},
+];
+
+// AI Visibility Tool Directory FAQ.
+export const DIRECTORY_FAQS: FaqItem[] = [
+	{
+		question: "What is an AI visibility tool?",
+		answer:
+			"An AI visibility tool tracks how AI answer engines like ChatGPT, Perplexity, Gemini, and Google AI Overviews mention and cite your brand. It measures how often you appear in AI answers, which competitors show up alongside you, and which sources the models reference.",
+	},
+	{
+		question: "What is Answer Engine Optimization (AEO)?",
+		answer:
+			"Answer Engine Optimization (AEO), also called generative engine optimization (GEO), is the practice of improving how often AI answer engines mention and cite your brand. AI visibility tools measure that presence so you can track and improve it over time.",
+	},
+	{
+		question: "How do I choose the best AI visibility tool?",
+		answer:
+			"The right tool depends on which AI engines you need to track, whether you want self-hosting and data ownership, your budget, and any agency or white-label needs. This directory compares 100+ tools feature-by-feature so you can match a tool to your requirements.",
+	},
+	{
+		question: "Is there an open-source AI visibility tool?",
+		answer:
+			"Yes. Elmo is an open-source, self-hostable AI visibility platform. You can run it on your own infrastructure for free, audit exactly how each metric is calculated, and export your data at any time.",
+	},
+];

--- a/apps/www/src/lib/seo.ts
+++ b/apps/www/src/lib/seo.ts
@@ -69,7 +69,17 @@ export function organizationJsonLd() {
 		name: SITE_NAME,
 		url: SITE_URL,
 		logo: SITE_LOGO_URL,
-		sameAs: ["https://github.com/elmohq/elmo"],
+		sameAs: [
+			"https://github.com/elmohq/elmo",
+			"https://x.com/tryelmo",
+			"https://www.linkedin.com/company/elmohq",
+			"https://discord.gg/s24nubCtKz",
+		],
+		parentOrganization: {
+			"@type": "Organization",
+			name: "Blue Whale Software, LLC",
+			url: "https://bluewhale.dev",
+		},
 	});
 }
 
@@ -143,6 +153,32 @@ export function breadcrumbJsonLd(items: { name: string; path: string }[]) {
 			position: index + 1,
 			name: item.name,
 			item: canonicalUrl(item.path),
+		})),
+	});
+}
+
+export function faqJsonLd(items: { question: string; answer: string }[]) {
+	return jsonLd({
+		"@type": "FAQPage",
+		mainEntity: items.map((item) => ({
+			"@type": "Question",
+			name: item.question,
+			acceptedAnswer: {
+				"@type": "Answer",
+				text: item.answer,
+			},
+		})),
+	});
+}
+
+export function itemListJsonLd(items: { name: string; path: string }[]) {
+	return jsonLd({
+		"@type": "ItemList",
+		itemListElement: items.map((item, index) => ({
+			"@type": "ListItem",
+			position: index + 1,
+			name: item.name,
+			url: canonicalUrl(item.path),
 		})),
 	});
 }

--- a/apps/www/src/routes/ai-visibility-tools/$slug.tsx
+++ b/apps/www/src/routes/ai-visibility-tools/$slug.tsx
@@ -2,8 +2,14 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Navbar } from "@/components/navbar";
 import { CompetitorComparison } from "@/components/competitor-comparison";
 import { Footer } from "@/components/footer";
-import { ogMeta, canonicalUrl, breadcrumbJsonLd } from "@/lib/seo";
-import { competitors, getComparisonSlug, isLowDR, type Competitor } from "@/lib/competitors";
+import { ogMeta, canonicalUrl, breadcrumbJsonLd, faqJsonLd } from "@/lib/seo";
+import {
+	competitors,
+	getComparisonSlug,
+	getComparisonFaqs,
+	isLowDR,
+	type Competitor,
+} from "@/lib/competitors";
 
 export const Route = createFileRoute("/ai-visibility-tools/$slug")({
 	head: ({ params }) => {
@@ -31,6 +37,7 @@ export const Route = createFileRoute("/ai-visibility-tools/$slug")({
 					{ name: "AI Visibility Tool Directory", path: "/ai-visibility-tools" },
 					{ name: `Elmo vs ${competitor.name}`, path },
 				]),
+				faqJsonLd(getComparisonFaqs(competitor)),
 			],
 		};
 	},

--- a/apps/www/src/routes/ai-visibility-tools/index.tsx
+++ b/apps/www/src/routes/ai-visibility-tools/index.tsx
@@ -2,11 +2,32 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { CompetitorDirectory } from "@/components/competitor-directory";
-import { ogMeta, canonicalUrl, breadcrumbJsonLd } from "@/lib/seo";
+import { Faq } from "@/components/faq";
+import { DIRECTORY_FAQS } from "@/lib/faqs";
+import {
+	ogMeta,
+	canonicalUrl,
+	breadcrumbJsonLd,
+	faqJsonLd,
+	itemListJsonLd,
+} from "@/lib/seo";
+import { competitors, getComparisonSlug, isLowDR } from "@/lib/competitors";
 
 const title = "AI Visibility Tool Directory | Compare AI Search Tools · Elmo";
 const description =
-	"Compare 70+ AI visibility and Answer Engine Optimization tools. Feature matrix, pricing, and head-to-head comparisons with Elmo.";
+	"Compare 100+ AI visibility and Answer Engine Optimization tools. Feature matrix, pricing, and head-to-head comparisons with Elmo.";
+
+// Indexed comparison pages (mirrors the sitemap filter), surfaced as ItemList
+// structured data so AI engines can extract the full directory of tools.
+const directoryItems = competitors
+	.filter(
+		(c) =>
+			c.status !== "shutting-down" && c.category !== "other" && !isLowDR(c),
+	)
+	.map((c) => ({
+		name: c.name,
+		path: `/ai-visibility-tools/${getComparisonSlug(c)}`,
+	}));
 
 export const Route = createFileRoute("/ai-visibility-tools/")({
 	head: () => ({
@@ -27,6 +48,8 @@ export const Route = createFileRoute("/ai-visibility-tools/")({
 				{ name: "Home", path: "/" },
 				{ name: "AI Visibility Tool Directory", path: "/ai-visibility-tools" },
 			]),
+			faqJsonLd(DIRECTORY_FAQS),
+			itemListJsonLd(directoryItems),
 		],
 	}),
 	component: AeoToolsPage,
@@ -38,6 +61,7 @@ function AeoToolsPage() {
 			<Navbar />
 			<main>
 				<CompetitorDirectory />
+				<Faq items={DIRECTORY_FAQS} eyebrow="/ FAQ" />
 			</main>
 			<Footer />
 		</div>

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -7,11 +7,14 @@ import { Community } from "@/components/community";
 import { Pricing } from "@/components/pricing";
 import { CTA } from "@/components/cta";
 import { Footer } from "@/components/footer";
+import { Faq } from "@/components/faq";
+import { HOME_FAQS } from "@/lib/faqs";
 import {
 	SITE_NAME,
 	SITE_DESCRIPTION,
 	ogMeta,
 	softwareApplicationJsonLd,
+	faqJsonLd,
 	canonicalUrl,
 } from "@/lib/seo";
 
@@ -27,7 +30,7 @@ export const Route = createFileRoute("/")({
 			}),
 		],
 		links: [{ rel: "canonical", href: canonicalUrl("/") }],
-		scripts: [softwareApplicationJsonLd()],
+		scripts: [softwareApplicationJsonLd(), faqJsonLd(HOME_FAQS)],
 	}),
 	component: HomePage,
 });
@@ -42,6 +45,7 @@ function HomePage() {
 				<Features />
 				<Community />
 				<Pricing />
+				<Faq items={HOME_FAQS} eyebrow="/ FAQ" />
 				<CTA />
 			</main>
 			<Footer />

--- a/apps/www/src/routes/llms[.]txt.ts
+++ b/apps/www/src/routes/llms[.]txt.ts
@@ -28,7 +28,7 @@ Elmo is Answer Engine Optimization (AEO), also called generative engine optimiza
 
 ## Resources
 
-- [AI Visibility Tool Directory](https://www.elmohq.com/ai-visibility-tools): Compare 70+ AI visibility and Answer Engine Optimization tools, with a feature matrix, pricing, and head-to-head comparisons with Elmo.
+- [AI Visibility Tool Directory](https://www.elmohq.com/ai-visibility-tools): Compare 100+ AI visibility and Answer Engine Optimization tools, with a feature matrix, pricing, and head-to-head comparisons with Elmo.
 - [Changelog](https://www.elmohq.com/changelog): Recent releases, improvements, and bug fixes.
 - [Roadmap](https://www.elmohq.com/roadmap): What's coming next, prioritized in the open on GitHub.
 - [Provider Status](https://www.elmohq.com/status): Real-time status and performance monitoring for AI answer engine integrations.

--- a/apps/www/src/routes/pricing.tsx
+++ b/apps/www/src/routes/pricing.tsx
@@ -3,7 +3,9 @@ import { Navbar } from "@/components/navbar";
 import { Pricing } from "@/components/pricing";
 import { CTA } from "@/components/cta";
 import { Footer } from "@/components/footer";
-import { ogMeta, canonicalUrl, breadcrumbJsonLd } from "@/lib/seo";
+import { Faq } from "@/components/faq";
+import { PRICING_FAQS } from "@/lib/faqs";
+import { ogMeta, canonicalUrl, breadcrumbJsonLd, faqJsonLd } from "@/lib/seo";
 
 const title = "Pricing · Elmo";
 const description =
@@ -22,6 +24,7 @@ export const Route = createFileRoute("/pricing")({
 				{ name: "Home", path: "/" },
 				{ name: "Pricing", path: "/pricing" },
 			]),
+			faqJsonLd(PRICING_FAQS),
 		],
 	}),
 	component: PricingPage,
@@ -33,6 +36,7 @@ function PricingPage() {
 			<Navbar />
 			<main>
 				<Pricing />
+				<Faq items={PRICING_FAQS} eyebrow="/ FAQ" />
 				<CTA />
 			</main>
 			<Footer />


### PR DESCRIPTION
Makes the marketing site more extractable and citable by AI answer engines (ChatGPT, Perplexity, Gemini, Google AI Overviews). All copy is auto-generated from existing data and rendered **visibly** *and* as JSON-LD so the two never drift — please review the wording.

## P1 — FAQ schema + visible FAQ sections (`FAQPage`)
New `<Faq>` component + `faqJsonLd()` helper. Each page builds its FAQ once and feeds both the on-page `<dl>` and the structured data.
- **Comparison pages** (`Elmo vs X`, ~70 indexed): per-competitor Q&As generated from the competitor dataset (difference, open-source status, pricing, self-hosting) — these map to AI query fan-out variants. Copy lives in `src/lib/competitors/content.ts`.
- **Homepage / Pricing / Directory index**: category & product FAQs ("What is Elmo?", "What is AEO?", "Is Elmo free?", …) in `src/lib/faqs.ts`.

## P3 — Lead answer block on comparison pages
Comparison pages now open with a 40–60 word verdict (data-driven; branches on whether the competitor is itself open source) instead of a one-line tagline — a self-contained passage AI engines can lift verbatim. Verified grammatically clean across all 108 competitors / 7 categories.

## P4 — Richer `Organization` schema
`sameAs` now lists GitHub, X, LinkedIn, and Discord (was GitHub only) and adds `parentOrganization` (Blue Whale Software) — strengthens entity recognition for the Knowledge Graph / Gemini / AI Overviews.

## P5 — `ItemList` schema on the directory index
The directory now emits `ItemList` structured data (mirroring the sitemap filter) so AI engines can extract the full list of tools with Elmo's comparison pages as the destination.

## Notes
- `/pricing.md` (P2) was intentionally **out of scope** — not requested.
- No changeset (marketing-site content, not a package release).
- All FAQ/verdict copy is easy to tweak in `src/lib/faqs.ts` and `src/lib/competitors/content.ts`.

## Validation
- `pnpm --filter @workspace/www check-types` ✅
- `pnpm --filter @workspace/www build` ✅
- Generator output spot-checked against all 108 competitors (0 grammar offenders)