### PR TITLE
Move Tool Directory link to the Learn column in the footer

### DIFF
--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -22,7 +22,6 @@ const cols = [
 			{ label: "Blog", href: "/blog" },
 			{ label: "Documentation", href: "/docs" },
 			{ label: "API Reference", href: "/docs/api" },
-			{ label: "Tool Directory", href: "/ai-visibility-tools" },
 			{ label: "Provider Status", href: "/status" },
 			{
 				label: "Issues",
@@ -37,6 +36,7 @@ const cols = [
 			{ label: "AEO Glossary", href: "/glossary" },
 			{ label: "AI Search Guides", href: "/ai-search" },
 			{ label: "AEO by Industry", href: "/aeo-for" },
+			{ label: "Tool Directory", href: "/ai-visibility-tools" },
 			{ label: "Compare Tools", href: "/ai-visibility-tools/compare" },
 		],
 	},


### PR DESCRIPTION
Moves the **Tool Directory** link (`/ai-visibility-tools`) from the **Resources** column to the **Learn** column in the marketing-site footer, placing it directly above the related **Compare Tools** link (`/ai-visibility-tools/compare`).

No duplication — the link is relocated, not added in two places.