### PR TITLE
Add Google Shopping breakdown to the prompt details page

### DIFF
--- a/.changeset/prompt-google-shopping.md
+++ b/.changeset/prompt-google-shopping.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Added the Google Shopping breakdown to a prompt's Citations tab on the prompt details page.

--- a/apps/web/scripts/benchmark-postgres-analytics.ts
+++ b/apps/web/scripts/benchmark-postgres-analytics.ts
@@ -129,9 +129,6 @@ async function benchBrand(
 		results.push(await bench("getDailyCitationStats",
 			() => pgRead.getDailyCitationStats(brandId, fromDate, toDate, tz, promptIds)));
 
-		results.push(await bench("getPromptCitationStats",
-			() => pgRead.getPromptCitationStats(firstPromptId, fromDate, toDate, tz)));
-
 		results.push(await bench("getPromptCitationUrlStats",
 			() => pgRead.getPromptCitationUrlStats(firstPromptId, fromDate, toDate, tz)));
 	}

--- a/apps/web/src/lib/google-module.ts
+++ b/apps/web/src/lib/google-module.ts
@@ -1,0 +1,134 @@
+/**
+ * Google AI Mode module builder.
+ *
+ * Shopping product cards and search links Google AI Mode surfaces aren't external
+ * citations in the traditional sense (they point back into Google's own results),
+ * so they're pulled OUT of the citation source mix and surfaced here instead —
+ * products attributed brand-vs-competitor by name, and searches, each tied to the
+ * prompts that triggered them. Shared by the brand-wide citations view and the
+ * per-prompt detail view so both render the same Google Shopping section.
+ */
+import {
+	type ProductAttribution,
+	isGoogleShoppingUrl,
+	isGoogleSearchUrl,
+	parseGoogleProductName,
+	parseGoogleSearchQuery,
+	attributeProduct,
+} from "@/lib/domain-categories";
+
+/** Minimal per-prompt cited-page row this builder needs (a structural subset of
+ *  `PerPromptCitationPageRow`). */
+export interface GoogleModulePageRow {
+	prompt_id: string;
+	url: string | null;
+	domain: string;
+	title: string | null;
+	count: number;
+}
+
+export type GooglePromptRef = { id: string; value: string; count: number };
+export type GoogleProduct = {
+	name: string;
+	count: number;
+	attribution: ProductAttribution["kind"];
+	competitorName?: string;
+	prompts: GooglePromptRef[];
+	urls: { url: string; count: number }[];
+};
+export type GoogleQuery = { query: string; count: number; prompts: GooglePromptRef[] };
+export type GoogleModule = {
+	shopping: { totalCitations: number; brandCount: number; competitorCount: number; products: GoogleProduct[] };
+	search: { totalCitations: number; queries: GoogleQuery[] };
+};
+
+export const emptyGoogleModule = (): GoogleModule => ({
+	shopping: { totalCitations: 0, brandCount: 0, competitorCount: 0, products: [] },
+	search: { totalCitations: 0, queries: [] },
+});
+
+/**
+ * Build the Google AI Mode module from per-prompt cited pages: Shopping products
+ * (attributed brand/competitor/other by name) and search queries, each tied to
+ * the prompts that triggered them.
+ */
+export function buildGoogleModule(
+	pages: GoogleModulePageRow[],
+	brandName: string,
+	competitors: { id: string; name: string }[],
+	promptValue: (id: string) => string | undefined,
+): GoogleModule {
+	type ProductAgg = { name: string; count: number; attribution: ProductAttribution; prompts: Map<string, number>; urls: Map<string, number> };
+	type QueryAgg = { query: string; count: number; prompts: Map<string, number> };
+	const productByKey = new Map<string, ProductAgg>();
+	const queryByKey = new Map<string, QueryAgg>();
+
+	for (const row of pages) {
+		if (!row.url) continue;
+		const c = Number(row.count);
+		if (isGoogleShoppingUrl(row.url)) {
+			const name = parseGoogleProductName(row.url, row.title);
+			if (!name) continue;
+			const key = name.toLowerCase();
+			let e = productByKey.get(key);
+			if (!e) {
+				e = { name, count: 0, attribution: attributeProduct(name, brandName, competitors), prompts: new Map(), urls: new Map() };
+				productByKey.set(key, e);
+			}
+			e.count += c;
+			e.prompts.set(row.prompt_id, (e.prompts.get(row.prompt_id) ?? 0) + c);
+			e.urls.set(row.url, (e.urls.get(row.url) ?? 0) + c);
+		} else if (isGoogleSearchUrl(row.url)) {
+			const query = parseGoogleSearchQuery(row.url);
+			if (!query) continue;
+			const key = query.toLowerCase();
+			let e = queryByKey.get(key);
+			if (!e) {
+				e = { query, count: 0, prompts: new Map() };
+				queryByKey.set(key, e);
+			}
+			e.count += c;
+			e.prompts.set(row.prompt_id, (e.prompts.get(row.prompt_id) ?? 0) + c);
+		}
+	}
+
+	const promptRefs = (m: Map<string, number>): GooglePromptRef[] =>
+		[...m.entries()]
+			.map(([id, count]) => {
+				const value = promptValue(id);
+				return value ? { id, value, count } : null;
+			})
+			.filter((p): p is GooglePromptRef => p !== null)
+			.sort((a, b) => b.count - a.count);
+
+	const products: GoogleProduct[] = [...productByKey.values()]
+		.map((e) => ({
+			name: e.name,
+			count: e.count,
+			attribution: e.attribution.kind,
+			competitorName: e.attribution.kind === "competitor" ? e.attribution.competitorName : undefined,
+			prompts: promptRefs(e.prompts),
+			urls: [...e.urls.entries()].map(([url, count]) => ({ url, count })).sort((a, b) => b.count - a.count),
+		}))
+		.sort((a, b) => b.count - a.count);
+
+	const queries: GoogleQuery[] = [...queryByKey.values()]
+		.map((e) => ({ query: e.query, count: e.count, prompts: promptRefs(e.prompts) }))
+		.sort((a, b) => b.count - a.count);
+
+	const brandCount = products.filter((p) => p.attribution === "brand").reduce((s, p) => s + p.count, 0);
+	const competitorCount = products.filter((p) => p.attribution === "competitor").reduce((s, p) => s + p.count, 0);
+
+	return {
+		shopping: {
+			totalCitations: products.reduce((s, p) => s + p.count, 0),
+			brandCount,
+			competitorCount,
+			products,
+		},
+		search: {
+			totalCitations: queries.reduce((s, q) => s + q.count, 0),
+			queries,
+		},
+	};
+}

--- a/apps/web/src/lib/postgres-read.ts
+++ b/apps/web/src/lib/postgres-read.ts
@@ -652,27 +652,6 @@ export async function getCitationUrlStats(
 // Prompt-Level Citation Stats
 // ============================================================================
 
-export async function getPromptCitationStats(
-	promptId: string,
-	fromDate: string,
-	toDate: string,
-	timezone: string,
-): Promise<CitationDomainStats[]> {
-	const rows = await queryPg<CitationDomainStats>(sql`
-		SELECT
-			domain,
-			count(*)::int AS count,
-			(array_agg(title ORDER BY created_at DESC) FILTER (WHERE title IS NOT NULL))[1] AS example_title
-		FROM citations
-		WHERE prompt_id = ${promptId}
-			AND created_at >= (${fromDate}::date AT TIME ZONE ${timezone})
-			AND created_at < ((${toDate}::date + interval '1 day') AT TIME ZONE ${timezone})
-		GROUP BY domain
-		ORDER BY count DESC
-	`);
-	return rows;
-}
-
 export async function getPromptCitationUrlStats(
 	promptId: string,
 	fromDate: string,

--- a/apps/web/src/server/citations.ts
+++ b/apps/web/src/server/citations.ts
@@ -8,13 +8,12 @@ import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
 import { db } from "@workspace/lib/db/db";
 import { brands, competitors, prompts, SYSTEM_TAGS } from "@workspace/lib/db/schema";
 import { eq, and } from "drizzle-orm";
-import { getCitationUrlStats, getPerPromptDailyCitationPages, getPerPromptCitationPages, type PerPromptCitationPageRow } from "@/lib/postgres-read";
+import { getCitationUrlStats, getPerPromptDailyCitationPages, getPerPromptCitationPages } from "@/lib/postgres-read";
 import { getEffectiveBrandedStatus } from "@workspace/lib/tag-utils";
 import { citationDateWindow, applyPerPromptKeyedLVCF } from "@/lib/chart-utils";
 import {
 	type CitationCategory,
 	type CitationPageType,
-	type ProductAttribution,
 	CITATION_CATEGORIES,
 	CITATION_PAGE_TYPES,
 	emptyCategoryCounts,
@@ -23,120 +22,10 @@ import {
 	normalizeUrl,
 	toRoundedPercentages,
 	resolvePageType,
-	isGoogleShoppingUrl,
-	isGoogleSearchUrl,
 	isGoogleSurfaceUrl,
-	parseGoogleProductName,
-	parseGoogleSearchQuery,
-	attributeProduct,
 } from "@/lib/domain-categories";
 import { categorizeDomain as categorizeDomainShared, classifyUrl as classifyUrlShared } from "@/lib/domain-categories.server";
-
-type GooglePromptRef = { id: string; value: string; count: number };
-type GoogleProduct = {
-	name: string;
-	count: number;
-	attribution: ProductAttribution["kind"];
-	competitorName?: string;
-	prompts: GooglePromptRef[];
-	urls: { url: string; count: number }[];
-};
-type GoogleQuery = { query: string; count: number; prompts: GooglePromptRef[] };
-type GoogleModule = {
-	shopping: { totalCitations: number; brandCount: number; competitorCount: number; products: GoogleProduct[] };
-	search: { totalCitations: number; queries: GoogleQuery[] };
-};
-
-const emptyGoogleModule = (): GoogleModule => ({
-	shopping: { totalCitations: 0, brandCount: 0, competitorCount: 0, products: [] },
-	search: { totalCitations: 0, queries: [] },
-});
-
-/**
- * Build the Google AI Mode module from per-prompt cited pages: Shopping products
- * (attributed brand/competitor/other by name) and search queries, each tied to
- * the prompts that triggered them.
- */
-function buildGoogleModule(
-	pages: PerPromptCitationPageRow[],
-	brandName: string,
-	competitors: { id: string; name: string }[],
-	promptValue: (id: string) => string | undefined,
-): GoogleModule {
-	type ProductAgg = { name: string; count: number; attribution: ProductAttribution; prompts: Map<string, number>; urls: Map<string, number> };
-	type QueryAgg = { query: string; count: number; prompts: Map<string, number> };
-	const productByKey = new Map<string, ProductAgg>();
-	const queryByKey = new Map<string, QueryAgg>();
-
-	for (const row of pages) {
-		if (!row.url) continue;
-		const c = Number(row.count);
-		if (isGoogleShoppingUrl(row.url)) {
-			const name = parseGoogleProductName(row.url, row.title);
-			if (!name) continue;
-			const key = name.toLowerCase();
-			let e = productByKey.get(key);
-			if (!e) {
-				e = { name, count: 0, attribution: attributeProduct(name, brandName, competitors), prompts: new Map(), urls: new Map() };
-				productByKey.set(key, e);
-			}
-			e.count += c;
-			e.prompts.set(row.prompt_id, (e.prompts.get(row.prompt_id) ?? 0) + c);
-			e.urls.set(row.url, (e.urls.get(row.url) ?? 0) + c);
-		} else if (isGoogleSearchUrl(row.url)) {
-			const query = parseGoogleSearchQuery(row.url);
-			if (!query) continue;
-			const key = query.toLowerCase();
-			let e = queryByKey.get(key);
-			if (!e) {
-				e = { query, count: 0, prompts: new Map() };
-				queryByKey.set(key, e);
-			}
-			e.count += c;
-			e.prompts.set(row.prompt_id, (e.prompts.get(row.prompt_id) ?? 0) + c);
-		}
-	}
-
-	const promptRefs = (m: Map<string, number>): GooglePromptRef[] =>
-		[...m.entries()]
-			.map(([id, count]) => {
-				const value = promptValue(id);
-				return value ? { id, value, count } : null;
-			})
-			.filter((p): p is GooglePromptRef => p !== null)
-			.sort((a, b) => b.count - a.count);
-
-	const products: GoogleProduct[] = [...productByKey.values()]
-		.map((e) => ({
-			name: e.name,
-			count: e.count,
-			attribution: e.attribution.kind,
-			competitorName: e.attribution.kind === "competitor" ? e.attribution.competitorName : undefined,
-			prompts: promptRefs(e.prompts),
-			urls: [...e.urls.entries()].map(([url, count]) => ({ url, count })).sort((a, b) => b.count - a.count),
-		}))
-		.sort((a, b) => b.count - a.count);
-
-	const queries: GoogleQuery[] = [...queryByKey.values()]
-		.map((e) => ({ query: e.query, count: e.count, prompts: promptRefs(e.prompts) }))
-		.sort((a, b) => b.count - a.count);
-
-	const brandCount = products.filter((p) => p.attribution === "brand").reduce((s, p) => s + p.count, 0);
-	const competitorCount = products.filter((p) => p.attribution === "competitor").reduce((s, p) => s + p.count, 0);
-
-	return {
-		shopping: {
-			totalCitations: products.reduce((s, p) => s + p.count, 0),
-			brandCount,
-			competitorCount,
-			products,
-		},
-		search: {
-			totalCitations: queries.reduce((s, q) => s + q.count, 0),
-			queries,
-		},
-	};
-}
+import { buildGoogleModule, emptyGoogleModule } from "@/lib/google-module";
 
 /**
  * Get citation statistics for a brand

--- a/apps/web/src/server/prompts.ts
+++ b/apps/web/src/server/prompts.ts
@@ -11,7 +11,6 @@ import { eq, and, desc, gte, count, sql } from "drizzle-orm";
 import {
 	getPromptsSummary,
 	getPromptsFirstEvaluatedAt,
-	getPromptCitationStats,
 	getPromptCitationUrlStats,
 	getPromptDailyStats,
 	getPromptCompetitorDailyStats,
@@ -22,8 +21,17 @@ import { generateDateRange } from "@/lib/chart-utils";
 import type { LookbackPeriod } from "@/lib/chart-utils";
 import { getEffectiveBrandedStatus, computeSystemTags } from "@workspace/lib/tag-utils";
 import { createMultiplePromptJobSchedulers } from "@/lib/job-scheduler";
-import { extractDomain, normalizeUrl, emptyCategoryCounts } from "@/lib/domain-categories";
-import { categorizeDomain } from "@/lib/domain-categories.server";
+import {
+	extractDomain,
+	normalizeUrl,
+	emptyCategoryCounts,
+	emptyPageTypeCounts,
+	resolvePageType,
+	isGoogleSurfaceUrl,
+	CITATION_PAGE_TYPES,
+} from "@/lib/domain-categories";
+import { classifyUrl } from "@/lib/domain-categories.server";
+import { buildGoogleModule } from "@/lib/google-module";
 // Server Functions
 // ============================================================================
 
@@ -401,10 +409,14 @@ export const getPromptStatsFn = createServerFn({ method: "GET" })
 		};
 
 		// ---- Citation stats ----
+		// Mirrors the brand-wide citations view (server/citations.ts) at the single-
+		// prompt level: classify each citation at the URL level, pull Google AI Mode
+		// search/shopping surfaces OUT of the source mix into a dedicated Google
+		// Shopping module, and rebuild the domain distribution from the URL data.
 		let citationStats = undefined;
 		const [brandInfo, competitorsList] = await Promise.all([
-			db.select({ website: brands.website, additionalDomains: brands.additionalDomains }).from(brands).where(eq(brands.id, prompt[0].brandId)).limit(1),
-			db.select({ domains: competitors.domains }).from(competitors).where(eq(competitors.brandId, prompt[0].brandId)),
+			db.select({ name: brands.name, website: brands.website, additionalDomains: brands.additionalDomains }).from(brands).where(eq(brands.id, prompt[0].brandId)).limit(1),
+			db.select({ id: competitors.id, name: competitors.name, domains: competitors.domains }).from(competitors).where(eq(competitors.brandId, prompt[0].brandId)),
 		]);
 
 		const primaryBrandDomain = brandInfo[0] ? extractDomain(brandInfo[0].website) : "";
@@ -412,40 +424,78 @@ export const getPromptStatsFn = createServerFn({ method: "GET" })
 		const brandDomains = new Set([primaryBrandDomain, ...additionalBrandDomains].filter(Boolean));
 		const competitorDomains = new Set(competitorsList.flatMap((c) => c.domains.map(extractDomain)).filter(Boolean));
 
-		const [domainStats, urlStats] = await Promise.all([
-			getPromptCitationStats(data.promptId, fromDateStr, toDateStr, timezone),
-			getPromptCitationUrlStats(data.promptId, fromDateStr, toDateStr, timezone),
-		]);
+		const urlStats = await getPromptCitationUrlStats(data.promptId, fromDateStr, toDateStr, timezone);
 
-		if (domainStats.length > 0) {
-			const domainDistribution = domainStats.map(({ domain, count: cnt }) => ({
-				domain,
-				count: Number(cnt),
-				category: categorizeDomain(domain, brandDomains, competitorDomains),
-			}));
+		if (urlStats.length > 0) {
+			// Google AI Mode module: Shopping products (brand vs competitor) + search
+			// queries. Built from the raw URL rows (it picks out the Google surfaces);
+			// those same surfaces are excluded from the source mix below.
+			const googleModule = buildGoogleModule(
+				urlStats.map((u) => ({ prompt_id: data.promptId, url: u.url, domain: u.domain, title: u.title, count: u.count })),
+				brandInfo[0]?.name ?? "",
+				competitorsList.map((c) => ({ id: c.id, name: c.name })),
+				() => prompt[0].value,
+			);
 
-			const urlCounts = new Map<string, { count: number; title?: string; domain: string }>();
-			for (const { url, domain, title, count: cnt } of urlStats) {
+			const urlCounts = new Map<string, { count: number; title?: string; domain: string; positionSum: number; positionCount: number }>();
+			for (const { url, domain, title, count: cnt, avg_position } of urlStats) {
+				if (isGoogleSurfaceUrl(url)) continue;
 				const normalized = normalizeUrl(url);
+				const c = Number(cnt);
+				const positionSum = avg_position != null ? Number(avg_position) * c : 0;
+				const positionCount = avg_position != null ? c : 0;
 				const existing = urlCounts.get(normalized);
 				if (existing) {
-					existing.count += Number(cnt);
+					existing.count += c;
+					existing.positionSum += positionSum;
+					existing.positionCount += positionCount;
 					if (!existing.title && title) existing.title = title;
 				} else {
-					urlCounts.set(normalized, { count: Number(cnt), title: title || undefined, domain });
+					urlCounts.set(normalized, { count: c, title: title || undefined, domain, positionSum, positionCount });
 				}
 			}
 
 			const specificUrls = Array.from(urlCounts.entries())
-				.map(([url, { count: cnt, title, domain }]) => ({
-					url, title, domain, count: cnt,
-					category: categorizeDomain(domain, brandDomains, competitorDomains),
-				}))
+				.map(([url, { count: cnt, title, domain, positionSum, positionCount }]) => {
+					const category = classifyUrl(domain, url, title, brandDomains, competitorDomains);
+					return {
+						url, title, domain, count: cnt, category,
+						pageType: resolvePageType(url, title, category),
+						avgPosition: positionCount > 0 ? Math.round((positionSum / positionCount) * 10) / 10 : null,
+					};
+				})
+				.sort((a, b) => b.count - a.count);
+
+			// Domain distribution rebuilt from URL-level data, each domain taking its
+			// category from its top-cited URL (matches the brand-wide view).
+			const domainAgg = new Map<string, { count: number; category: (typeof specificUrls)[number]["category"]; topCount: number; exampleTitle?: string }>();
+			for (const u of specificUrls) {
+				const cur = domainAgg.get(u.domain);
+				if (cur) {
+					cur.count += u.count;
+					if (u.count > cur.topCount) {
+						cur.topCount = u.count;
+						cur.category = u.category;
+						cur.exampleTitle = u.title;
+					}
+				} else {
+					domainAgg.set(u.domain, { count: u.count, category: u.category, topCount: u.count, exampleTitle: u.title });
+				}
+			}
+			const domainDistribution = Array.from(domainAgg.entries())
+				.map(([domain, v]) => ({ domain, count: v.count, category: v.category, exampleTitle: v.exampleTitle }))
 				.sort((a, b) => b.count - a.count);
 
 			const categoryCounts = emptyCategoryCounts();
-			for (const d of domainDistribution) categoryCounts[d.category] += d.count;
+			const pageTypeCounts = emptyPageTypeCounts();
+			for (const u of specificUrls) {
+				categoryCounts[u.category] += u.count;
+				pageTypeCounts[u.pageType] += u.count;
+			}
 			const totalCitations = domainDistribution.reduce((s, d) => s + d.count, 0);
+			const pageTypeDistribution = CITATION_PAGE_TYPES
+				.map((pageType) => ({ pageType, count: pageTypeCounts[pageType] }))
+				.filter((d) => d.count > 0);
 
 			if (totalCitations > 0) {
 				citationStats = {
@@ -454,6 +504,8 @@ export const getPromptStatsFn = createServerFn({ method: "GET" })
 					categoryCounts,
 					domainDistribution,
 					specificUrls,
+					pageTypeDistribution,
+					googleModule,
 				};
 			}
 		}


### PR DESCRIPTION
Closes #328.

## What was wrong

The prompt details page already renders citations via the shared `CitationsDisplay` component, which knows how to draw a Google Shopping card — but only when `citationData.googleModule` is populated. The per-prompt server function (`getPromptStatsFn`) never built that module, so the card never appeared. It also classified citations at the domain level and didn't exclude Google AI Mode search/shopping surfaces, so `google.com` surfaces polluted Top Cited Domains/URLs (the same bug the brand-wide view fixed in #325).

## Changes

- **`apps/web/src/lib/google-module.ts`** (new): Extracted `buildGoogleModule` + its types out of `server/citations.ts` into a shared module so the brand-wide and per-prompt views build the Google Shopping section identically.
- **`apps/web/src/server/citations.ts`**: Now imports the helper from the shared module (removed the inlined copy; behavior unchanged).
- **`apps/web/src/server/prompts.ts`**: Reworked the citation section of `getPromptStatsFn` to mirror the brand-wide view at the single-prompt level — builds the `googleModule`, excludes Google surfaces from the source mix, classifies at the URL level (`classifyUrl` + `resolvePageType`), rebuilds the domain distribution from URL data, and adds `pageTypeDistribution` + `avgPosition`.
- **`apps/web/src/lib/postgres-read.ts`** + benchmark script: Removed the now-unused domain-level `getPromptCitationStats` query (URL-level data drives everything now).
- Added a changeset.

## Behavior

A prompt's Citations tab now shows the **Google Shopping** card (products attributed yours-vs-competitors, plus search queries), and Top Cited Domains/URLs no longer include Google surface links. Total Citations for prompts that previously counted Google surfaces drops accordingly — matching the brand-wide definition of "external websites cited."

**Edge case:** if a prompt's only Google AI Mode output is shopping cards with zero external web citations, the tab still shows "No citation data" because `CitationsDisplay` gates the whole panel on `totalCitations > 0`. That matches existing shared-component behavior; widening it would affect the brand-wide view too, so it's left out of scope.

## Testing

- `tsc --noEmit` clean
- biome clean on new/changed files
- 142 unit tests pass