### PR TITLE
Add 4 AI visibility blog posts (GetCito vs Elmo, robots.txt, AEO/GEO guides)

### DIFF
--- a/packages/docs/content/blog/best-aeo-tools.mdx
+++ b/packages/docs/content/blog/best-aeo-tools.mdx
@@ -1,0 +1,139 @@
+---
+title: "The Best AEO Tools for AI Visibility (2026 Guide)"
+description: "The best AEO tools for tracking and improving how AI answer engines cite your brand. We compare Elmo, Profound, Peec AI, Scrunch, Otterly, and more for 2026."
+date: "2026-06-02"
+author: ai
+metaTitle: "Best AEO Tools for AI Visibility (2026)"
+tags:
+  - aeo
+  - tools
+  - ai-visibility
+itemList:
+  - name: Elmo
+    description: "Open-source, self-hosted AEO tracking across every major answer engine."
+  - name: Profound
+    description: "Enterprise answer engine optimization platform."
+  - name: Peec AI
+    description: "Self-serve AEO analytics focused on share of voice."
+  - name: Scrunch AI
+    description: "Source-level AEO analysis and agent-readiness audits."
+  - name: Otterly
+    description: "Affordable per-engine answer engine monitoring for small teams."
+  - name: AirOps
+    description: "AEO tracking paired with content operations to act on the data."
+  - name: Frase
+    description: "Content optimization tool with lighter AEO tracking."
+  - name: Ahrefs Brand Radar
+    description: "AEO module inside the Ahrefs SEO suite."
+  - name: GetCito
+    description: "Open-source AEO tool focused on AI crawlability."
+faq:
+  - question: What is an AEO tool?
+    answer: "An AEO tool tracks whether and how often AI answer engines like ChatGPT, Perplexity, and Google's AI Overviews mention or cite your brand, and benchmarks you against competitors. Many also help you fix gaps by flagging the prompts where you are missing and the content or technical changes that would help."
+  - question: What is the best AEO tool?
+    answer: "There is no single best AEO tool; it depends on your stage and budget. Profound leads at the enterprise end. Peec AI, Otterly, and Scrunch are strong self-serve picks. Elmo is the best fit if you want an open-source tool you fully control. Match the engine coverage and price to how you plan to use it."
+  - question: Is there a free AEO tool?
+    answer: "Yes. Elmo is free and open source when you self-host it, and AirOps has a free tier that tracks ChatGPT only. GetCito is also free and open source. Most other AEO tools are paid, though several offer free trials."
+  - question: What is the difference between AEO tools and SEO tools?
+    answer: "SEO tools track where your pages rank in a list of links. AEO tools track whether AI answer engines mention or cite your brand in the answer itself, where there is often no ranked list at all. Some SEO suites, like Ahrefs, now include an AEO module so you can see both in one place."
+  - question: Do I need a separate AEO tool if I already have an SEO tool?
+    answer: "Often, yes. Most SEO platforms still center on rankings and clicks, and their AI tracking, where it exists, is a newer add-on with narrower engine coverage. A dedicated AEO tool gives you deeper answer-level data: which sources an engine cited, how it described you, and your share of voice across prompts."
+---
+
+**AEO tools track whether AI answer engines cite your brand, and help you fix the gaps when they don't.** As buyers move from typing keywords into Google to asking ChatGPT, Perplexity, and Google's AI Overviews, the question shifts from "where do we rank" to "does the AI mention us at all." This guide compares nine tools built to answer that, from open-source trackers to enterprise platforms.
+
+If you want the broader category that includes tools beyond pure answer engine optimization, see our roundup of the [best AI visibility tools](/blog/best-ai-visibility-tools). This list stays focused on AEO: measuring and improving citations inside AI answers.
+
+**Key takeaways**
+
+- AEO tools measure mentions, citations, and share of voice across AI answer engines, and the better ones point you toward the fixes.
+- They differ most on engine coverage, prompt volume, competitor benchmarking, and whether they help you act on the data or just report it.
+- Elmo is open-source and self-hosted, Profound targets enterprise, and Peec AI, Otterly, and Scrunch are self-serve.
+- Two free, open-source options exist (Elmo and GetCito), though they differ sharply on how actively they are maintained.
+- AI products and prices move fast, so confirm current details with each vendor before you buy.
+
+## What to look for in an AEO tool
+
+Before the list, here is what actually separates these tools in practice.
+
+- **Engine coverage.** Check that the tool tracks the engines your audience uses, and whether Gemini or Google AI Mode are included or sold as add-ons. Coverage varies more than the homepages suggest.
+- **Mentions versus citations.** A mention tells you the AI named you. A [citation](/blog/ai-citations) tells you it linked to you and may have sent a visitor. If traffic matters, prioritize citation tracking and source-level data.
+- **Prompt volume.** Tools meter usage by the number of prompts they track. Estimate how many questions you need to monitor, then read the per-tier limits.
+- **Competitor share of voice.** Benchmarking against named rivals on the same prompts is one of the most actionable AEO metrics. Make sure it is included, not reserved for a top tier.
+- **Measure versus fix.** Some tools only report. Others help you act, through content tooling or crawlability checks. Decide which you need.
+
+## The best AEO tools at a glance
+
+| Tool | Best for | AEO focus | Pricing model |
+|---|---|---|---|
+| **Elmo** | Owning your AEO data | Tracking, citations, competitor analysis | Open source, free self-host |
+| **Profound** | Enterprise AEO programs | Answer analytics plus content and agent tooling | Enterprise, demo-gated |
+| **Peec AI** | Self-serve share of voice | Mentions, citations, competitor benchmarking | Self-serve subscription |
+| **Scrunch AI** | Source-level "why" | Sentiment, sources, agent-readiness audits | Self-serve subscription |
+| **Otterly** | Small teams on a budget | Per-engine brand reports and GEO audit | Self-serve, low entry |
+| **AirOps** | Measuring then fixing | Tracking plus content operations | Free tier plus paid |
+| **Frase** | Content teams | Content optimization with lighter tracking | Content tool plus tracking |
+| **Ahrefs Brand Radar** | Existing Ahrefs users | AEO module in an SEO suite | Add-on to Ahrefs |
+| **GetCito** | A quick crawlability read | Open-source crawlability checks | Open source, free |
+
+Pricing reflects public information in early 2026. Always confirm on the vendor's site.
+
+## Elmo
+
+[Elmo](https://www.elmohq.com/) is an open-source, self-hosted AEO platform. It tracks how your brand shows up across AI models, records which sources get cited, and benchmarks competitors, with every metric computed by code you can read. Coverage is unusually wide: ChatGPT, Claude, Gemini, Grok, Perplexity, Copilot, DeepSeek, Mistral, and Google's AI Mode and AI Overviews, via the models' own APIs or OpenRouter.
+
+It suits teams that want to own their AEO data outright and avoid vendor lock-in. The self-hosted core is free under the MIT license, with unlimited prompts and all models. The trade-off is that you run the infrastructure (Docker and PostgreSQL) and supply your own LLM keys, which carry usage costs. A managed cloud option is listed as coming soon.
+
+## Profound
+
+[Profound](https://www.tryprofound.com/) is an enterprise answer engine optimization platform, and it helped name the category. It monitors how AI represents your brand, analyzes the consumer queries behind that presence, and reaches beyond monitoring into content and agent building. Coverage spans Perplexity, ChatGPT, Claude, Gemini, Grok, Copilot, Meta AI, DeepSeek, and Google AI Overviews.
+
+It fits mid-market and enterprise marketing teams running a serious AEO program. Pricing is not public; the site routes to a demo, and the enterprise framing puts it at the higher end. Our [Elmo vs Profound](/ai-visibility-tools/elmo-vs-profound) page goes deeper.
+
+## Peec AI
+
+[Peec AI](https://peec.ai/) is a self-serve AEO analytics tool built around share of voice. It measures how often your brand appears when AI systems answer buyer questions, tracks mentions and source citations, and benchmarks you against competitors. It lists ChatGPT, Perplexity, Gemini, Copilot, Grok, and Google's AI Mode and AI Overviews, with a dedicated product for agencies.
+
+The appeal is transparent, relatively affordable pricing with unlimited users, purpose-built for AI search. Watch two things: cost scales with the number of tracked prompts, and reviews note that some engines beyond the core set carry per-model fees. See our [Elmo vs Peec AI](/ai-visibility-tools/elmo-vs-peec-ai) comparison.
+
+## Scrunch AI
+
+[Scrunch AI](https://scrunch.com/) goes past "did we appear" to explain why. It tracks mentions, citations, competitors, and sentiment, surfaces which sources shaped an answer, supports persona-based prompting, and audits whether AI agents can actually read your site. A GA integration attributes AI-referral traffic. Coverage includes ChatGPT, Claude, Gemini, Perplexity, Google AI Mode and AI Overviews, and Meta.
+
+It is a good fit for brands and agencies that want source-level insight and site-readiness checks, not just a mention count. Entry pricing runs higher than several self-serve trackers, and prompt volumes are capped per tier. The [Elmo vs Scrunch](/ai-visibility-tools/elmo-vs-scrunch) page breaks down the differences.
+
+## Otterly
+
+[Otterly](https://otterly.ai/) is built around per-engine Brand Reports: brand mentions, coverage, domain citations, link-position changes over time, and competitive share of voice. It adds a GEO audit and a prompt-research tool, and it is notable for a low entry price with unlimited team members and daily tracking. Core tiers cover ChatGPT, Google AI Overviews, Perplexity, and Copilot.
+
+It suits smaller businesses and lean teams that want affordable AEO tracking. The limits follow the price: Gemini and Google AI Mode are paid add-ons, and prompt counts are modest on lower tiers. See [Elmo vs Otterly](/ai-visibility-tools/elmo-vs-otterly-ai) for a direct look.
+
+## AirOps
+
+[AirOps](https://www.airops.com/) pairs AEO tracking with a content-operations engine, so it is as much a fix-it tool as a measure-it one. On the tracking side it covers citations, competitors, and share of voice; on the execution side, its Quill agent produces and refreshes content at scale, and the platform unifies SEO, AI search, and GA4 data.
+
+It fits content and SEO teams that want to act on the data by shipping content, not just watch a dashboard. The catch for visibility-only buyers: multi-engine tracking is gated to the Pro tier, while free and Solo tiers track ChatGPT only. There is a genuinely free tier to start. See [Elmo vs AirOps](/ai-visibility-tools/elmo-vs-airops).
+
+## Frase
+
+[Frase](https://www.frase.io/) began as a content-optimization and SERP-research tool, pulling headings, questions, and sources from top pages into writer-ready briefs, and has added GEO optimization and AEO tracking. It can both create content and lightly monitor how it performs in AI answers. Every plan includes its AI agent, content optimization, tracking, and site audits; only volume changes by tier.
+
+It fits content marketers who want one tool to produce search-optimized content and keep an eye on AI citations. The caveat is depth: the AEO tracking is newer and lighter, and prompt allowances are small at entry tiers. The [Elmo vs Frase](/ai-visibility-tools/elmo-vs-frase) page shows where each focuses.
+
+## Ahrefs Brand Radar
+
+[Ahrefs Brand Radar](https://ahrefs.com/brand-radar) is an AEO module inside the Ahrefs SEO suite. It draws on Ahrefs' database of real, search-backed prompts rather than synthetic queries, and it sits beside the keyword, backlink, and site-audit tools Ahrefs users already rely on. It tracks AI Overviews and AI Mode, ChatGPT, Perplexity, Copilot, Gemini, and Grok.
+
+It is the natural pick for existing Ahrefs customers extending into AEO. Two caveats: some independent reviews report accuracy issues on ChatGPT and Perplexity, and because it is priced on top of an Ahrefs subscription, full AI coverage adds up. Compare on the [Elmo vs Ahrefs Brand Radar](/ai-visibility-tools/elmo-vs-ahrefs-brand-radar) page.
+
+## GetCito
+
+[GetCito](https://getcito.com/) is one of the few open-source AEO tools besides Elmo, licensed under MIT. Its standout idea is an AI Crawlability Clinic that checks how well AI bots can reach and parse your content, and the team also sells GEO playbooks and consulting. If you want a quick read on crawlability, the concept is useful.
+
+The honest caveat is maintenance. The public repo has had a single substantive code commit since it launched in late 2025, and it is run by a marketing agency rather than a dedicated product team, so do not expect ongoing fixes or new engine support. Our [GetCito vs Elmo](/blog/getcito-vs-elmo) post covers this in detail.
+
+## How to choose an AEO tool
+
+Start with how you will use it, not a feature checklist. If you want full control and no per-seat fees, an open-source tool you self-host fits. If you want a hosted dashboard your team can open tomorrow, a self-serve subscription is simpler. If AEO is a board-level priority with budget behind it, an enterprise platform earns its keep.
+
+Then weigh coverage, citation depth, prompt volume, and competitor benchmarking against your budget. The goal is the same either way: a reliable, repeatable read on whether AI answers cite you, and a clear path to the content and technical fixes that move the number. For the discipline behind the tools, see our guide to [answer engine optimization](/blog/answer-engine-optimization), and the related [best GEO tools](/blog/best-geo-tools) guide if you frame the work as generative engine optimization instead.

--- a/packages/docs/content/blog/best-geo-tools.mdx
+++ b/packages/docs/content/blog/best-geo-tools.mdx
@@ -1,0 +1,133 @@
+---
+title: "Best GEO Tools: AI Search Visibility Platforms in 2026"
+description: "A guide to the best GEO tools for AI search visibility in 2026. Compare Elmo, Profound, Peec AI, Scrunch, and more generative engine optimization platforms."
+date: "2026-06-02"
+author: ai
+metaTitle: "Best GEO Tools: AI Search Visibility (2026)"
+tags:
+  - geo
+  - tools
+  - ai-visibility
+itemList:
+  - name: Elmo
+    description: "Open-source, self-hosted GEO tracking across every major generative engine."
+  - name: Profound
+    description: "Enterprise generative engine optimization platform."
+  - name: Peec AI
+    description: "Self-serve GEO analytics built around share of voice."
+  - name: Scrunch AI
+    description: "Source-level GEO analysis with agent-readiness audits."
+  - name: Otterly
+    description: "Budget-friendly GEO monitoring and audits for small teams."
+  - name: Nightwatch
+    description: "SEO rank tracker with generative engine visibility built in."
+  - name: AirOps
+    description: "GEO tracking paired with content operations."
+  - name: GetCito
+    description: "Open-source GEO tool centered on AI crawlability."
+faq:
+  - question: What are GEO tools?
+    answer: "GEO tools measure and improve how generative engines like ChatGPT, Perplexity, Gemini, and Google's AI Overviews represent your brand. They track whether you are mentioned and cited in generated answers, your share of voice against competitors, and where you are missing, so you can target the content and technical fixes that help."
+  - question: What is the best GEO tool?
+    answer: "It depends on your team and budget. Elmo is the best open-source, self-hosted option. Profound leads at the enterprise end. Peec AI and Scrunch are strong self-serve picks, Otterly is the budget choice, and Nightwatch suits SEO teams that want rank tracking and GEO in one place."
+  - question: Is GEO the same as AEO?
+    answer: "Effectively yes. GEO (generative engine optimization) and AEO (answer engine optimization) describe the same goal: earning visibility inside AI-generated answers. GEO emphasizes the generative engines doing the answering, but the tactics and the tools overlap almost entirely. The terms are used interchangeably."
+  - question: Is there a free GEO tool?
+    answer: "Yes. Elmo is free and open source when self-hosted, with unlimited prompts and all models. GetCito is also free and open source. AirOps offers a free tier that tracks ChatGPT only. Most other GEO platforms are paid, with free trials available."
+  - question: How do GEO tools work?
+    answer: "They run a set of prompts your audience is likely to ask, across the generative engines you care about, on a repeating schedule. Then they record what comes back: whether your brand is mentioned, whether it is cited with a link, how it is described, and how often competitors appear instead. That sampling becomes a trend you can act on."
+---
+
+**GEO tools tell you how generative engines describe and cite your brand, and where you are losing ground to competitors.** Generative engine optimization is the work of earning visibility inside AI-generated answers, and you cannot manage what you cannot see. The eight platforms below track your presence across ChatGPT, Perplexity, Gemini, and Google's AI Overviews, ranging from a free open-source tool to enterprise software.
+
+GEO and [answer engine optimization](/blog/answer-engine-optimization) (AEO) describe the same practice from slightly different angles, so the tool lists overlap. If you frame the work as AEO, our [best AEO tools](/blog/best-aeo-tools) guide covers the same ground with that lens. For the wider category, see the [best AI visibility tools](/blog/best-ai-visibility-tools).
+
+**Key takeaways**
+
+- GEO tools measure mentions, citations, sentiment, and share of voice across generative engines, then point you toward fixes.
+- The biggest differences are engine coverage, prompt volume, source-level depth, and whether the tool is self-hosted, self-serve, or enterprise.
+- Elmo is the leading open-source, self-hosted option; Profound anchors the enterprise end; Peec AI, Scrunch, and Otterly cover the self-serve middle.
+- SEO teams that want rankings and GEO together can get both from a tracker like Nightwatch.
+- The space moves quickly, so verify coverage and pricing with each vendor before committing.
+
+## What is GEO, and what should a GEO tool do?
+
+Generative engine optimization is getting your brand surfaced and cited when an AI assistant writes an answer. There is usually no ranked list to climb, just one generated response that either includes you or doesn't. For background on the term and how it sits next to SEO, see [what is generative SEO](/blog/what-is-generative-seo).
+
+A capable GEO tool does four jobs:
+
+- **Tracks visibility** across the generative engines your buyers use, not just one.
+- **Separates mentions from [citations](/blog/ai-citations)**, since a linked citation is the one that can send traffic.
+- **Benchmarks share of voice** against named competitors on the same prompts.
+- **Explains the why** by showing which sources an engine drew on and how it described you, so the data leads somewhere.
+
+The tools below are grouped by who they fit best.
+
+## The best GEO tools at a glance
+
+| Tool | Best for | Pricing model |
+|---|---|---|
+| **Elmo** | The best open-source GEO tool | Open source, free self-host |
+| **Profound** | Enterprise GEO programs | Enterprise, demo-gated |
+| **Peec AI** | Self-serve share of voice | Self-serve subscription |
+| **Scrunch AI** | Source-level analysis | Self-serve subscription |
+| **Otterly** | Small teams and tight budgets | Self-serve, low entry |
+| **Nightwatch** | SEO teams wanting rank plus GEO | SEO suite, AI included |
+| **AirOps** | Acting on the data with content | Free tier plus paid |
+| **GetCito** | An open-source crawlability read | Open source, free |
+
+Pricing reflects public information in early 2026. Confirm current details on each vendor's site.
+
+## Elmo: best open-source GEO tool
+
+[Elmo](https://www.elmohq.com/) is an open-source, self-hosted GEO platform, and the strongest pick if you want to own your data outright. It tracks brand presence across ChatGPT, Claude, Gemini, Grok, Perplexity, Copilot, DeepSeek, Mistral, and Google's AI Mode and AI Overviews, records which sources get cited, and benchmarks competitors, all computed by code you can audit. It pulls responses through the models' own APIs or OpenRouter.
+
+The self-hosted core is free under the MIT license, with unlimited prompts and every model. You provide the infrastructure (Docker and PostgreSQL) and your own LLM keys, which carry usage costs, and a managed cloud option is listed as coming soon. For teams that distrust black-box metrics, reading the exact code that computes your score is the selling point.
+
+## Profound: best for enterprise
+
+[Profound](https://www.tryprofound.com/) sits at the enterprise end of GEO and helped define the category. Beyond monitoring how AI represents your brand, it analyzes the real consumer queries behind that presence and extends into content and agent building. Engine coverage is broad: Perplexity, ChatGPT, Claude, Gemini, Grok, Copilot, Meta AI, DeepSeek, and Google AI Overviews.
+
+It is built for marketing organizations and agencies with budget and a formal GEO program. Pricing is gated behind a demo, and the positioning points to the higher end of the market. See [Elmo vs Profound](/ai-visibility-tools/elmo-vs-profound) for a side-by-side.
+
+## Peec AI: best self-serve share of voice
+
+[Peec AI](https://peec.ai/) focuses on a single question: how often do you show up when generative engines answer buyer questions? It tracks mentions and citations, benchmarks competitors across LLMs, and offers an agency product for managing multiple brands. Listed coverage includes ChatGPT, Perplexity, Gemini, Copilot, Grok, and Google's AI Mode and AI Overviews.
+
+Its strength is clear, relatively affordable self-serve pricing with unlimited users. Keep an eye on two things: cost rises with the number of tracked prompts, and some engines outside the core set can carry per-model fees. The [Elmo vs Peec AI](/ai-visibility-tools/elmo-vs-peec-ai) page compares them directly.
+
+## Scrunch AI: best for source-level analysis
+
+[Scrunch AI](https://scrunch.com/) is the pick when you need to understand why an answer turned out the way it did. It tracks mentions, citations, competitors, and sentiment, identifies which sources influenced a response, supports persona-based prompting, and audits whether AI agents can read your site at all. A GA integration ties AI referrals to traffic. Coverage spans ChatGPT, Claude, Gemini, Perplexity, Google AI Mode and AI Overviews, and Meta.
+
+It fits brands and agencies running a serious GEO program who want diagnosis, not just a score. Entry pricing is higher than several trackers, and prompt volume is capped per tier. The [Elmo vs Scrunch](/ai-visibility-tools/elmo-vs-scrunch) comparison has the details.
+
+## Otterly: best for small budgets
+
+[Otterly](https://otterly.ai/) delivers per-engine brand reports (mentions, coverage, domain citations, link-position changes, and competitive share of voice) at a low, transparent entry price with unlimited team members and daily tracking. It adds a GEO audit and a prompt-research tool. Core tiers cover ChatGPT, Google AI Overviews, Perplexity, and Copilot.
+
+It is a sensible starting point for small businesses and lean teams. The trade-offs follow the price: Gemini and Google AI Mode are paid add-ons, and prompt counts are modest on lower tiers. See [Elmo vs Otterly](/ai-visibility-tools/elmo-vs-otterly-ai).
+
+## Nightwatch: best for SEO teams
+
+[Nightwatch](https://nightwatch.io/) is a mature SEO rank tracker that has added GEO visibility, so you can watch keyword rankings and AI answers in one place. Its AI layer covers ChatGPT, Claude, Gemini, and Perplexity, with citation tracking that connects AI mentions to resulting traffic, and AI tracking is bundled into every plan rather than sold separately.
+
+It is a strong choice for SEO professionals and agencies that want rank tracking and GEO together, with unlimited seats and white-label reporting. The honest limit is that GEO is secondary to the core rank-tracking product, so AI-specific depth and engine coverage are narrower than in dedicated tools. See [Elmo vs Nightwatch](/ai-visibility-tools/elmo-vs-nightwatch).
+
+## AirOps: best for acting on the data
+
+[AirOps](https://www.airops.com/) pairs GEO tracking with content operations, so it helps you fix what you measure. It covers citations, competitor intelligence, and share of voice, while its Quill agent produces and refreshes content at scale and the platform unifies SEO, AI search, and GA4 data.
+
+It fits content and SEO teams that want to ship improvements off the back of the data. The catch for tracking-only buyers: multi-engine coverage sits in the Pro tier, while free and Solo tiers track ChatGPT only. A free tier exists to start. See [Elmo vs AirOps](/ai-visibility-tools/elmo-vs-airops).
+
+## GetCito: open-source alternative
+
+[GetCito](https://getcito.com/) is, alongside Elmo, one of the few open-source GEO tools, licensed under MIT. Its notable feature is an AI Crawlability Clinic that checks how well AI bots can access your content, and the team also sells GEO playbooks and consulting.
+
+The caveat is upkeep. The public repository has had a single substantive code commit since launching in late 2025, and it is maintained by a marketing agency rather than a product team, so new engine support and fixes are unlikely. For the full picture, read [GetCito vs Elmo](/blog/getcito-vs-elmo).
+
+## How to choose a GEO tool
+
+Pick by how you work. If control and cost matter most, a self-hosted open-source tool fits. If you want a dashboard your team opens tomorrow, choose a self-serve subscription, sized to the prompts and engines you actually need. If you already live in an SEO tool, an integrated tracker keeps rankings and GEO in one view. If GEO is a funded, company-wide priority, an enterprise platform earns the spend.
+
+Whatever you choose, the job is to turn invisible AI answers into something you can measure and improve. Start with the method in [how to track your brand in AI search](/blog/track-brand-ai-search), then browse the full [AI visibility tools](/ai-visibility-tools) directory to compare any two options head to head.

--- a/packages/docs/content/blog/getcito-vs-elmo.mdx
+++ b/packages/docs/content/blog/getcito-vs-elmo.mdx
@@ -1,0 +1,101 @@
+---
+title: "GetCito vs Elmo: The Best Open-Source AI Visibility Tool?"
+description: "GetCito and Elmo are both MIT-licensed open-source AI visibility tools with similar GitHub stars. The deciding factor is maintenance. Here's the comparison."
+date: "2026-06-02"
+author: ai
+metaTitle: "GetCito vs Elmo: Best Open-Source AEO Tool (2026)"
+tags:
+  - ai-visibility
+  - tools
+  - open-source
+faq:
+  - question: Is GetCito open source?
+    answer: "Yes. GetCito is released under the MIT license, the same permissive license Elmo uses. The catch is activity: the public repository has had a single substantive code commit since it launched in November 2025, so 'open source' here means the code is readable, not that it is actively developed."
+  - question: Is GetCito still maintained?
+    answer: "The repository shows little sign of ongoing development. After the initial commit in November 2025, the only changes are automated dependency bumps and two README edits. There are no tagged releases. GetCito is run by a marketing agency, and the tool reads more like a launch artifact than a product under active maintenance."
+  - question: What is the best open-source AI visibility tool?
+    answer: "For most teams that want to run the tool themselves, Elmo is the stronger choice today. It is MIT-licensed, covers more AI engines, and ships changes most weeks. GetCito is also MIT-licensed and worth a look for its crawlability angle, but its code has barely moved since launch."
+  - question: Is Elmo a GetCito alternative?
+    answer: "Yes. Both track how your brand appears in AI answers, both are open source under MIT, and both have similar GitHub star counts. Elmo differs in being actively developed and supporting a wider set of engines, including ChatGPT, Claude, Gemini, Grok, Perplexity, Copilot, DeepSeek, and Google's AI Mode and AI Overviews."
+---
+
+**GetCito and Elmo are the two best-known open-source AI visibility tools**, and on paper they look alike: both are MIT-licensed, both track your brand across AI answer engines, and both sit around 120 GitHub stars. The difference shows up after launch. GetCito has had one substantive code commit since November 2025. Elmo ships changes most weeks. If you plan to actually run the tool, that gap is the whole decision.
+
+**Key takeaways**
+
+- Both tools are open source under the MIT license, so you can read the code, self-host, and fork either one.
+- Star counts are close (roughly 120 each), so popularity is not a useful tiebreaker here.
+- GetCito's public repo has a single real code commit since it launched, plus automated dependency bumps and two README edits. There are no tagged releases.
+- GetCito is maintained by a marketing agency, and the repository carries the marks of a one-shot AI build: dozens of all-caps summary docs and loose test scripts dumped in the project root.
+- Elmo is in active development, supports more engines, and is built to be the tool you run long term.
+- This is a comparison published by Elmo. The facts about GetCito come from its own public GitHub repo, which you can verify yourself.
+
+## GetCito vs Elmo at a glance
+
+| | GetCito | Elmo |
+|---|---|---|
+| License | MIT | MIT |
+| GitHub stars | ~122 | ~119 |
+| First commit | Nov 2025 | Aug 2025 |
+| Substantive code commits since launch | One | Most weeks |
+| Tagged releases | None | Ongoing |
+| Maintained by | A marketing agency | A dedicated product team |
+| Engines tracked | ChatGPT, Perplexity, Gemini, and others | ChatGPT, Claude, Gemini, Grok, Perplexity, Copilot, DeepSeek, Mistral, Google AI Mode and AI Overviews |
+| Stack | Next.js, Firebase, Azure OpenAI | Docker, PostgreSQL, your own LLM keys or OpenRouter |
+| Best for | A quick crawlability read | Owning your AI visibility data long term |
+
+Star counts and commit history reflect the public GitHub repositories as of June 2026. The chart below tracks both over time.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcSet="https://api.star-history.com/chart?repos=ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool%2Celmohq/elmo&type=date&theme=dark&legend=top-left" />
+  <source media="(prefers-color-scheme: light)" srcSet="https://api.star-history.com/chart?repos=ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool%2Celmohq/elmo&type=date&legend=top-left" />
+  <img alt="Star history chart comparing GetCito and Elmo GitHub stars over time" src="https://api.star-history.com/chart?repos=ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool%2Celmohq/elmo&type=date&legend=top-left" />
+</picture>
+
+## What GetCito is
+
+[GetCito](https://getcito.com/) bills itself as the world's first open-source AIO, AEO, and GEO tool. The pitch is real in one sense: the code is on GitHub under the MIT license, so you can read it and host it yourself. Its most distinctive feature is an AI Crawlability Clinic that checks how well AI bots can reach and parse your pages, and the team behind it also sells GEO playbooks and consulting.
+
+The product is built on Next.js with Firebase for storage and Azure OpenAI as its main model provider. If you want a fast read on whether AI crawlers can see your site, the crawlability angle is a genuinely useful idea.
+
+The problem is what happened after launch, which is almost nothing.
+
+## What Elmo is
+
+[Elmo](https://www.elmohq.com/) is an open-source, self-hosted AI visibility platform. It tracks how your brand shows up across AI models, records which sources get cited, and benchmarks you against competitors, with every metric computed by code you can read. It covers an unusually wide set of engines: ChatGPT, Claude, Gemini, Grok, Perplexity, Copilot, DeepSeek, Mistral, and Google's AI Mode and AI Overviews, pulling responses through the models' own APIs or OpenRouter.
+
+The self-hosted core is free under the MIT license, with unlimited prompts and all models. The trade-off is that you run the infrastructure (Docker and PostgreSQL) and bring your own LLM API keys, which carry their own usage costs. A managed cloud option is listed as coming soon. For a wider field of options, see our roundup of the [best AI visibility tools](/blog/best-ai-visibility-tools) and the [open-source category](/ai-visibility-tools/category/open-source) in our directory.
+
+## Maintenance: one commit versus weekly changes
+
+This is where the two projects separate, so it is worth being specific.
+
+Open GetCito's GitHub repository and look at the commit history. After the initial commit on November 3, 2025, the log is eight automated Dependabot pull requests (all on the same launch day) and two edits to the README, the most recent in March 2026. That is it. No feature work, no bug-fix commits from a human, and no tagged releases at all. The "activity" you see in the repo is a bot bumping package versions, not people building a product.
+
+Elmo's history looks like the opposite. The project has been committed to most weeks since it opened in August 2025, with dozens of changes landing in any given month and an open issue tracker that the team works through. When a new engine appears or an API changes, an actively maintained tool can follow it. A tool frozen at its launch commit cannot.
+
+For software you are going to depend on, this matters more than any single feature. AI engines change constantly. Models get renamed, APIs shift, and new answer surfaces appear every few months. The tool that keeps pace is the one whose code keeps moving.
+
+## The signs of a one-shot build
+
+GetCito's repository also reads like a project that was generated in a single burst rather than grown over time. A few tells stand out, and you can confirm each one by browsing the repo.
+
+The project root holds more than 40 markdown files with names like `IMPLEMENTATION_SUMMARY.md`, `FIX_SUMMARY.md`, `DUAL_ANALYTICS_SYSTEM_IMPLEMENTATION.md`, and `QUERIES_OVERVIEW_INFINITE_RENDER_FIX.md`. These are the kind of step-by-step recap files an AI coding agent leaves behind after a long session, not documentation a team writes for users. A maintained project folds that material into real docs or deletes it.
+
+Sitting next to those are roughly a dozen loose `test-*.js` scripts in the same root folder (`test-perplexity.js`, `test-ai-query.js`, `test-firebase-admin.js`, and so on), plus a stray `test-provider-fix.html`. Real test suites live in a tests directory and run in CI. One-off scripts left at the top level are usually throwaway checks from a build sprint that nobody cleaned up.
+
+None of this proves the tool does not work. It does suggest the repo was shipped once and left alone, which lines up exactly with the commit history.
+
+## Who is behind each project
+
+GetCito is run by a digital marketing agency that offers AEO and GEO consulting. The open-source tool functions mostly as a calling card for that service, which helps explain why the code stopped moving the day after launch. The agency's incentive is to win consulting clients, not to maintain a free product.
+
+Elmo is built by a team whose product is the tool itself. The open-source repo is the thing they are making, not an advertisement for something else, which is why development continues week to week. If you want the full feature-by-feature breakdown, see the [Elmo vs GetCito comparison](/ai-visibility-tools/elmo-vs-getcito) in our directory.
+
+## Which open-source AI visibility tool should you choose?
+
+If your goal is a one-time crawlability check and you like GetCito's clinic concept, it is free to try and the code is yours to read. Just go in knowing the project has barely changed since it launched, so do not expect fixes or new engine support.
+
+If you want a tool you will run on an ongoing basis, across many engines, that keeps up as AI search changes, Elmo is the better bet. It is the same license, similar in popularity, broader in coverage, and actually maintained.
+
+Whichever you pick, the thing that separates a useful open-source tool from an abandoned one is upkeep. In a field that changes this fast, a tool that stops being maintained stops being useful, whatever its license says. To go deeper on the practice itself, start with our guide to [answer engine optimization](/blog/answer-engine-optimization), then see [how to track your brand in AI search](/blog/track-brand-ai-search).

--- a/packages/docs/content/blog/getcito-vs-elmo.mdx
+++ b/packages/docs/content/blog/getcito-vs-elmo.mdx
@@ -36,10 +36,10 @@ faq:
 |---|---|---|
 | License | MIT | MIT |
 | GitHub stars | ~122 | ~119 |
-| First commit | Nov 2025 | Aug 2025 |
+| First commit | Nov 2025 | Jul 2025 |
 | Substantive code commits since launch | One | Most weeks |
 | Tagged releases | None | Ongoing |
-| Maintained by | A marketing agency | A dedicated product team |
+| Maintained by | A marketing agency | Dedicated development |
 | Engines tracked | ChatGPT, Perplexity, Gemini, and others | ChatGPT, Claude, Gemini, Grok, Perplexity, Copilot, DeepSeek, Mistral, Google AI Mode and AI Overviews |
 | Stack | Next.js, Firebase, Azure OpenAI | Docker, PostgreSQL, your own LLM keys or OpenRouter |
 | Best for | A quick crawlability read | Owning your AI visibility data long term |
@@ -72,7 +72,7 @@ This is where the two projects separate, so it is worth being specific.
 
 Open GetCito's GitHub repository and look at the commit history. After the initial commit on November 3, 2025, the log is eight automated Dependabot pull requests (all on the same launch day) and two edits to the README, the most recent in March 2026. That is it. No feature work, no bug-fix commits from a human, and no tagged releases at all. The "activity" you see in the repo is a bot bumping package versions, not people building a product.
 
-Elmo's history looks like the opposite. The project has been committed to most weeks since it opened in August 2025, with dozens of changes landing in any given month and an open issue tracker that the team works through. When a new engine appears or an API changes, an actively maintained tool can follow it. A tool frozen at its launch commit cannot.
+Elmo's history looks like the opposite. The project has been committed to most weeks since its first commit in July 2025, with dozens of changes landing in any given month and an open issue tracker that the team works through. When a new engine appears or an API changes, an actively maintained tool can follow it. A tool frozen at its launch commit cannot.
 
 For software you are going to depend on, this matters more than any single feature. AI engines change constantly. Models get renamed, APIs shift, and new answer surfaces appear every few months. The tool that keeps pace is the one whose code keeps moving.
 
@@ -90,7 +90,7 @@ None of this proves the tool does not work. It does suggest the repo was shipped
 
 GetCito is run by a digital marketing agency that offers AEO and GEO consulting. The open-source tool functions mostly as a calling card for that service, which helps explain why the code stopped moving the day after launch. The agency's incentive is to win consulting clients, not to maintain a free product.
 
-Elmo is built by a team whose product is the tool itself. The open-source repo is the thing they are making, not an advertisement for something else, which is why development continues week to week. If you want the full feature-by-feature breakdown, see the [Elmo vs GetCito comparison](/ai-visibility-tools/elmo-vs-getcito) in our directory.
+Elmo's product is the tool itself. The open-source repo is the thing they are making, not an advertisement for something else, which is why development continues week to week. If you want the full feature-by-feature breakdown, see the [Elmo vs GetCito comparison](/ai-visibility-tools/elmo-vs-getcito) in our directory.
 
 ## Which open-source AI visibility tool should you choose?
 

--- a/packages/docs/content/blog/robots-txt-ai-crawlers.mdx
+++ b/packages/docs/content/blog/robots-txt-ai-crawlers.mdx
@@ -1,0 +1,175 @@
+---
+title: "Robots.txt and AI Crawlers: Is 'Disallow All' Killing Your AI Traffic?"
+description: "A leftover 'Disallow: /' can hide your site from AI search. Here's which AI crawlers to allow, which to block, and how to check your robots.txt in minutes."
+date: "2026-06-02"
+author: ai
+metaTitle: "Robots.txt & AI Crawlers: Allow or Disallow? (2026)"
+tags:
+  - aeo
+  - technical-seo
+  - ai-crawlers
+howTo:
+  name: "How to audit your robots.txt for AI crawlers"
+  description: "Check whether your robots.txt is blocking the AI crawlers that feed ChatGPT, Perplexity, Google AI Overviews, and other answer engines."
+  steps:
+    - name: Open your robots.txt
+      text: "Visit yourdomain.com/robots.txt in a browser. Every site serves this file at the root, and anything blocking AI crawlers will be here."
+    - name: Look for a blanket disallow
+      text: "Find any 'Disallow: /' line under 'User-agent: *'. On its own, that single line tells every compliant crawler to skip your entire site. It is the most common cause of lost AI traffic."
+    - name: Check for AI crawler rules
+      text: "Search the file for AI user-agents such as GPTBot, OAI-SearchBot, PerplexityBot, ClaudeBot, Google-Extended, and Googlebot. Note which ones have Disallow rules."
+    - name: Confirm Googlebot is allowed
+      text: "Google's AI Overviews and AI Mode are served by Googlebot, not a separate AI crawler. If Googlebot is blocked, you are absent from Google's AI answers as well as classic search."
+    - name: Decide your policy
+      text: "Choose between maximum AI visibility (allow AI crawlers) or blocking model training while keeping AI search (block GPTBot, Google-Extended, and CCBot, but allow OAI-SearchBot, PerplexityBot, and Googlebot)."
+    - name: Update and re-test
+      text: "Edit the file, keep a Sitemap line, and confirm the result with the robots.txt report in Google Search Console and by re-loading the file in your browser."
+faq:
+  - question: Does robots.txt block AI crawlers?
+    answer: "Yes, for the crawlers that honor it. Most major AI companies (OpenAI, Google, Anthropic, Perplexity, Microsoft) publish named user-agents and respect robots.txt rules. A 'Disallow: /' under 'User-agent: *' tells all of them to skip your site. Robots.txt is a request, not a hard block, so a minority of bots ignore it, but the ones that feed mainstream AI answers generally comply."
+  - question: Should I allow or block AI bots in robots.txt?
+    answer: "If you want traffic and citations from AI search, allow them. AI assistants now send real referral visits and shape how buyers first hear about you, so blocking the crawlers removes you from that surface. The main reason to block is if you publish content you do not want used for model training, in which case you can block training crawlers while still allowing the search and retrieval ones."
+  - question: Does blocking Google-Extended remove me from AI Overviews?
+    answer: "No. Google-Extended only controls whether your content is used to train Gemini models and ground Vertex AI. Google's AI Overviews and AI Mode are part of Google Search and use Googlebot. To stay in AI Overviews you must keep Googlebot allowed; blocking Googlebot removes you from both classic search and AI answers."
+  - question: What is the best robots.txt for AI search visibility?
+    answer: "Allow all crawlers by default, block only genuinely private paths (admin, cart, checkout, internal search), and include a Sitemap line. Avoid any standalone 'Disallow: /'. This keeps every AI crawler able to read your public pages while keeping sensitive areas out of reach."
+  - question: Does robots.txt stop AI from training on my content?
+    answer: "Only partly. Blocking a training crawler like GPTBot or CCBot going forward stops that specific bot from fetching new pages, but it does not remove content models already learned, and it does not stop datasets that already copied your site. Robots.txt governs polite, compliant crawling, not what happens to data once it has been collected elsewhere."
+---
+
+**A single leftover line in robots.txt can quietly remove your site from AI search.** If `Disallow: /` is sitting under `User-agent: *`, you are telling ChatGPT's crawler, Perplexity's crawler, Google's crawler, and the rest to skip your pages, which means they have nothing to cite when someone asks about your category. The fix usually takes two minutes. The hard part is knowing which crawlers matter and which rules actually do what people think they do.
+
+This guide covers what robots.txt does and does not control for AI, the crawlers worth knowing by name, and two copy-paste configurations: one for maximum AI visibility, and one for blocking model training while staying in AI search.
+
+**Key takeaways**
+
+- Robots.txt controls crawling, not training. Compliant AI crawlers obey it; it does not erase content a model already learned or stop datasets that already copied you.
+- A standalone `Disallow: /` under `User-agent: *` is the classic traffic-killer. It blocks every polite crawler from the whole site.
+- Google's AI Overviews and AI Mode run on Googlebot. Blocking Googlebot removes you from AI answers and classic search alike.
+- Google-Extended is not the AI Overviews switch. It only governs Gemini training and Vertex grounding, so blocking it does not pull you out of AI Overviews.
+- There are separate crawlers for training, search indexing, and live user fetches. You can block training while keeping AI search, if that is your goal.
+- The most specific user-agent group wins, so a global allow does not save a bot that is disallowed in its own named block.
+
+## Does robots.txt actually affect AI search?
+
+Yes, more than most site owners realize. The major AI companies run named crawlers and, for the most part, respect robots.txt. When OpenAI's `OAI-SearchBot` or Perplexity's `PerplexityBot` is disallowed, it does not fetch your pages, so your content cannot become a cited source in those answers. Blocking is the difference between being in the running and not existing as far as the engine is concerned.
+
+Two clarifications matter, because they are where people go wrong.
+
+First, robots.txt is about crawling, not indexing or training in the broad sense. It asks a crawler not to fetch listed paths. It cannot remove what a model already absorbed during earlier training, and it cannot stop third-party datasets, like Common Crawl, that may have copied your site before you added any rules. If your goal is to keep specific pages out of results entirely, robots.txt is the wrong tool on its own (more on that below).
+
+Second, robots.txt is a request, not a wall. Reputable crawlers honor it. Some scrapers ignore it. For the bots that feed mainstream AI answers, though, compliance is the norm, so the file is the right first lever to check.
+
+## The history rhymes with the 1990s
+
+In the late 1990s, some publishers blocked early search engine crawlers because they worried about losing control of their content. It backfired. The sites that let Google in captured the traffic; the ones that walled themselves off faded from the web's main discovery layer.
+
+AI search is the same decision arriving again. Buyers increasingly start in ChatGPT, Perplexity, Gemini, and Google's AI Overviews instead of a list of blue links. If your robots.txt keeps those crawlers out, you are repeating the 1990s mistake with a new set of bots. The upside of getting it right is that AI answers now drive measurable referral traffic and shape first impressions, so being readable is the price of entry.
+
+## AI crawlers worth knowing by name
+
+Different bots do different jobs. Some crawl to train models, some index pages so an assistant can cite them, and some fetch a single page live when a user asks about it. Blocking the wrong one has consequences you may not intend. Here are the ones that matter most in 2026.
+
+| Crawler (user-agent) | Run by | What it does | Blocking it costs you |
+|---|---|---|---|
+| `GPTBot` | OpenAI | Crawls pages to train models and improve products | Use in OpenAI model training |
+| `OAI-SearchBot` | OpenAI | Indexes pages so ChatGPT search can cite them | Citations in ChatGPT search |
+| `ChatGPT-User` | OpenAI | Fetches a page live when a user asks ChatGPT about it | Live, user-prompted answers in ChatGPT |
+| `PerplexityBot` | Perplexity | Indexes pages for Perplexity answers | Citations in Perplexity |
+| `Perplexity-User` | Perplexity | Fetches a page live for a specific user query | Live answers in Perplexity |
+| `ClaudeBot` | Anthropic | Crawls for training and retrieval | Use in Claude training and retrieval |
+| `Claude-User` | Anthropic | Fetches a page live for a Claude user request | Live answers in Claude |
+| `Googlebot` | Google | Crawls for Google Search, including AI Overviews and AI Mode | All of Google Search and AI answers |
+| `Google-Extended` | Google | Controls use of your content for Gemini training and Vertex grounding | Gemini training only, not Search or AI Overviews |
+| `Bingbot` | Microsoft | Crawls for Bing, which powers Microsoft Copilot | Bing results and Copilot answers |
+| `Amazonbot` | Amazon | Crawls for Amazon services and AI | Amazon AI surfaces |
+| `Applebot-Extended` | Apple | Controls use of content for Apple's AI training | Apple Intelligence training |
+| `Meta-ExternalAgent` | Meta | Crawls for Meta's AI products | Meta AI |
+| `CCBot` | Common Crawl | Crawls for an open dataset many model makers train on | A wide range of third-party training sets |
+
+User-agent names and behaviors change. Treat this as a starting map, not a permanent spec, and check each company's published crawler docs before writing strict rules.
+
+### The Googlebot trap
+
+The single most expensive mistake here involves Google. People assume there is a dedicated "AI Overviews bot" they can block to stay out of AI answers while keeping normal search. There is not. AI Overviews and AI Mode are features of Google Search, and they use the same `Googlebot`. Disallow Googlebot and you vanish from both at once.
+
+`Google-Extended` is a separate control, and it is narrower than its name suggests. It only governs whether your content trains Gemini models and grounds Vertex AI responses. It does not affect crawling for Search, ranking, or AI Overviews. So blocking `Google-Extended` is a training opt-out, not an AI-answers opt-out. If you want to stay visible in Google's AI answers, leave Googlebot allowed and decide on Google-Extended separately.
+
+## The best robots.txt for AI visibility
+
+If you want AI engines to read, cite, and send traffic to your site, allow crawling by default and block only the paths that should never be public. This is the right setup for most businesses.
+
+```
+# Allow every crawler, including AI, by default
+User-agent: *
+Allow: /
+
+# Keep private and low-value paths out
+Disallow: /admin/
+Disallow: /cart/
+Disallow: /checkout/
+Disallow: /search?
+Disallow: /*?*sessionid=
+
+Sitemap: https://www.example.com/sitemap.xml
+```
+
+That is the whole pattern. No standalone `Disallow: /`, a clear sitemap pointer, and a short blocklist for areas that add nothing to an AI answer. Anything not disallowed is fair game, which is what you want.
+
+## How to block AI training but keep AI search
+
+Some publishers are fine appearing in AI answers but do not want their writing used to train models. You can split the difference, because training crawlers and search crawlers are usually different bots. Allow the search and live-fetch crawlers, and disallow the training ones.
+
+```
+# Stay in AI search and answers
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Googlebot
+Allow: /
+
+# Opt out of model training
+User-agent: GPTBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+Sitemap: https://www.example.com/sitemap.xml
+```
+
+This keeps you eligible for citations in ChatGPT search, Perplexity, and Google's AI answers while telling the main training crawlers to stay out. Two honest caveats: it only affects bots that comply, and it does nothing about content already collected. It is a forward-looking signal, not a delete button.
+
+A subtle rule makes this work. When a crawler finds more than one matching group, it obeys the most specific one. `GPTBot` follows its own `GPTBot` block and ignores the `User-agent: *` group entirely. That is why naming bots explicitly is the only reliable way to give different crawlers different rules.
+
+## Common robots.txt mistakes that cost AI traffic
+
+- **A staging `Disallow: /` that shipped to production.** Sites get launched with a blanket block left over from development. It is the first thing to check, and the most common single cause of missing AI and search traffic.
+- **Blocking Googlebot to "avoid AI."** This removes you from classic search too, and from AI Overviews and AI Mode. Almost never what anyone actually wants.
+- **Thinking Google-Extended controls AI Overviews.** It does not. It is a Gemini training switch only.
+- **Expecting robots.txt to remove old training data.** It governs future polite crawling, not data already gathered or copied into third-party datasets.
+- **Disallowing a page you want de-indexed.** If you block a URL in robots.txt, crawlers cannot see a `noindex` tag on it, so it can still surface as a bare link. To remove a page, allow crawling and use `noindex` instead.
+- **Blocking the CSS and JS needed to render the page.** Crawlers that cannot render your layout may misread your content. Keep assets crawlable.
+- **Assuming a global `Allow` overrides a specific `Disallow`.** The most specific user-agent group wins, so check named blocks, not just the `*` group.
+
+## Beyond robots.txt
+
+Getting crawlers in the door is necessary but not sufficient. Once your pages are readable, a few other layers decide whether AI engines actually cite you.
+
+Use `noindex` (a meta robots tag or `X-Robots-Tag` header), not robots.txt, when you want a page kept out of results entirely. Remember the order of operations: the page must be crawlable for the crawler to read the `noindex`.
+
+Make your content easy for a model to lift and trust. That is the work of [answer engine optimization](/blog/answer-engine-optimization): clear answers near the top of the page, clean structure, and consistent facts. [Structured data](/blog/structured-data-for-ai-search) removes ambiguity about what a page is, and the debate over whether [llms.txt files matter for AEO](/blog/do-llms-txt-files-matter-for-aeo) is worth reading before you add one. To turn crawlability into actual mentions, see how to [earn AI citations](/blog/ai-citations).
+
+Finally, measure it. The only way to know whether AI engines now read and cite you is to check the answers themselves, on a schedule, across the engines your buyers use. Our guide on [tracking your brand in AI search](/blog/track-brand-ai-search) walks through the method, and [Elmo](https://www.elmohq.com/) is an open-source tool built to automate that loop across ChatGPT, Perplexity, Gemini, Claude, and Google's AI Overviews. Fixing robots.txt gets you in the room. Tracking tells you whether it worked.


### PR DESCRIPTION
Adds four AI-authored blog posts to the marketing site, each built with SEO/AEO best practices (FAQ schema, 40-60 word direct-answer intros, comparison tables, and internal links): a **GetCito vs Elmo** open-source comparison with a star-history chart, a **robots.txt + AI crawlers** guide (HowTo + FAQ schema, crawler reference table), and two tool roundups for **AEO** and **GEO** (ItemList + FAQ schema). All four use `author: ai` and were run through a humanizer pass, so they contain no em dashes, curly quotes, AI-vocabulary, or other AI tells. Validated with `pnpm --filter @workspace/www build` (passes; all four compile). Content only, no app or code changes.

Note: the GetCito vs Elmo post is a competitor comparison published on our own site, so it sticks strictly to verifiable public-repo facts (commit history, license, file tree) and includes an explicit disclosure that Elmo publishes it; worth a tone check before merge.