### PR TITLE
Fix /ai-visibility-tools/features 404 + add category CTA banner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,9 @@ elmo.yaml
 e2e/artifacts
 
 # retroactive cleanup
-features/
+# Anchored to the repo root: an unanchored `features/` also matches source
+# directories like apps/www/src/routes/ai-visibility-tools/features/.
+/features/
 .agents/
 .cursor/
 apps/www/dist/

--- a/apps/www/src/components/directory-shell.tsx
+++ b/apps/www/src/components/directory-shell.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { Badge } from "@workspace/ui/components/badge";
 import { Button } from "@workspace/ui/components/button";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 import type { ReactNode } from "react";
 
 /** Back link to the directory, matching the competitor comparison pages. */
@@ -42,6 +42,48 @@ export function DirectoryHero({
 					{title}
 				</h1>
 				<p className="mt-4 max-w-3xl text-lg text-balance text-zinc-600">{lead}</p>
+			</div>
+		</section>
+	);
+}
+
+/**
+ * The "Elmo: the open-source alternative" banner, surfaced high on a page right
+ * under the hero. `pitch` is the page-specific paragraph; `comparison` points the
+ * secondary button at the matching Elmo-vs comparison page.
+ */
+export function DirectoryElmoBanner({
+	pitch,
+	comparison,
+}: {
+	pitch: string;
+	comparison: { slug: string; name: string };
+}) {
+	return (
+		<section className="border-b border-zinc-200 bg-zinc-50 py-10">
+			<div className="mx-auto max-w-6xl px-4 md:px-6">
+				<div className="rounded-md border border-blue-200 bg-blue-50/40 p-6">
+					<h2 className="font-heading text-xl text-zinc-950">
+						Elmo: the open-source alternative
+					</h2>
+					<p className="mt-2 max-w-3xl text-sm leading-relaxed text-zinc-600">
+						{pitch}
+					</p>
+					<div className="mt-4 flex flex-wrap gap-3">
+						<Button asChild size="sm">
+							<Link to="/docs">Deploy Elmo</Link>
+						</Button>
+						<Button asChild variant="outline" size="sm">
+							<Link
+								to="/ai-visibility-tools/$slug"
+								params={{ slug: comparison.slug }}
+							>
+								Elmo vs {comparison.name}
+								<ArrowRight className="h-3.5 w-3.5" />
+							</Link>
+						</Button>
+					</div>
+				</div>
 			</div>
 		</section>
 	);

--- a/apps/www/src/lib/competitors/directory.ts
+++ b/apps/www/src/lib/competitors/directory.ts
@@ -394,3 +394,29 @@ export function getCategoryFaqs(
 		},
 	];
 }
+
+/**
+ * Category-tailored pitch for the "Elmo: the open-source alternative" banner.
+ * Each one frames Elmo against what that category actually leads with, so the
+ * CTA reads as specific to the page rather than a generic blurb.
+ */
+const CATEGORY_ELMO_PITCH: Record<CompetitorCategory, string> = {
+	tracking:
+		"Elmo does the same core job as the tools on this page: it measures how AI engines mention and cite your brand. The difference is that it is open source. You can self-host it for free, keep your prompts and history on your own infrastructure, and check exactly how each score is built instead of trusting a number from a closed dashboard.",
+	content:
+		"Most tools in this category lead with content generation. Elmo takes a narrower path and focuses on transparent tracking, so you can measure how AI engines mention and cite your brand before you decide what to publish. It is open source and self-hosted, with no per-seat fees and no scores you cannot inspect.",
+	"api-developer":
+		"The tools here are API-first. Elmo gives you the data and the code: self-host the whole platform, read how every metric is produced, and pull mentions and citations into your own dashboards without paying per call or depending on a pipeline you cannot see.",
+	ecommerce:
+		"Elmo tracks how ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews describe your brand across the major engines. It is the open-source choice in this space, so you run it yourself for free and verify every number rather than trusting a hosted score.",
+	"seo-traditional":
+		"The platforms in this category bolted AI search tracking onto an existing SEO suite. Elmo was built for the AI layer from the start, and it is open source, so you can self-host it for free and confirm how each visibility metric is calculated instead of taking a bundled feature on faith.",
+	"open-source":
+		"Like the other projects here, Elmo is open source, so you can read the code and run it yourself. It is built specifically for verifiable AI visibility tracking across ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews, and it adds white-label support for agencies with no per-seat pricing.",
+	other:
+		"Elmo is the open-source AI visibility platform in this directory. Self-host it for free, keep your data in-house, and verify how it tracks the way AI engines mention and cite your brand.",
+};
+
+export function getCategoryElmoPitch(category: CompetitorCategory): string {
+	return CATEGORY_ELMO_PITCH[category];
+}

--- a/apps/www/src/lib/competitors/index.ts
+++ b/apps/www/src/lib/competitors/index.ts
@@ -53,4 +53,5 @@ export {
 	getFeatureFaqs,
 	getCategoryVerdict,
 	getCategoryFaqs,
+	getCategoryElmoPitch,
 } from "./directory";

--- a/apps/www/src/routes/ai-visibility-tools/alternatives/$slug.tsx
+++ b/apps/www/src/routes/ai-visibility-tools/alternatives/$slug.tsx
@@ -1,12 +1,11 @@
-import { createFileRoute, notFound, Link } from "@tanstack/react-router";
-import { Button } from "@workspace/ui/components/button";
-import { ArrowRight } from "lucide-react";
+import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { Faq } from "@/components/faq";
 import { ToolGrid } from "@/components/tool-list";
 import {
 	DirectoryBackLink,
+	DirectoryElmoBanner,
 	DirectoryHero,
 	DirectorySection,
 	ElmoCta,
@@ -14,6 +13,7 @@ import {
 import { ogMeta, canonicalUrl, breadcrumbJsonLd, faqJsonLd } from "@/lib/seo";
 import {
 	getCompetitorBySlug,
+	getComparisonSlug,
 	isIndexed,
 	getAlternatives,
 	getAlternativesVerdict,
@@ -69,37 +69,13 @@ function AlternativesPage() {
 					lead={getAlternativesVerdict(competitor)}
 				/>
 
-				{/* Elmo: the open-source pick */}
-				<section className="border-b border-zinc-200 bg-zinc-50 py-10">
-					<div className="mx-auto max-w-6xl px-4 md:px-6">
-						<div className="rounded-md border border-blue-200 bg-blue-50/40 p-6">
-							<h2 className="font-heading text-xl text-zinc-950">
-								Elmo: the open-source alternative
-							</h2>
-							<p className="mt-2 max-w-3xl text-sm leading-relaxed text-zinc-600">
-								Elmo tracks how ChatGPT, Claude, Perplexity, Gemini, and Google
-								AI Overviews mention and cite your brand. It is open source, so
-								you self-host it for free, keep your data in-house, and verify
-								exactly how each metric is calculated. No per-seat pricing, no
-								black-box scores, no lock-in.
-							</p>
-							<div className="mt-4 flex flex-wrap gap-3">
-								<Button asChild size="sm">
-									<Link to="/docs">Deploy Elmo</Link>
-								</Button>
-								<Button asChild variant="outline" size="sm">
-									<Link
-										to="/ai-visibility-tools/$slug"
-										params={{ slug: `elmo-vs-${competitor.slug}` }}
-									>
-										Elmo vs {competitor.name}
-										<ArrowRight className="h-3.5 w-3.5" />
-									</Link>
-								</Button>
-							</div>
-						</div>
-					</div>
-				</section>
+				<DirectoryElmoBanner
+					pitch="Elmo tracks how ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews mention and cite your brand. It is open source, so you self-host it for free, keep your data in-house, and verify exactly how each metric is calculated. No per-seat pricing, no black-box scores, no lock-in."
+					comparison={{
+						slug: getComparisonSlug(competitor),
+						name: competitor.name,
+					}}
+				/>
 
 				<DirectorySection title={`Other ${competitor.name} alternatives`}>
 					<ToolGrid competitors={alternatives} />

--- a/apps/www/src/routes/ai-visibility-tools/category/$slug.tsx
+++ b/apps/www/src/routes/ai-visibility-tools/category/$slug.tsx
@@ -5,6 +5,7 @@ import { Faq } from "@/components/faq";
 import { ToolGrid } from "@/components/tool-list";
 import {
 	DirectoryBackLink,
+	DirectoryElmoBanner,
 	DirectoryHero,
 	DirectorySection,
 	ElmoCta,
@@ -12,6 +13,8 @@ import {
 import { ogMeta, canonicalUrl, breadcrumbJsonLd, faqJsonLd } from "@/lib/seo";
 import {
 	getCategoryBySlug,
+	getCategoryElmoPitch,
+	getComparisonSlug,
 	toolsInCategory,
 	getCategoryVerdict,
 	getCategoryFaqs,
@@ -71,6 +74,13 @@ function CategoryPage() {
 					eyebrow="Category"
 					title={CATEGORY_HEADINGS[category]}
 					lead={getCategoryVerdict(category, tools)}
+				/>
+				<DirectoryElmoBanner
+					pitch={getCategoryElmoPitch(category)}
+					comparison={{
+						slug: getComparisonSlug(tools[0]),
+						name: tools[0].name,
+					}}
 				/>
 				<DirectorySection title="Tools in this category">
 					<ToolGrid competitors={tools} />

--- a/apps/www/src/routes/ai-visibility-tools/features/$slug.tsx
+++ b/apps/www/src/routes/ai-visibility-tools/features/$slug.tsx
@@ -1,0 +1,86 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { Faq } from "@/components/faq";
+import { ToolGrid } from "@/components/tool-list";
+import {
+	DirectoryBackLink,
+	DirectoryHero,
+	DirectorySection,
+	ElmoCta,
+} from "@/components/directory-shell";
+import { ogMeta, canonicalUrl, breadcrumbJsonLd, faqJsonLd } from "@/lib/seo";
+import {
+	getFeatureKeyBySlug,
+	toolsWithFeature,
+	getFeatureLabel,
+	getFeatureVerdict,
+	getFeatureFaqs,
+	MIN_TOOLS_FOR_FEATURE_PAGE,
+	type Competitor,
+	type FeatureKey,
+} from "@/lib/competitors";
+
+export const Route = createFileRoute("/ai-visibility-tools/features/$slug")({
+	head: ({ params }) => {
+		const key = getFeatureKeyBySlug(params.slug);
+		if (!key) return {};
+		const tools = toolsWithFeature(key);
+		if (tools.length < MIN_TOOLS_FOR_FEATURE_PAGE) return {};
+		const label = getFeatureLabel(key);
+		const title = `AI Visibility Tools with ${label} · Elmo`;
+		const description = `See which AI visibility tools offer ${label.toLowerCase()} and how they compare, including the open-source option, Elmo.`;
+		const path = `/ai-visibility-tools/features/${params.slug}`;
+		return {
+			meta: [
+				{ title },
+				{ name: "description", content: description },
+				...ogMeta({ title, description, path }),
+			],
+			links: [{ rel: "canonical", href: canonicalUrl(path) }],
+			scripts: [
+				breadcrumbJsonLd([
+					{ name: "Home", path: "/" },
+					{ name: "AI Visibility Tool Directory", path: "/ai-visibility-tools" },
+					{ name: label, path },
+				]),
+				faqJsonLd(getFeatureFaqs(key, tools)),
+			],
+		};
+	},
+	loader: ({ params }) => {
+		const key = getFeatureKeyBySlug(params.slug);
+		if (!key) throw notFound();
+		const tools = toolsWithFeature(key);
+		if (tools.length < MIN_TOOLS_FOR_FEATURE_PAGE) throw notFound();
+		return { featureKey: key, tools };
+	},
+	component: FeaturePage,
+});
+
+function FeaturePage() {
+	const { featureKey, tools } = Route.useLoaderData() as {
+		featureKey: FeatureKey;
+		tools: Competitor[];
+	};
+	const label = getFeatureLabel(featureKey);
+	return (
+		<div className="min-h-screen">
+			<Navbar />
+			<main>
+				<DirectoryBackLink />
+				<DirectoryHero
+					eyebrow="Feature"
+					title={`AI visibility tools with ${label}`}
+					lead={getFeatureVerdict(featureKey, tools)}
+				/>
+				<DirectorySection title="Tools that offer this feature">
+					<ToolGrid competitors={tools} />
+				</DirectorySection>
+				<Faq items={getFeatureFaqs(featureKey, tools)} eyebrow="/ FAQ" />
+				<ElmoCta />
+			</main>
+			<Footer />
+		</div>
+	);
+}

--- a/apps/www/src/routes/ai-visibility-tools/features/index.tsx
+++ b/apps/www/src/routes/ai-visibility-tools/features/index.tsx
@@ -1,0 +1,104 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import {
+	DirectoryBackLink,
+	DirectoryHero,
+	DirectorySection,
+	ElmoCta,
+} from "@/components/directory-shell";
+import {
+	ogMeta,
+	canonicalUrl,
+	breadcrumbJsonLd,
+	itemListJsonLd,
+} from "@/lib/seo";
+import {
+	FEATURE_CATEGORIES,
+	FEATURE_SLUGS,
+	getFeatureLabel,
+	indexableFeatureKeys,
+	toolsWithFeature,
+	type FeatureKey,
+} from "@/lib/competitors";
+
+const title = "AI Visibility Tools by Feature · Elmo";
+const description =
+	"Browse AI visibility tools by capability: multi-LLM tracking, citation analytics, sentiment, white-label, and more. See which tools offer each feature.";
+
+const indexableKeys = new Set(indexableFeatureKeys());
+
+// Group the indexable features under their feature-matrix sections, keeping the
+// matrix order. Sections with no indexable feature are dropped.
+const featureGroups = Object.values(FEATURE_CATEGORIES)
+	.map((section) => ({
+		label: section.label,
+		keys: (Object.keys(section.features) as FeatureKey[]).filter((key) =>
+			indexableKeys.has(key),
+		),
+	}))
+	.filter((group) => group.keys.length > 0);
+
+const items = indexableFeatureKeys().map((key) => ({
+	name: getFeatureLabel(key),
+	path: `/ai-visibility-tools/features/${FEATURE_SLUGS[key]}`,
+}));
+
+export const Route = createFileRoute("/ai-visibility-tools/features/")({
+	head: () => ({
+		meta: [
+			{ title },
+			{ name: "description", content: description },
+			...ogMeta({ title, description, path: "/ai-visibility-tools/features" }),
+		],
+		links: [
+			{ rel: "canonical", href: canonicalUrl("/ai-visibility-tools/features") },
+		],
+		scripts: [
+			breadcrumbJsonLd([
+				{ name: "Home", path: "/" },
+				{ name: "AI Visibility Tool Directory", path: "/ai-visibility-tools" },
+				{ name: "Features", path: "/ai-visibility-tools/features" },
+			]),
+			itemListJsonLd(items),
+		],
+	}),
+	component: FeatureHub,
+});
+
+function FeatureHub() {
+	return (
+		<div className="min-h-screen">
+			<Navbar />
+			<main>
+				<DirectoryBackLink />
+				<DirectoryHero
+					eyebrow="By feature"
+					title="Browse AI visibility tools by feature"
+					lead="Filter the field by capability. Pick a feature to see which AI visibility tools offer it and how they compare, including the open-source option you can self-host."
+				/>
+				{featureGroups.map((group) => (
+					<DirectorySection key={group.label} title={group.label}>
+						<ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+							{group.keys.map((key) => (
+								<li key={key}>
+									<a
+										href={`/ai-visibility-tools/features/${FEATURE_SLUGS[key]}`}
+										className="flex items-center justify-between rounded-md border border-zinc-200 bg-white px-4 py-3 text-sm font-medium text-zinc-700 transition-colors hover:border-zinc-300 hover:text-zinc-950"
+									>
+										<span>{getFeatureLabel(key)}</span>
+										<span className="font-mono text-[11px] text-zinc-400">
+											{toolsWithFeature(key).length}
+										</span>
+									</a>
+								</li>
+							))}
+						</ul>
+					</DirectorySection>
+				))}
+				<ElmoCta />
+			</main>
+			<Footer />
+		</div>
+	);
+}


### PR DESCRIPTION
## What & why

Two issues on the AI Visibility Tool Directory:

### 1. `/ai-visibility-tools/features` was a 404
The directory's "Browse by feature" card, the sitemap (22 URLs), and the generated route tree all reference `/ai-visibility-tools/features`, but the route components never made it into the repo.

**Root cause:** a `.gitignore` entry added in `87a47e8` to drop a root-level `features/` directory was written **unanchored** (`features/`), so it also matched `apps/www/src/routes/ai-visibility-tools/features/`. When #309 generated the feature pages, git silently ignored them — the route tree and sitemap got committed, the actual `.tsx` files did not.

Fixes:
- Anchor the ignore to `/features/` so it only targets the root dir, not source directories.
- Add the missing **features hub** (`/ai-visibility-tools/features`) and **per-feature slice pages** (`/ai-visibility-tools/features/$slug`). These are built entirely on the helpers that already existed (`FEATURE_SLUGS`, `getFeatureKeyBySlug`, `toolsWithFeature`, `getFeatureVerdict`, `getFeatureFaqs`) and mirror the sibling `category`/`alternatives` pages. This resolves **21 feature slices + the hub**, matching #309's intent and the existing sitemap entries.

The hub groups features by the feature-matrix sections (Core Tracking, Platform, Advanced Analytics, etc.) and shows a tool count per feature. Each slice page lists the tools that offer the feature, with an FAQ and the standard closing CTA.

### 2. Category pages had no Elmo CTA
Alternatives pages (e.g. `/alternatives/profound`) have a prominent "Elmo: the open-source alternative" banner, but category pages (e.g. `/category/content-generation`) had nothing similar.

- Extracted that banner into a shared `DirectoryElmoBanner` component (in `directory-shell.tsx`, alongside the other shared directory pieces) and refactored the alternatives page to use it — no visual change there.
- Added a **category-tailored** version to the category pages: copy written per category (`getCategoryElmoPitch`) that frames Elmo against what each category actually leads with, plus an "Elmo vs &lt;most popular tool in category&gt;" comparison button.
- Applies to the dynamic category pages (tracking, content-generation, ecommerce, seo). The `open-source` category keeps its dedicated rich guide.

## Validation
- `pnpm --filter @workspace/www build` ✓ (route tree regenerated identically — the new files match the route IDs that were already committed)
- `pnpm --filter @workspace/www check-types` ✓ (this also un-breaks `tsc`, which was failing on the dead `features` imports in the committed route tree)

No changeset: consistent with #309, which added these directory pages without one (www marketing pages aren't part of the release-notes flow).