### PR TITLE
Apply the filtered-list shell to #60 and #328

### DIFF
--- a/.changeset/prompt-ordering.md
+++ b/.changeset/prompt-ordering.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Added a sort control to the Visibility page.

--- a/apps/web/src/components/filter-bar.tsx
+++ b/apps/web/src/components/filter-bar.tsx
@@ -99,7 +99,9 @@ type FilterTriggerButtonProps = {
 // Props forward to the underlying Button so `<DropdownMenuTrigger asChild>` /
 // `<PopoverTrigger asChild>` can hand their ref + data-state directly to the
 // button element (wrapping in a div would make Slot target the div instead).
-function FilterTriggerButton({
+// Exported so page-specific bar controls (e.g. the prompts sort dropdown)
+// share the same trigger look without re-implementing it.
+export function FilterTriggerButton({
 	icon,
 	label,
 	active,
@@ -404,6 +406,7 @@ export function FilterBar({
 	showModelSelector,
 	resultCount,
 	resultTotal,
+	extraControls,
 }: {
 	availableTags: readonly string[];
 	availableModels: string[];
@@ -413,6 +416,9 @@ export function FilterBar({
 	resultCount?: number;
 	/** Unfiltered count — when it differs from `resultCount` the line reads "n of m results". */
 	resultTotal?: number;
+	/** Page-specific controls rendered inline with the dropdown group
+	 *  (e.g. the prompts list's sort dropdown). */
+	extraControls?: ReactNode;
 }) {
 	return (
 		<div className="flex flex-wrap items-center justify-between gap-2">
@@ -420,6 +426,7 @@ export function FilterBar({
 				{showModelSelector && <ModelDropdown availableModels={availableModels} />}
 				<TagsDropdown availableTags={availableTags} />
 				<LookbackDropdown />
+				{extraControls}
 				<ResultCount count={resultCount} total={resultTotal} />
 			</div>
 			{showSearch && <SearchInput />}

--- a/apps/web/src/components/filtered-list-shell.tsx
+++ b/apps/web/src/components/filtered-list-shell.tsx
@@ -14,6 +14,9 @@ interface FilteredListShellProps {
 	showModelSelector?: boolean;
 	/** Show "n results" / "n of m results" next to the filter dropdowns. */
 	showResultCount?: boolean;
+	/** Page-specific controls rendered inline with the filter-bar dropdown
+	 *  group (e.g. the prompts list's sort dropdown). */
+	filterBarExtras?: ReactNode;
 	/** Extra content inside the sticky filter section, below the bar
 	 *  (e.g. the visibility bar on the prompts page). */
 	filterSectionExtras?: ReactNode;
@@ -48,6 +51,7 @@ export function FilteredListShell({
 	showSearch = false,
 	showModelSelector = true,
 	showResultCount = false,
+	filterBarExtras,
 	filterSectionExtras,
 	isLoading = false,
 	loadingState,
@@ -103,6 +107,7 @@ export function FilteredListShell({
 					showModelSelector={showModelSelector}
 					resultCount={showResultCount && !isLoading ? effectiveFilteredCount : undefined}
 					resultTotal={showResultCount && !isLoading ? totalCount : undefined}
+					extraControls={filterBarExtras}
 				/>
 				{filterSectionExtras}
 			</FilterSection>

--- a/apps/web/src/components/prompt-order-dropdown.tsx
+++ b/apps/web/src/components/prompt-order-dropdown.tsx
@@ -54,10 +54,10 @@ export function PromptOrderDropdown() {
 					active={selected !== DEFAULT_PROMPT_ORDER}
 				/>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="start" className="w-48">
+			<DropdownMenuContent align="start" className="w-60">
 				<DropdownMenuRadioGroup value={selected} onValueChange={(v) => setOrder(v as PromptOrder)}>
 					{PROMPT_ORDER_OPTIONS.map((o) => (
-						<DropdownMenuRadioItem key={o.value} value={o.value} className="cursor-pointer">
+						<DropdownMenuRadioItem key={o.value} value={o.value} className="cursor-pointer whitespace-nowrap">
 							{o.label}
 						</DropdownMenuRadioItem>
 					))}

--- a/apps/web/src/components/prompt-order-dropdown.tsx
+++ b/apps/web/src/components/prompt-order-dropdown.tsx
@@ -1,0 +1,65 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { ArrowUpDown } from "lucide-react";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger,
+} from "@workspace/ui/components/dropdown-menu";
+import { FilterTriggerButton } from "@/components/filter-bar";
+import {
+	PROMPT_ORDER_OPTIONS,
+	DEFAULT_PROMPT_ORDER,
+	coercePromptOrder,
+	type PromptOrder,
+} from "@/lib/prompt-order";
+
+/** Sort control for the prompts list (#60). Reads/writes the `order` URL key
+ *  the visibility route declares in its `validateSearch`. Like the filter-bar
+ *  widgets it subscribes to just its own key, and writes with `replace` + no
+ *  scroll reset, dropping the key when set back to the default so default
+ *  state keeps a clean URL. */
+export function PromptOrderDropdown() {
+	const navigate = useNavigate();
+	const selected = useSearch({
+		strict: false,
+		select: (s) => coercePromptOrder((s as { order?: unknown }).order),
+	});
+
+	const setOrder = (next: PromptOrder) =>
+		navigate({
+			to: ".",
+			search: (prev: Record<string, unknown>) => ({
+				...prev,
+				order: next === DEFAULT_PROMPT_ORDER ? undefined : next,
+			}),
+			replace: true,
+			resetScroll: false,
+		});
+
+	// The trigger shows the option's short form (the default order's is "Sort"),
+	// keeping the long "(high → low)" menu labels off the filter row.
+	const label = PROMPT_ORDER_OPTIONS.find((o) => o.value === selected)?.trigger ?? "Sort";
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<FilterTriggerButton
+					icon={<ArrowUpDown className="size-3.5" />}
+					label={label}
+					active={selected !== DEFAULT_PROMPT_ORDER}
+				/>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start" className="w-48">
+				<DropdownMenuRadioGroup value={selected} onValueChange={(v) => setOrder(v as PromptOrder)}>
+					{PROMPT_ORDER_OPTIONS.map((o) => (
+						<DropdownMenuRadioItem key={o.value} value={o.value} className="cursor-pointer">
+							{o.label}
+						</DropdownMenuRadioItem>
+					))}
+				</DropdownMenuRadioGroup>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/web/src/components/prompt-order-dropdown.tsx
+++ b/apps/web/src/components/prompt-order-dropdown.tsx
@@ -38,9 +38,12 @@ export function PromptOrderDropdown() {
 			resetScroll: false,
 		});
 
-	// The trigger shows the option's short form (the default order's is "Sort"),
-	// keeping the long "(high → low)" menu labels off the filter row.
-	const label = PROMPT_ORDER_OPTIONS.find((o) => o.value === selected)?.trigger ?? "Sort";
+	// The button reads "Sort" in the default state and otherwise echoes the
+	// chosen order's menu label (arrows and all).
+	const label =
+		selected === DEFAULT_PROMPT_ORDER
+			? "Sort"
+			: (PROMPT_ORDER_OPTIONS.find((o) => o.value === selected)?.label ?? "Sort");
 
 	return (
 		<DropdownMenu>

--- a/apps/web/src/components/prompts-display.tsx
+++ b/apps/web/src/components/prompts-display.tsx
@@ -8,14 +8,16 @@ import { usePromptsSummary } from "@/hooks/use-prompts-summary";
 import { useBatchChartData } from "@/hooks/use-batch-chart-data";
 import { useBrand } from "@/hooks/use-brands";
 import { useListFilters } from "@/hooks/use-list-filters";
-import { Link } from "@tanstack/react-router";
+import { Link, useSearch } from "@tanstack/react-router";
 import { VirtualizedPromptList } from "@/components/virtualized-prompt-list";
 import { ChartDataProvider } from "@/contexts/chart-data-context";
 import { Skeleton } from "@workspace/ui/components/skeleton";
 import { PageHeader } from "@/components/page-header";
 import { getAvailableModels, ALL_MODELS_VALUE } from "@/components/filter-bar";
 import { FilteredListShell } from "@/components/filtered-list-shell";
+import { PromptOrderDropdown } from "@/components/prompt-order-dropdown";
 import { VisibilityBarSection } from "@/components/visibility-bar-section";
+import { coercePromptOrder, orderPrompts } from "@/lib/prompt-order";
 import type { LookbackPeriod } from "@/lib/chart-utils";
 import type { Brand, Competitor } from "@workspace/lib/db/schema";
 
@@ -49,6 +51,12 @@ function PromptsContent({ brandId, editLink }: { brandId: string | undefined; ed
 	const { brand } = useBrand(brandId);
 	const filters = useListFilters();
 	const { model, lookback, tags, search } = filters;
+	// `order` is this route's own search key (not a narrowing filter), so it
+	// rides outside `useListFilters` / `isFiltered`.
+	const order = useSearch({
+		strict: false,
+		select: (s) => coercePromptOrder((s as { order?: unknown }).order),
+	});
 
 	// Server hands us `effectiveModels` — the deployment-configured model ids
 	// this brand actually runs, after applying `enabledModels`. FilterBar
@@ -71,16 +79,18 @@ function PromptsContent({ brandId, editLink }: { brandId: string | undefined; ed
 
 	const availableTags = promptsSummary?.availableTags ?? [];
 
-	// The prompt list is still search-filtered client-side for display. The
-	// chart/visibility sections no longer receive this id list — they resolve
-	// the same prompts server-side from the tag + search filters (issue #68).
+	// The prompt list is still search-filtered client-side for display, then
+	// re-ordered per the `order` control (#60). The chart/visibility sections
+	// no longer receive this id list — they resolve the same prompts
+	// server-side from the tag + search filters (issue #68).
 	const sortedPrompts = useMemo(() => {
 		if (!promptsSummary) return [];
 		const allPrompts = promptsSummary.prompts;
-		return search
-			? allPrompts.filter((p: { value: string }) => p.value.toLowerCase().includes(search.toLowerCase()))
+		const filtered = search
+			? allPrompts.filter((p) => p.value.toLowerCase().includes(search.toLowerCase()))
 			: allPrompts;
-	}, [promptsSummary, search]);
+		return orderPrompts(filtered, order);
+	}, [promptsSummary, search, order]);
 
 	const isInitialLoad = isLoadingSummary && !promptsSummary;
 
@@ -92,6 +102,7 @@ function PromptsContent({ brandId, editLink }: { brandId: string | undefined; ed
 			showSearch
 			showModelSelector
 			showResultCount
+			filterBarExtras={<PromptOrderDropdown />}
 			filterSectionExtras={<VisibilityBarSection brandId={brandId} />}
 			isLoading={isInitialLoad}
 			loadingState={<ContentLoadingSkeleton />}

--- a/apps/web/src/lib/prompt-order.ts
+++ b/apps/web/src/lib/prompt-order.ts
@@ -1,0 +1,77 @@
+/** Ordering options for the prompts list (#60). "Default" keeps the server's
+ *  smart order (visibility priority → weighted mentions → A–Z); the rest
+ *  re-sort the already-fetched summaries client-side, each with an ascending
+ *  and a descending direction. Ordering never narrows the list, so it stays
+ *  out of `useListFilters` / `isFiltered` and lives in the visibility route's
+ *  own `validateSearch` (the page-specific search key pattern from PR #336).
+ *
+ *  `label` is the menu text; `trigger` is the shorter form shown on the bar
+ *  button so a long "(high → low)" label doesn't dominate the filter row. */
+export const PROMPT_ORDER_OPTIONS = [
+	{ value: "default", label: "Default", trigger: "Sort" },
+	{ value: "brand-desc", label: "Brand Visibility (high → low)", trigger: "Brand Visibility ↓" },
+	{ value: "brand-asc", label: "Brand Visibility (low → high)", trigger: "Brand Visibility ↑" },
+	{ value: "competitor-desc", label: "Competitor Visibility (high → low)", trigger: "Competitor Visibility ↓" },
+	{ value: "competitor-asc", label: "Competitor Visibility (low → high)", trigger: "Competitor Visibility ↑" },
+	{ value: "prompt-asc", label: "Prompt (A → Z)", trigger: "Prompt A–Z" },
+	{ value: "prompt-desc", label: "Prompt (Z → A)", trigger: "Prompt Z–A" },
+] as const;
+
+export type PromptOrder = (typeof PROMPT_ORDER_OPTIONS)[number]["value"];
+export const DEFAULT_PROMPT_ORDER: PromptOrder = "default";
+
+const ORDER_VALUES = PROMPT_ORDER_OPTIONS.map((o) => o.value) as readonly string[];
+
+/** Normalize a raw URL value to a known order, falling back to the default
+ *  for stale/garbage links. */
+export function coercePromptOrder(raw: unknown): PromptOrder {
+	return ORDER_VALUES.includes(raw as string) ? (raw as PromptOrder) : DEFAULT_PROMPT_ORDER;
+}
+
+/** The fields the comparators read off a prompt summary. */
+export interface OrderablePrompt {
+	value: string;
+	brandMentionRate: number;
+	competitorMentionRate: number;
+	averageWeightedMentions: number;
+}
+
+/** Re-order a list of prompt summaries. `default` returns the input untouched
+ *  so the server's order is preserved; every other key sorts a copy with an
+ *  alphabetical tiebreak so equal-metric prompts stay stable and readable. */
+export function orderPrompts<T extends OrderablePrompt>(prompts: T[], order: PromptOrder): T[] {
+	if (order === "default") return prompts;
+	const byValue = (a: T, b: T) => a.value.localeCompare(b.value);
+	const sorted = [...prompts];
+	switch (order) {
+		case "brand-desc":
+			sorted.sort(
+				(a, b) =>
+					b.brandMentionRate - a.brandMentionRate ||
+					b.averageWeightedMentions - a.averageWeightedMentions ||
+					byValue(a, b),
+			);
+			break;
+		case "brand-asc":
+			sorted.sort(
+				(a, b) =>
+					a.brandMentionRate - b.brandMentionRate ||
+					a.averageWeightedMentions - b.averageWeightedMentions ||
+					byValue(a, b),
+			);
+			break;
+		case "competitor-desc":
+			sorted.sort((a, b) => b.competitorMentionRate - a.competitorMentionRate || byValue(a, b));
+			break;
+		case "competitor-asc":
+			sorted.sort((a, b) => a.competitorMentionRate - b.competitorMentionRate || byValue(a, b));
+			break;
+		case "prompt-asc":
+			sorted.sort(byValue);
+			break;
+		case "prompt-desc":
+			sorted.sort((a, b) => byValue(b, a));
+			break;
+	}
+	return sorted;
+}

--- a/apps/web/src/lib/prompt-order.ts
+++ b/apps/web/src/lib/prompt-order.ts
@@ -1,20 +1,19 @@
 /** Ordering options for the prompts list (#60). "Default" keeps the server's
  *  smart order (visibility priority → weighted mentions → A–Z); the rest
  *  re-sort the already-fetched summaries client-side, each with an ascending
- *  and a descending direction. Ordering never narrows the list, so it stays
- *  out of `useListFilters` / `isFiltered` and lives in the visibility route's
- *  own `validateSearch` (the page-specific search key pattern from PR #336).
- *
- *  `label` is the menu text; `trigger` is the shorter form shown on the bar
- *  button so a long "(high → low)" label doesn't dominate the filter row. */
+ *  and a descending direction (↑ low→high, ↓ high→low). Ordering never narrows
+ *  the list, so it stays out of `useListFilters` / `isFiltered` and lives in
+ *  the visibility route's own `validateSearch` (the page-specific search key
+ *  pattern from PR #336). The label is used both in the menu and (for a chosen
+ *  order) on the bar button. */
 export const PROMPT_ORDER_OPTIONS = [
-	{ value: "default", label: "Default", trigger: "Sort" },
-	{ value: "brand-desc", label: "Brand Visibility (high → low)", trigger: "Brand Visibility ↓" },
-	{ value: "brand-asc", label: "Brand Visibility (low → high)", trigger: "Brand Visibility ↑" },
-	{ value: "competitor-desc", label: "Competitor Visibility (high → low)", trigger: "Competitor Visibility ↓" },
-	{ value: "competitor-asc", label: "Competitor Visibility (low → high)", trigger: "Competitor Visibility ↑" },
-	{ value: "prompt-asc", label: "Prompt (A → Z)", trigger: "Prompt A–Z" },
-	{ value: "prompt-desc", label: "Prompt (Z → A)", trigger: "Prompt Z–A" },
+	{ value: "default", label: "Default" },
+	{ value: "brand-desc", label: "Brand Visibility ↓" },
+	{ value: "brand-asc", label: "Brand Visibility ↑" },
+	{ value: "competitor-desc", label: "Competitor Visibility ↓" },
+	{ value: "competitor-asc", label: "Competitor Visibility ↑" },
+	{ value: "prompt-asc", label: "Prompt A–Z" },
+	{ value: "prompt-desc", label: "Prompt Z–A" },
 ] as const;
 
 export type PromptOrder = (typeof PROMPT_ORDER_OPTIONS)[number]["value"];

--- a/apps/web/src/routes/_authed/app/$brand/prompts/$promptId.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/prompts/$promptId.tsx
@@ -16,11 +16,11 @@ import {
 import { Badge } from "@workspace/ui/components/badge";
 import { Skeleton } from "@workspace/ui/components/skeleton";
 import { Separator } from "@workspace/ui/components/separator";
-import { Button } from "@workspace/ui/components/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@workspace/ui/components/tooltip";
-import { IconChevronLeft, IconChevronRight, IconInfoCircle } from "@tabler/icons-react";
+import { IconInfoCircle } from "@tabler/icons-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@workspace/ui/components/tabs";
 import { ProgressBarChart } from "@/components/progress-bar-chart";
+import { ListPagination } from "@/components/list-pagination";
 import { CitationsDisplay, type CitationData } from "@/components/citations-display";
 import { LookbackSelector, useLookbackPeriod } from "@/components/lookback-selector";
 import { InfoTip, QueryWordsSection, UnknownQueriesNote, VariationsList, type VariationModelCount } from "@/components/fanout-sections";
@@ -511,49 +511,6 @@ function CitationsTab({
 	return <CitationsDisplay citationData={citationStats} brandId={brandId} brandName={brandName} showStats={true} maxDomains={10} maxUrls={50} />;
 }
 
-function PaginationControls({
-	className,
-	pagination,
-	currentPage,
-	onPageChange,
-	isLoading,
-}: {
-	className?: string;
-	pagination: any;
-	currentPage: number;
-	onPageChange: (page: number) => void;
-	isLoading: boolean;
-}) {
-	if (!pagination || pagination.totalPages <= 1) return null;
-	return (
-		<div className={`flex items-center gap-2 ${className || ""}`}>
-			<Button
-				variant="outline"
-				size="sm"
-				onClick={() => onPageChange(currentPage - 1)}
-				disabled={!pagination.hasPrev || isLoading}
-				className="cursor-pointer disabled:cursor-not-allowed"
-			>
-				<IconChevronLeft className="h-4 w-4" />
-				Previous
-			</Button>
-			<span className="text-sm text-muted-foreground tabular-nums">
-				Page {pagination.page} of {pagination.totalPages}
-			</span>
-			<Button
-				variant="outline"
-				size="sm"
-				onClick={() => onPageChange(currentPage + 1)}
-				disabled={!pagination.hasNext || isLoading}
-				className="cursor-pointer disabled:cursor-not-allowed"
-			>
-				Next
-				<IconChevronRight className="h-4 w-4" />
-			</Button>
-		</div>
-	);
-}
-
 function ResponsesTab({
 	runs,
 	pagination,
@@ -610,10 +567,7 @@ function ResponsesTab({
 
 	return (
 		<div className="space-y-4">
-			<div className="flex justify-between items-center">
-				<h3 className="text-base font-medium">Individual Prompt Runs</h3>
-				<PaginationControls pagination={pagination} currentPage={currentPage} onPageChange={onPageChange} isLoading={isLoading} />
-			</div>
+			<h3 className="text-base font-medium">Individual Prompt Runs</h3>
 
 			{runs.map((run: any) => (
 				<Card key={run.id}>
@@ -680,7 +634,12 @@ function ResponsesTab({
 				</Card>
 			))}
 
-			<PaginationControls className="justify-center pt-4" pagination={pagination} currentPage={currentPage} onPageChange={onPageChange} isLoading={isLoading} />
+			<ListPagination
+				page={currentPage - 1}
+				pageSize={pagination?.limit ?? 15}
+				totalItems={pagination?.total ?? runs.length}
+				onPageChange={(p) => onPageChange(p + 1)}
+			/>
 		</div>
 	);
 }

--- a/apps/web/src/routes/_authed/app/$brand/visibility.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/visibility.tsx
@@ -8,8 +8,16 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { PromptsDisplay } from "@/components/prompts-display";
 import { getAppName, getBrandName, buildTitle } from "@/lib/route-head";
+import { coercePromptOrder, DEFAULT_PROMPT_ORDER, type PromptOrder } from "@/lib/prompt-order";
 
 export const Route = createFileRoute("/_authed/app/$brand/visibility")({
+	// The prompts list's sort order (#60) is this route's own search key, on top
+	// of the brand-wide filter keys validated by the `$brand` layout route. The
+	// default order is omitted so default state keeps a clean URL.
+	validateSearch: (search: Record<string, unknown>): { order?: PromptOrder } => {
+		const order = coercePromptOrder(search.order);
+		return order === DEFAULT_PROMPT_ORDER ? {} : { order };
+	},
 	head: ({ matches, match }) => {
 		const appName = getAppName(match);
 		const brandName = getBrandName(matches);


### PR DESCRIPTION
Two follow-ups the shell extraction in #336 called out.

### #60 — Prompt ordering
Adds a **Sort** control to the Visibility page's filter bar. **Default** keeps the server's smart order; **Brand Visibility** and **Competitor Visibility** sort high→low or low→high, and **Prompt** sorts A–Z or Z–A. The order is a route-owned `?order=` search key (not a narrowing filter), wired through a new `extraControls` slot on `FilterBar` / `FilteredListShell` so other pages can drop controls into the bar later.

### #328 — Prompt-details card list
Moves the prompt-details **Individual Prompt Runs** list off its hand-rolled Previous/Next paginator onto the shared `ListPagination` (single footer, "1–15 of N"). Google Shopping already renders on this page (shipped separately), so no data work was needed.

### Notes
- `tsc` clean; new files lint clean; existing Storybook render tests unaffected (additive optional props; no story renders these pages).
- Behavior delta: the runs list now paginates from one bottom footer instead of top + bottom.