### PR TITLE
Resolve visibility prompt filters server-side to fix request URL overflow

### DIFF
--- a/.changeset/visibility-filters-not-prompt-ids.md
+++ b/.changeset/visibility-filters-not-prompt-ids.md
@@ -2,4 +2,4 @@
 "@workspace/web": patch
 ---
 
-Fix the visibility page failing to load for brands with many active prompts. The chart and visibility data now resolve from the active filters server-side instead of sending the full prompt-id list in the request, which previously overflowed the request URL (414 on Vercel / 431 in local dev) once a brand had a few hundred prompts.
+Fix the visibility page failing to load for brands with many active prompts.

--- a/.changeset/visibility-filters-not-prompt-ids.md
+++ b/.changeset/visibility-filters-not-prompt-ids.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Fix the visibility page failing to load for brands with many active prompts. The chart and visibility data now resolve from the active filters server-side instead of sending the full prompt-id list in the request, which previously overflowed the request URL (414 on Vercel / 431 in local dev) once a brand had a few hundred prompts.

--- a/apps/web/src/components/prompts-display.tsx
+++ b/apps/web/src/components/prompts-display.tsx
@@ -73,16 +73,15 @@ function PromptsContent({ brandId, editLink }: { brandId: string | undefined; ed
 
 	const availableTags = promptsSummary?.availableTags ?? [];
 
-	const { sortedPrompts, filteredPromptIds } = useMemo(() => {
-		if (!promptsSummary) return { sortedPrompts: [], filteredPromptIds: [] as string[] };
+	// The prompt list is still search-filtered client-side for display. The
+	// chart/visibility sections no longer receive this id list — they resolve
+	// the same prompts server-side from the tag + search filters (issue #68).
+	const sortedPrompts = useMemo(() => {
+		if (!promptsSummary) return [];
 		const allPrompts = promptsSummary.prompts;
-		const filtered = searchQuery
+		return searchQuery
 			? allPrompts.filter((p: { value: string }) => p.value.toLowerCase().includes(searchQuery.toLowerCase()))
 			: allPrompts;
-		return {
-			sortedPrompts: filtered,
-			filteredPromptIds: filtered.map((p: { id: string }) => p.id),
-		};
 	}, [promptsSummary, searchQuery]);
 
 	const isInitialLoad = isLoadingSummary && !promptsSummary;
@@ -102,7 +101,7 @@ function PromptsContent({ brandId, editLink }: { brandId: string | undefined; ed
 					showModelSelector
 					resultCount={isInitialLoad ? undefined : sortedPrompts.length}
 				/>
-				<VisibilityBarSection brandId={brandId} promptIds={filteredPromptIds} />
+				<VisibilityBarSection brandId={brandId} />
 			</FilterSection>
 
 			<div className="space-y-6">
@@ -146,8 +145,8 @@ function PromptsContent({ brandId, editLink }: { brandId: string | undefined; ed
 						selectedModel={selectedModel}
 						modelParam={modelParam}
 						searchQuery={searchQuery}
+						selectedTags={selectedTags}
 						sortedPrompts={sortedPrompts}
-						filteredPromptIds={filteredPromptIds}
 						availableIndividualModels={availableIndividualModels}
 					/>
 				)}
@@ -166,8 +165,8 @@ function ChartSection({
 	selectedModel,
 	modelParam,
 	searchQuery,
+	selectedTags,
 	sortedPrompts,
-	filteredPromptIds,
 	availableIndividualModels,
 }: {
 	brandId: string | undefined;
@@ -175,14 +174,15 @@ function ChartSection({
 	selectedModel: ReturnType<typeof usePageFilters>["selectedModel"];
 	modelParam: string | undefined;
 	searchQuery: string;
+	selectedTags: string[];
 	sortedPrompts: { id: string; value: string; firstEvaluatedAt?: Date | string | null }[];
-	filteredPromptIds: string[];
 	availableIndividualModels: string[];
 }) {
 	const { batchChartData, isLoading: isLoadingChartData } = useBatchChartData(brandId, {
 		lookback,
 		model: modelParam,
-		promptIds: filteredPromptIds,
+		tags: selectedTags.length > 0 ? selectedTags : undefined,
+		search: searchQuery || undefined,
 	});
 
 	const { startDate, endDate } = useMemo(() => {

--- a/apps/web/src/components/visibility-bar-section.tsx
+++ b/apps/web/src/components/visibility-bar-section.tsx
@@ -5,11 +5,11 @@ import { usePageFilters } from "@/components/filter-bar";
 
 /**
  * Self-contained visibility bar. Subscribes directly to the filter URL
- * keys it needs and fetches `useFilteredVisibility` itself, so it's a
- * sibling of the chart section rather than something the parent has to
- * wire through. The parent passes the already-search-filtered prompt
- * IDs since search is applied client-side and we don't want to duplicate
- * that logic here.
+ * keys it needs (lookback, model, tags, search) and fetches
+ * `useFilteredVisibility` itself, so it's a sibling of the chart section
+ * rather than something the parent has to wire through. The tag + search
+ * filters are resolved to prompt IDs server-side, so we pass the criteria
+ * rather than a prompt-id list (issue #68).
  *
  * The skeleton stays mounted inside a grid overlay so the bar reserves
  * its vertical space on load and doesn't shove the charts down when the
@@ -17,12 +17,10 @@ import { usePageFilters } from "@/components/filter-bar";
  */
 export function VisibilityBarSection({
 	brandId,
-	promptIds,
 }: {
 	brandId: string | undefined;
-	promptIds: string[];
 }) {
-	const { selectedLookback, selectedModel } = usePageFilters();
+	const { selectedLookback, selectedModel, selectedTags, searchQuery } = usePageFilters();
 	const modelParam = selectedModel === "all" ? undefined : selectedModel;
 
 	const {
@@ -31,7 +29,8 @@ export function VisibilityBarSection({
 		isValidating: isValidatingVisibility,
 	} = useFilteredVisibility(brandId, {
 		lookback: selectedLookback,
-		promptIds: promptIds.length > 0 ? promptIds : undefined,
+		tags: selectedTags.length > 0 ? selectedTags : undefined,
+		search: searchQuery || undefined,
 		model: modelParam,
 	});
 

--- a/apps/web/src/hooks/use-batch-chart-data.tsx
+++ b/apps/web/src/hooks/use-batch-chart-data.tsx
@@ -7,14 +7,15 @@ export type LookbackPeriod = "1w" | "1m" | "3m" | "6m" | "1y" | "all";
 export interface BatchChartDataFilters {
 	lookback?: LookbackPeriod;
 	model?: string;
-	promptIds: string[];
+	/** Tag filter (resolved to prompt IDs server-side). */
+	tags?: string[];
+	/** Search term applied to prompt text (resolved server-side). */
+	search?: string;
 }
 
 export function useBatchChartData(brandId?: string, filters?: BatchChartDataFilters) {
 	const params = useParams({ strict: false }) as { brand?: string };
 	const resolvedBrandId = brandId || params.brand;
-
-	const hasPromptIds = (filters?.promptIds?.length ?? 0) > 0;
 
 	const query = useQuery({
 		queryKey: [
@@ -22,7 +23,8 @@ export function useBatchChartData(brandId?: string, filters?: BatchChartDataFilt
 			resolvedBrandId,
 			filters?.lookback,
 			filters?.model,
-			filters?.promptIds?.join(","),
+			filters?.tags?.join(","),
+			filters?.search,
 		],
 		queryFn: () =>
 			getBatchChartDataFn({
@@ -30,11 +32,12 @@ export function useBatchChartData(brandId?: string, filters?: BatchChartDataFilt
 					brandId: resolvedBrandId!,
 					lookback: filters?.lookback || "1m",
 					model: filters?.model,
-					promptIds: filters?.promptIds || [],
+					tags: filters?.tags?.join(","),
+					search: filters?.search,
 					timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 				},
 			}),
-		enabled: !!resolvedBrandId && hasPromptIds,
+		enabled: !!resolvedBrandId,
 		staleTime: 60_000,
 		refetchOnWindowFocus: false,
 		refetchOnReconnect: true,

--- a/apps/web/src/hooks/use-filtered-visibility.tsx
+++ b/apps/web/src/hooks/use-filtered-visibility.tsx
@@ -6,8 +6,11 @@ export type LookbackPeriod = "1w" | "1m" | "3m" | "6m" | "1y" | "all";
 
 export interface FilteredVisibilityFilters {
 	lookback?: LookbackPeriod;
-	promptIds?: string[];
 	model?: string;
+	/** Tag filter (resolved to prompt IDs server-side). */
+	tags?: string[];
+	/** Search term applied to prompt text (resolved server-side). */
+	search?: string;
 }
 
 export function useFilteredVisibility(brandId?: string, filters?: FilteredVisibilityFilters) {
@@ -20,7 +23,8 @@ export function useFilteredVisibility(brandId?: string, filters?: FilteredVisibi
 			resolvedBrandId,
 			filters?.lookback,
 			filters?.model,
-			filters?.promptIds?.join(","),
+			filters?.tags?.join(","),
+			filters?.search,
 		],
 		queryFn: () =>
 			getFilteredVisibilityFn({
@@ -28,7 +32,8 @@ export function useFilteredVisibility(brandId?: string, filters?: FilteredVisibi
 					brandId: resolvedBrandId!,
 					lookback: filters?.lookback || "1m",
 					model: filters?.model,
-					promptIds: filters?.promptIds || [],
+					tags: filters?.tags?.join(","),
+					search: filters?.search,
 					timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 				},
 			}),

--- a/apps/web/src/server/visibility.ts
+++ b/apps/web/src/server/visibility.ts
@@ -8,8 +8,8 @@ import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
 import { db } from "@workspace/lib/db/db";
-import { brands, competitors, prompts } from "@workspace/lib/db/schema";
-import { eq, and, inArray } from "drizzle-orm";
+import { brands, competitors, prompts, SYSTEM_TAGS } from "@workspace/lib/db/schema";
+import { eq, and } from "drizzle-orm";
 import { type LookbackPeriod } from "@/lib/chart-utils";
 import { getTimezoneLookbackRange, resolveTimezone } from "@/lib/timezone-utils";
 import {
@@ -66,6 +66,77 @@ export interface FilteredVisibilityResponse {
 }
 
 // ============================================================================
+// Prompt resolution
+// ============================================================================
+
+interface ResolvedPrompt {
+	id: string;
+	value: string;
+	systemTags: string[];
+	tags: string[];
+}
+
+/**
+ * Resolve the in-scope prompts for a brand from filter criteria, entirely
+ * server-side. Mirrors the filtering the visibility page applies to build its
+ * prompt list — the tag filter from `getPromptsSummaryFn` plus the search box —
+ * so the chart and visibility aggregates cover the same prompts the list shows.
+ *
+ * Resolving here (instead of having the client serialize the full prompt-id
+ * list into the GET request URL) keeps the request bounded regardless of how
+ * many prompts a brand has. Shipping the id list overflowed the request URL for
+ * brands with a few hundred prompts — 414 URI Too Long on Vercel, 431 Request
+ * Header Fields Too Large in dev. See issue #68.
+ *
+ * NOTE: the tag-filter logic here must stay in sync with `getPromptsSummaryFn`
+ * (apps/web/src/server/prompts.ts), which produces the displayed list.
+ */
+async function resolveFilteredPrompts(
+	brandId: string,
+	opts: { tags?: string; search?: string },
+): Promise<ResolvedPrompt[]> {
+	const allPrompts = await db
+		.select({
+			id: prompts.id,
+			value: prompts.value,
+			systemTags: prompts.systemTags,
+			tags: prompts.tags,
+		})
+		.from(prompts)
+		.where(and(eq(prompts.brandId, brandId), eq(prompts.enabled, true)));
+
+	const tagFilter = opts.tags?.split(",").filter(Boolean) || [];
+	const search = opts.search;
+
+	return allPrompts
+		.filter((p) => {
+			const userTags = p.tags || [];
+
+			// Tag filter — match getPromptsSummaryFn: a prompt's effective tags
+			// are its user tags plus exactly one system tag reflecting its
+			// effective branded status.
+			if (tagFilter.length > 0) {
+				const { isBranded } = getEffectiveBrandedStatus(p.systemTags || [], userTags);
+				const systemTag = isBranded ? SYSTEM_TAGS.BRANDED : SYSTEM_TAGS.UNBRANDED;
+				const effectiveTags = userTags.includes(systemTag) ? userTags : [...userTags, systemTag];
+				if (!tagFilter.some((t) => effectiveTags.includes(t))) return false;
+			}
+
+			// Search filter — previously applied in the browser against the
+			// prompt text (case-insensitive substring).
+			if (search && !p.value.toLowerCase().includes(search.toLowerCase())) return false;
+
+			return true;
+		})
+		.map((p) => ({
+			id: p.id,
+			value: p.value,
+			systemTags: p.systemTags || [],
+			tags: p.tags || [],
+		}));
+}
+
+// ============================================================================
 // Server functions
 // ============================================================================
 
@@ -75,7 +146,8 @@ export const getBatchChartDataFn = createServerFn({ method: "GET" })
 			brandId: z.string(),
 			lookback: z.enum(["1w", "1m", "3m", "6m", "1y", "all"]).default("1m"),
 			model: z.string().optional(),
-			promptIds: z.array(z.string()),
+			tags: z.string().optional(),
+			search: z.string().optional(),
 			timezone: z.string().default("UTC"),
 		}),
 	)
@@ -86,16 +158,22 @@ export const getBatchChartDataFn = createServerFn({ method: "GET" })
 		const timezone = resolveTimezone(data.timezone);
 		const lookbackParam = data.lookback as LookbackPeriod;
 
+		// `allStrategy: "1y"` guarantees concrete bounds for every lookback
+		// (including "all"), so the dates are never null here.
 		const { fromDateStr, toDateStr } = getTimezoneLookbackRange(lookbackParam, timezone, {
 			allStrategy: "1y",
-		});
+		}) as { fromDateStr: string; toDateStr: string };
 
-		if (data.promptIds.length === 0) {
-			throw new Error("promptIds parameter is required");
-		}
+		// Resolve the in-scope prompts server-side from the filter criteria so
+		// the client never ships the full prompt-id list (issue #68).
+		const resolvedPrompts = await resolveFilteredPrompts(data.brandId, {
+			tags: data.tags,
+			search: data.search,
+		});
+		const promptIds = resolvedPrompts.map((p) => p.id);
 
 		// Get brand and competitors from PostgreSQL
-		const [brandResult, competitorsResult, promptsResult] = await Promise.all([
+		const [brandResult, competitorsResult] = await Promise.all([
 			db
 				.select({ id: brands.id, name: brands.name })
 				.from(brands)
@@ -105,10 +183,6 @@ export const getBatchChartDataFn = createServerFn({ method: "GET" })
 				.select({ id: competitors.id, name: competitors.name })
 				.from(competitors)
 				.where(eq(competitors.brandId, data.brandId)),
-			db
-				.select({ id: prompts.id, value: prompts.value })
-				.from(prompts)
-				.where(and(eq(prompts.brandId, data.brandId), inArray(prompts.id, data.promptIds))),
 		]);
 
 		if (brandResult.length === 0) {
@@ -117,8 +191,20 @@ export const getBatchChartDataFn = createServerFn({ method: "GET" })
 
 		const brand = brandResult[0];
 
+		// No prompts match the current filters — return an empty-but-valid
+		// payload rather than erroring (the page renders an empty state).
+		if (promptIds.length === 0) {
+			return {
+				chartData: [],
+				visibility: { currentVisibility: 0, totalRuns: 0, visibilityTimeSeries: [] },
+				brand: { id: brand.id, name: brand.name },
+				competitors: competitorsResult,
+				dateRange: { fromDate: fromDateStr, toDate: toDateStr },
+			};
+		}
+
 		// Determine branded prompt IDs
-		const brandedPromptIds = promptsResult
+		const brandedPromptIds = resolvedPrompts
 			.filter((p) => p.value.toLowerCase().includes(brand.name.toLowerCase()))
 			.map((p) => p.id);
 
@@ -126,7 +212,7 @@ export const getBatchChartDataFn = createServerFn({ method: "GET" })
 		const [chartData, visibilityData] = await Promise.all([
 			getBatchChartData(
 				data.brandId,
-				data.promptIds,
+				promptIds,
 				fromDateStr,
 				toDateStr,
 				timezone,
@@ -135,7 +221,7 @@ export const getBatchChartDataFn = createServerFn({ method: "GET" })
 			),
 			getBatchVisibilityData(
 				data.brandId,
-				data.promptIds,
+				promptIds,
 				brandedPromptIds,
 				fromDateStr,
 				toDateStr,
@@ -158,8 +244,8 @@ export const getBatchChartDataFn = createServerFn({ method: "GET" })
 			brand: { id: brand.id, name: brand.name },
 			competitors: competitorsResult,
 			dateRange: {
-				fromDate: fromDateStr!,
-				toDate: toDateStr!,
+				fromDate: fromDateStr,
+				toDate: toDateStr,
 			},
 		};
 	});
@@ -170,7 +256,8 @@ export const getFilteredVisibilityFn = createServerFn({ method: "GET" })
 			brandId: z.string(),
 			lookback: z.enum(["1w", "1m", "3m", "6m", "1y", "all"]).default("1m"),
 			model: z.string().optional(),
-			promptIds: z.array(z.string()).default([]),
+			tags: z.string().optional(),
+			search: z.string().optional(),
 			timezone: z.string().default("UTC"),
 		}),
 	)
@@ -180,34 +267,14 @@ export const getFilteredVisibilityFn = createServerFn({ method: "GET" })
 
 		await requireOrgAccess(session.user.id, data.brandId);
 
-		if (data.promptIds.length === 0) {
-			return {
-				currentVisibility: 0,
-				totalRuns: 0,
-				totalPrompts: 0,
-				totalCitations: 0,
-				visibilityTimeSeries: [],
-				lookback: lookbackParam,
-			};
-		}
-
-		const timezone = resolveTimezone(data.timezone);
-
-		// Get brand name and prompt values for branded/non-branded determination
-		const [brandResult, promptsResult] = await Promise.all([
-			db.select({ name: brands.name }).from(brands).where(eq(brands.id, data.brandId)).limit(1),
-			db
-				.select({
-					id: prompts.id,
-					value: prompts.value,
-					systemTags: prompts.systemTags,
-					tags: prompts.tags,
-				})
-				.from(prompts)
-				.where(and(eq(prompts.brandId, data.brandId), inArray(prompts.id, data.promptIds))),
-		]);
-
-		const totalPrompts = promptsResult.length;
+		// Resolve the in-scope prompts server-side from the filter criteria so
+		// the client never ships the full prompt-id list (issue #68).
+		const resolvedPrompts = await resolveFilteredPrompts(data.brandId, {
+			tags: data.tags,
+			search: data.search,
+		});
+		const promptIds = resolvedPrompts.map((p) => p.id);
+		const totalPrompts = promptIds.length;
 
 		if (totalPrompts === 0) {
 			return {
@@ -220,12 +287,11 @@ export const getFilteredVisibilityFn = createServerFn({ method: "GET" })
 			};
 		}
 
-		// Determine branded prompt IDs
-		const brandedPromptIds = promptsResult
-			.filter((p) => {
-				const effectiveStatus = getEffectiveBrandedStatus(p.systemTags || [], p.tags || []);
-				return effectiveStatus.isBranded;
-			})
+		const timezone = resolveTimezone(data.timezone);
+
+		// Determine branded prompt IDs from effective branded status
+		const brandedPromptIds = resolvedPrompts
+			.filter((p) => getEffectiveBrandedStatus(p.systemTags, p.tags).isBranded)
 			.map((p) => p.id);
 
 		// `allStrategy: "1y"` caps the "all" lookback at a one-year window so
@@ -244,11 +310,11 @@ export const getFilteredVisibilityFn = createServerFn({ method: "GET" })
 				fromDate,
 				toDate,
 				timezone,
-				data.promptIds,
+				promptIds,
 				brandedPromptIds,
 				data.model,
 			),
-			getCitationsTotalCount(data.brandId, fromDate, toDate, timezone, data.promptIds, data.model),
+			getCitationsTotalCount(data.brandId, fromDate, toDate, timezone, promptIds, data.model),
 		]);
 
 		// Roll the period totals from the raw observation sums (actual_*);


### PR DESCRIPTION
The visibility page failed to load for brands with many active prompts because `getBatchChartDataFn` and `getFilteredVisibilityFn` serialized the full prompt-id list into the GET request URL, overflowing it (414 URI Too Long on Vercel / 431 Request Header Fields Too Large in local dev) once a brand had a few hundred prompts. Both functions now accept the tag/model/search filter criteria and resolve the in-scope prompt IDs server-side via a shared `resolveFilteredPrompts` helper (mirroring `getCitationsFn`), so the request stays bounded regardless of prompt count. The search term — previously applied client-side — is now sent to the server too, and the visibility/chart hooks and their consumers pass filters instead of an id list (the prompt list is still search-filtered client-side for display only). Verified with `tsc --noEmit`, biome lint, and a production build; includes a user-facing changeset.

Fixes #68