### PR TITLE
Sync monorepo root package version to the release train

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elmo",
-  "version": "0.1.0",
+  "version": "0.2.12",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@11.5.0",
@@ -18,7 +18,7 @@
     "cli:link": "npm unlink -g @elmohq/cli || true && pnpm -C apps/cli build && (cd apps/cli && npm link)",
     "cli:unlink": "npm unlink -g @elmohq/cli",
     "changeset": "changeset",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && node scripts/sync-root-version.mjs",
     "release": "pnpm build && changeset publish",
     "test:e2e": "pnpm --filter e2e test:e2e",
     "test:e2e-local": "bash e2e/run-local.sh",

--- a/scripts/sync-root-version.mjs
+++ b/scripts/sync-root-version.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+/**
+ * Sync the monorepo root package version to the release train.
+ *
+ * The root `elmo` package is not a workspace member, so `changeset version`
+ * never bumps it and it drifts behind the published packages. Every workspace
+ * package shares a single version (changesets `fixed: [["**"]]`), so we copy
+ * that version onto the root purely as a visual marker of the current release.
+ * Runs automatically as part of `pnpm version-packages`.
+ *
+ * Idempotent: only rewrites the root manifest when the version differs, and
+ * touches only the version string so the rest of the file is left untouched.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const rootPkgPath = join(rootDir, "package.json");
+
+// The published CLI is part of the fixed version group, so its version is the
+// canonical release version shared by every workspace package.
+const sourceVersion = JSON.parse(
+  readFileSync(join(rootDir, "apps/cli/package.json"), "utf8"),
+).version;
+
+const rootContent = readFileSync(rootPkgPath, "utf8");
+const currentVersion = JSON.parse(rootContent).version;
+
+if (currentVersion === sourceVersion) {
+  console.log(`Root version already at ${sourceVersion}; nothing to sync.`);
+  process.exit(0);
+}
+
+// Replace only the first "version" field (the root package's own) so the rest
+// of the manifest's formatting is left untouched.
+const updated = rootContent.replace(
+  /"version":\s*"[^"]*"/,
+  `"version": "${sourceVersion}"`,
+);
+
+writeFileSync(rootPkgPath, updated);
+console.log(`Synced root version ${currentVersion} → ${sourceVersion}.`);


### PR DESCRIPTION
## What

The root `elmo` package version now tracks the release train. It was bumped `0.1.0 → 0.2.12` to match the rest of the workspace, and a small script keeps it in sync going forward.

- **`scripts/sync-root-version.mjs`** (new) — copies the shared release version (read from the published `@elmohq/cli`, which is part of the `fixed: [["**"]]` changesets group) onto the root manifest. Idempotent, and only rewrites the first `"version"` field so the rest of `package.json` is untouched.
- **`package.json`** — root version `0.1.0 → 0.2.12`; `version-packages` now runs `changeset version && node scripts/sync-root-version.mjs`.

## Why

The root `elmo` package is `private: true` and isn't a workspace member (workspace globs are `apps/*`, `packages/*`, `e2e`), so `changeset version` never bumps it. As a result it sat at the scaffold value `0.1.0` while every workspace package advanced to `0.2.12`. Nothing reads the root version — this is purely a visual marker so the monorepo root reflects the current release.

## Verification

- First run synced `0.1.0 → 0.2.12`; second run is a clean no-op.
- Surgical diff — only the version string changes, no formatting churn.

No changeset: this is internal release tooling, not a user-facing change.