### PR TITLE
Refresh roadmap upcoming features

### DIFF
--- a/apps/www/src/data/upcoming-features.json
+++ b/apps/www/src/data/upcoming-features.json
@@ -1,20 +1,20 @@
 {
-  "lastUpdated": "2026-05-08",
+  "lastUpdated": "2026-06-18",
   "note": "Curated list of upcoming highlights surfaced from the project board. Refresh via the `update-changelog` Claude skill.",
   "highlights": [
+    {
+      "title": "Elmo Cloud",
+      "description": "A fully hosted version of Elmo — sign up and start tracking your AI visibility in minutes, with no infrastructure to manage.",
+      "tag": "In progress",
+      "issue": 342,
+      "url": "https://github.com/elmohq/elmo/issues/342"
+    },
     {
       "title": "Citation sentiment tracking",
       "description": "Detect whether mentions of your brand in AI responses skew positive, neutral, or negative.",
       "tag": "Planned",
       "issue": 15,
       "url": "https://github.com/elmohq/elmo/issues/15"
-    },
-    {
-      "title": "Top action items",
-      "description": "Prioritized recommendations for what to improve next, generated from your visibility data.",
-      "tag": "In progress",
-      "issue": 73,
-      "url": "https://github.com/elmohq/elmo/issues/73"
     },
     {
       "title": "Content simulator",


### PR DESCRIPTION
Updates the curated "Upcoming Features" cards on the `/roadmap` page (`apps/www/src/data/upcoming-features.json`).

## Changes
- **Add "Elmo Cloud" (#342)** as the lead highlight — the hosted/self-serve launch is the dominant new initiative on the project board (epic #342–#352, opened 2026-06-10).
- **Remove "Top action items" (#73)** — shipped on 2026-06-07 via #314 and now closed, so it no longer belongs on an *upcoming* list.
- Keep the three still-open highlights (Citation sentiment #15, Content simulator #37, ChatGPT ads tracking #168), all verified open.
- Bump `lastUpdated` 2026-05-08 → 2026-06-18.

The "Trending and Recent Issues" section is fetched live from GitHub at load time, so it needs no manual update.