### PR TITLE
Minor security improvements

### DIFF
--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -2,6 +2,16 @@ import "../instrument.server.mjs";
 import { wrapFetchWithSentry } from "@sentry/tanstackstart-react";
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
 
+// HSTS asserts HTTPS-only for the host that served the response. Whitelabel
+// deployments run on customer-controlled custom domains, where `includeSubDomains`
+// would wrongly assert HTTPS across subdomains we don't own — so that directive
+// is scoped to our own deployments. Browsers ignore HSTS received over plain
+// HTTP, so it stays inert on localhost.
+const strictTransportSecurity =
+	process.env.DEPLOYMENT_MODE === "whitelabel"
+		? "max-age=63072000"
+		: "max-age=63072000; includeSubDomains";
+
 const SECURITY_HEADERS: Record<string, string> = {
 	"Content-Security-Policy": [
 		"default-src 'self'",
@@ -15,9 +25,13 @@ const SECURITY_HEADERS: Record<string, string> = {
 		"base-uri 'self'",
 		"form-action 'self'",
 	].join("; "),
+	"Strict-Transport-Security": strictTransportSecurity,
 	"X-Frame-Options": "DENY",
 	"X-Content-Type-Options": "nosniff",
 	"Referrer-Policy": "strict-origin-when-cross-origin",
+	// same-origin-allow-popups (not same-origin) keeps OAuth/SSO popups that rely on
+	// window.opener working while still isolating us from cross-origin openers.
+	"Cross-Origin-Opener-Policy": "same-origin-allow-popups",
 	"Permissions-Policy":
 		"camera=(), microphone=(), geolocation=(), payment=(), usb=(), browsing-topics=()",
 };

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -2,13 +2,25 @@
  * TanStack Start global configuration.
  *
  * Registers global middleware that runs on every request/server function.
+ *
+ * Start only auto-installs its CSRF middleware for server functions when an app
+ * has no `start.ts`. Because we define one, we register `createCsrfMiddleware`
+ * ourselves — without it, server functions fall back to SameSite cookies alone.
+ * The `serverFn` filter scopes the same-origin check to server functions; route
+ * handlers are untouched (/api/auth/* has better-auth's own Origin check,
+ * /api/v1/* uses Bearer auth).
  */
 import { sentryGlobalFunctionMiddleware, sentryGlobalRequestMiddleware } from "@sentry/tanstackstart-react";
-import { createStart } from "@tanstack/react-start";
+import { createCsrfMiddleware, createStart } from "@tanstack/react-start";
 import { deploymentMiddleware, readOnlyMiddleware } from "@/middleware/deployment";
 import { authMiddleware } from "@/middleware/auth";
 
+const csrfMiddleware = createCsrfMiddleware({
+	filter: (ctx) => ctx.handlerType === "serverFn",
+});
+
 export const startInstance = createStart(() => ({
-	requestMiddleware: [sentryGlobalRequestMiddleware, deploymentMiddleware],
+	// csrf first so forged cross-site requests are rejected before any other work runs
+	requestMiddleware: [csrfMiddleware, sentryGlobalRequestMiddleware, deploymentMiddleware],
 	functionMiddleware: [sentryGlobalFunctionMiddleware, authMiddleware, readOnlyMiddleware],
 }));


### PR DESCRIPTION
## What

Two small hardening changes to `apps/web`.

**CSRF protection for server functions** (`start.ts`)
- Registers `createCsrfMiddleware`, filtered to server functions.
- TanStack Start auto-installs this middleware *only* when an app has no `start.ts`. We define one, so server functions had been relying on `SameSite=Lax` cookies alone. This restores the framework's same-origin check (`Sec-Fetch-Site`/`Origin`/`Referer`) as defense-in-depth. better-auth routes (`/api/auth/*`) already had their own Origin check; the `serverFn` filter leaves route handlers (`/api/v1/*` Bearer, `/api/og`, `/api/plausible/*`) untouched.

**Response security headers** (`server.ts`)
- **HSTS** `max-age=63072000` — `includeSubDomains` gated **off** for `whitelabel` (customer custom domains we don't control), **on** for our own deployments. No `preload`.
- **Cross-Origin-Opener-Policy** `same-origin-allow-popups` — the popup-safe variant, so it won't break OAuth/SSO popup flows.
- Existing headers (CSP, X-Frame-Options, nosniff, Referrer-Policy, Permissions-Policy) unchanged.

## Watch out for
- The CSRF check rejects requests lacking `Sec-Fetch-Site`/`Origin`/`Referer`. Real browsers (incl. Playwright e2e) always send these; only a raw-HTTP POST directly to a server-function endpoint would now 403 — those belong on `/api/v1/*` (Bearer) anyway.
- Whitelabel behind a proxy that rewrites Origin: if false 403s appear, set `createCsrfMiddleware({ origin: <public-origin> })`.