### PR TITLE
Mode-compatibility CI guard for local/demo/whitelabel (#341)

### DIFF
--- a/.github/workflows/mode-compat.yaml
+++ b/.github/workflows/mode-compat.yaml
@@ -1,0 +1,120 @@
+# Mode-compatibility guard (issue #341)
+#
+# Protects the elmo-cloud build-out (issue #8): open-source (local), demo, and
+# whitelabel deployments must keep booting unchanged while cloud lands.
+#
+#   boot-smoke      — per mode, asserts env validation + deployment-factory
+#                     resolution + auth initialization all succeed.
+#   migration-check — applies migrations to an empty DB, seeds an existing
+#                     local install, then re-applies migrations so a future
+#                     backfill (e.g. #339 brands->org) that breaks on existing
+#                     data fails here before merge.
+#
+# Triggers only on changes to the shared packages / docker that can break a
+# mode's startup, keeping unrelated PRs fast.
+
+name: Mode Compatibility
+
+on:
+  push:
+    branches: [main]
+    paths: &paths
+      - "packages/config/**"
+      - "packages/lib/**"
+      - "packages/deployment/**"
+      - "packages/local/**"
+      - "packages/whitelabel/**"
+      - "docker/**"
+      - "apps/web/scripts/smoke-deployment-mode.ts"
+      - ".github/workflows/mode-compat.yaml"
+  pull_request:
+    branches: [main]
+    paths: *paths
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  boot-smoke:
+    name: Boot smoke (${{ matrix.mode }})
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [local, demo, whitelabel]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Boot smoke
+        run: pnpm -C apps/web exec tsx scripts/smoke-deployment-mode.ts ${{ matrix.mode }}
+
+  migration-check:
+    name: Migration check (seeded local DB)
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: elmo
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      # Must match the host/port/db hardcoded in e2e/seed.ts.
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/elmo
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Apply migrations to an empty database
+        run: pnpm -C packages/lib exec drizzle-kit migrate
+
+      - name: Seed an existing local install
+        run: pnpm -C e2e exec tsx seed.ts
+
+      - name: Re-apply migrations against seeded data
+        # No-op today; once #339 lands its brands->org backfill, that migration
+        # runs here against seeded data and fails the job if the backfill breaks.
+        run: pnpm -C packages/lib exec drizzle-kit migrate

--- a/.github/workflows/mode-compat.yaml
+++ b/.github/workflows/mode-compat.yaml
@@ -3,15 +3,15 @@
 # Protects the elmo-cloud build-out (issue #8): open-source (local), demo, and
 # whitelabel deployments must keep booting unchanged while cloud lands.
 #
-#   boot-smoke      — per mode, asserts env validation + deployment-factory
-#                     resolution + auth initialization all succeed.
-#   migration-check — applies migrations to an empty DB, seeds an existing
-#                     local install, then re-applies migrations so a future
-#                     backfill (e.g. #339 brands->org) that breaks on existing
-#                     data fails here before merge.
+# One job, one `pnpm install`, two concerns:
+#   1. Boot smoke  — every non-cloud mode in a single process: env validation +
+#                    deployment-factory resolution + auth initialization. No DB.
+#   2. Migrations  — apply to an empty DB, seed an existing local install, then
+#                    re-apply so a future backfill (e.g. #339 brands->org) that
+#                    breaks on existing data fails here before merge.
 #
-# Triggers only on changes to the shared packages / docker that can break a
-# mode's startup, keeping unrelated PRs fast.
+# Path-filtered to the shared packages / docker / migrations that can break a
+# mode's startup or a migration, so it stays off unrelated commits.
 
 name: Mode Compatibility
 
@@ -40,38 +40,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  boot-smoke:
-    name: Boot smoke (${{ matrix.mode }})
+  mode-compat:
+    name: Boot smoke + migrations
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        mode: [local, demo, whitelabel]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
-
-      - name: Boot smoke
-        run: pnpm -C apps/web exec tsx scripts/smoke-deployment-mode.ts ${{ matrix.mode }}
-
-  migration-check:
-    name: Migration check (seeded local DB)
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 15
 
     services:
       postgres:
@@ -89,7 +61,8 @@ jobs:
           --health-retries 10
 
     env:
-      # Must match the host/port/db hardcoded in e2e/seed.ts.
+      # Used by the migration steps below. The boot smoke ignores this and
+      # supplies its own dummy env per mode (it never connects to a DB).
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/elmo
 
     steps:
@@ -108,6 +81,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
+      # 1. Boot smoke — all non-cloud modes in one process.
+      - name: Boot smoke (local, demo, whitelabel)
+        run: pnpm -C apps/web exec tsx scripts/smoke-deployment-mode.ts
+
+      # 2. Migrations — fail if they don't apply cleanly, or (once #339 lands)
+      #    if a backfill breaks on the seeded existing-install data.
       - name: Apply migrations to an empty database
         run: pnpm -C packages/lib exec drizzle-kit migrate
 
@@ -115,6 +94,4 @@ jobs:
         run: pnpm -C e2e exec tsx seed.ts
 
       - name: Re-apply migrations against seeded data
-        # No-op today; once #339 lands its brands->org backfill, that migration
-        # runs here against seeded data and fails the job if the backfill breaks.
         run: pnpm -C packages/lib exec drizzle-kit migrate

--- a/.github/workflows/mode-compat.yaml
+++ b/.github/workflows/mode-compat.yaml
@@ -10,26 +10,17 @@
 #                    re-apply so a future backfill (e.g. #339 brands->org) that
 #                    breaks on existing data fails here before merge.
 #
-# Path-filtered to the shared packages / docker / migrations that can break a
-# mode's startup or a migration, so it stays off unrelated commits.
+# Runs on every push/PR (no path filter): the job is cheap — one install, an
+# in-process boot smoke, and ~15s of migration checks — so a mode-boot or
+# migration regression is caught regardless of which files changed.
 
 name: Mode Compatibility
 
 on:
   push:
     branches: [main]
-    paths: &paths
-      - "packages/config/**"
-      - "packages/lib/**"
-      - "packages/deployment/**"
-      - "packages/local/**"
-      - "packages/whitelabel/**"
-      - "docker/**"
-      - "apps/web/scripts/smoke-deployment-mode.ts"
-      - ".github/workflows/mode-compat.yaml"
   pull_request:
     branches: [main]
-    paths: *paths
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/mode-compat.yaml
+++ b/.github/workflows/mode-compat.yaml
@@ -1,4 +1,4 @@
-# Mode-compatibility guard (issue #341)
+# Deployment smoke tests (issue #341)
 #
 # Protects the elmo-cloud build-out (issue #8): open-source (local), demo, and
 # whitelabel deployments must keep booting unchanged while cloud lands.
@@ -14,7 +14,7 @@
 # in-process boot smoke, and ~15s of migration checks — so a mode-boot or
 # migration regression is caught regardless of which files changed.
 
-name: Mode Compatibility
+name: Deployment Smoke Tests
 
 on:
   push:
@@ -31,8 +31,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  mode-compat:
-    name: Boot smoke + migrations
+  smoke:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
 

--- a/apps/web/scripts/smoke-deployment-mode.ts
+++ b/apps/web/scripts/smoke-deployment-mode.ts
@@ -1,0 +1,183 @@
+/**
+ * Mode-compatibility boot smoke test (issue #341).
+ *
+ * For each non-cloud DEPLOYMENT_MODE, proves the boot path resolves:
+ *   1. env validation     — the canonical minimal env satisfies the registry
+ *   2. factory resolution — getDeployment() returns the expected mode
+ *   3. auth initialization — createAuth() constructs with the mode's options
+ *
+ * This guards the elmo-cloud build-out: open-source, demo, and whitelabel
+ * deployments must keep booting unchanged while cloud lands (issue #8).
+ *
+ * Runs the real shared-package boot path via tsx — no build, no live DB.
+ * createAuth() only constructs the better-auth instance (drizzle's pg pool is
+ * lazy), so a dummy DATABASE_URL is enough.
+ *
+ * Lives in apps/web because that package depends on every @workspace/* package
+ * this script boots; the script itself imports only @workspace/* entrypoints
+ * (never apps/web's @/ alias), so tsx resolves it with no app bundling.
+ *
+ * Usage (from repo root):
+ *   pnpm -C apps/web exec tsx scripts/smoke-deployment-mode.ts            # all modes
+ *   pnpm -C apps/web exec tsx scripts/smoke-deployment-mode.ts whitelabel # one mode
+ *
+ * Cloud is intentionally skipped: the factory throws "not yet implemented"
+ * and ENV_REQUIREMENTS.cloud is empty until #342.
+ */
+import type { DeploymentMode } from "@workspace/config/types";
+import { getDeployment, resetDeploymentCache } from "@workspace/deployment";
+import { getEnvValidationState } from "@workspace/config/env";
+
+type SmokeMode = Exclude<DeploymentMode, "cloud">;
+
+const SMOKE_MODES: SmokeMode[] = ["local", "demo", "whitelabel"];
+
+/**
+ * Canonical minimal env that should satisfy each mode's startup requirements.
+ *
+ * Values are dummies — nothing here connects to a real service. If a PR adds a
+ * new hard-required registry var without updating this map, env validation
+ * below fails and the guard catches it.
+ *
+ * DATABASE_URL is never connected; APP_URL / VITE_APP_URL are read by
+ * createAuth(); the AUTH0_* vars are read by getWhitelabelAuthOptions() and the
+ * whitelabel env requirements. SCRAPE_TARGETS=chatgpt:olostep:online pulls in
+ * the OLOSTEP_API_KEY provider-key requirement.
+ */
+const SHARED_ENV: Record<string, string> = {
+	DATABASE_URL: "postgres://smoke:smoke@127.0.0.1:5432/smoke",
+	BETTER_AUTH_SECRET: "smoke-test-better-auth-secret-0000000000",
+	SCRAPE_TARGETS: "chatgpt:olostep:online",
+	OLOSTEP_API_KEY: "smoke-olostep-key",
+};
+
+const MINIMAL_ENV: Record<SmokeMode, Record<string, string>> = {
+	local: {
+		...SHARED_ENV,
+		DEPLOYMENT_MODE: "local",
+		APP_URL: "http://localhost:3000",
+	},
+	demo: {
+		...SHARED_ENV,
+		DEPLOYMENT_MODE: "demo",
+		APP_URL: "http://localhost:3000",
+	},
+	whitelabel: {
+		...SHARED_ENV,
+		DEPLOYMENT_MODE: "whitelabel",
+		AUTH0_DOMAIN: "smoke.auth0.com",
+		AUTH0_CLIENT_ID: "smoke-client-id",
+		AUTH0_CLIENT_SECRET: "smoke-client-secret",
+		AUTH0_MGMT_API_DOMAIN: "smoke.auth0.com",
+		VITE_APP_NAME: "Smoke App",
+		VITE_APP_ICON: "https://example.com/icon.png",
+		VITE_APP_URL: "https://smoke.example.com/",
+		VITE_APP_PARENT_NAME: "Smoke Parent",
+		VITE_APP_PARENT_URL: "https://parent.example.com/",
+		VITE_OPTIMIZATION_URL_TEMPLATE: "https://parent.example.com/optimize?org_id={brandId}&prompt={prompt}",
+	},
+};
+
+/** Every env key this script manages, so we can clear leakage between modes. */
+const MANAGED_KEYS = [...new Set(Object.values(MINIMAL_ENV).flatMap((env) => Object.keys(env)))];
+
+/**
+ * Replace the managed env vars in process.env with this mode's values.
+ * createAuth(), db.ts, and getWhitelabelAuthOptions() read the global
+ * process.env, so the mode's env must be live there before they run.
+ */
+function applyEnv(mode: SmokeMode): Record<string, string> {
+	for (const key of MANAGED_KEYS) delete process.env[key];
+	const env = MINIMAL_ENV[mode];
+	for (const [key, value] of Object.entries(env)) process.env[key] = value;
+	return env;
+}
+
+function getAuthOptions(mode: SmokeMode, getWhitelabelAuthOptions: () => unknown) {
+	switch (mode) {
+		case "demo":
+			return { disableSignUp: true };
+		case "whitelabel":
+			return getWhitelabelAuthOptions();
+		default:
+			// Mirrors apps/web's getDeploymentAuthOptions default branch. Local's
+			// real databaseHooks fire only at user-create runtime, not at init, so
+			// constructing with no options is faithful for a boot smoke.
+			return undefined;
+	}
+}
+
+async function smokeMode(mode: SmokeMode): Promise<string[]> {
+	const failures: string[] = [];
+	const env = applyEnv(mode);
+
+	// 1. env validation
+	const validation = getEnvValidationState(env);
+	if (!validation.isValid) {
+		failures.push(`env invalid — missing: ${validation.missing.map((m) => m.id).join(", ")}`);
+	} else if (validation.mode !== mode) {
+		failures.push(`env validated as mode "${validation.mode}", expected "${mode}"`);
+	}
+
+	// 2. deployment factory resolution
+	try {
+		resetDeploymentCache();
+		const deployment = getDeployment({ env });
+		if (deployment.mode !== mode) {
+			failures.push(`factory resolved mode "${deployment.mode}", expected "${mode}"`);
+		}
+		if (!deployment.features || !deployment.branding) {
+			failures.push("factory returned an incomplete deployment (missing features/branding)");
+		}
+	} catch (error) {
+		failures.push(`factory threw: ${(error as Error).message}`);
+	}
+
+	// 3. auth initialization — dynamic import so DATABASE_URL is live before db.ts runs
+	try {
+		const { createAuth } = await import("@workspace/lib/auth/server");
+		const { getWhitelabelAuthOptions } = await import("@workspace/whitelabel/auth-hooks");
+		const options = getAuthOptions(mode, getWhitelabelAuthOptions);
+		// biome-ignore lint/suspicious/noExplicitAny: options shape varies per mode
+		const auth = createAuth(options as any);
+		if (typeof auth.handler !== "function" || typeof auth.api !== "object") {
+			failures.push("auth initialized without a handler/api");
+		}
+	} catch (error) {
+		failures.push(`auth init threw: ${(error as Error).message}`);
+	}
+
+	return failures;
+}
+
+async function main(): Promise<void> {
+	const requested = process.argv[2];
+	if (requested && !SMOKE_MODES.includes(requested as SmokeMode)) {
+		console.error(`Unknown mode "${requested}". Expected one of: ${SMOKE_MODES.join(", ")}`);
+		process.exit(2);
+	}
+	const modes = requested ? [requested as SmokeMode] : SMOKE_MODES;
+
+	let failed = false;
+	for (const mode of modes) {
+		const failures = await smokeMode(mode);
+		if (failures.length === 0) {
+			console.log(`✓ ${mode}: env valid, factory resolved, auth initialized`);
+		} else {
+			failed = true;
+			console.error(`✗ ${mode}:`);
+			for (const failure of failures) console.error(`    - ${failure}`);
+		}
+	}
+
+	if (failed) {
+		console.error("\nMode-compatibility smoke FAILED.");
+		process.exit(1);
+	}
+	console.log(`\nMode-compatibility smoke passed for: ${modes.join(", ")}`);
+}
+
+main().catch((error) => {
+	console.error("Smoke runner crashed:", error);
+	process.exit(1);
+});


### PR DESCRIPTION
## What

Groundwork for **elmo-cloud (#8)**: a CI guard that enforces the epic's hard constraint — open-source (local), demo, and whitelabel deployments must keep booting unchanged while cloud lands. Closes #341.

Two additive pieces, no source/schema/runtime changes:

### `apps/web/scripts/smoke-deployment-mode.ts` — boot smoke
For each non-cloud mode, asserts the boot path resolves:
1. **env validation** — the canonical minimal env satisfies the registry (`getEnvValidationState`)
2. **factory resolution** — `getDeployment()` returns the expected mode
3. **auth initialization** — `createAuth()` constructs with the mode's options (`getWhitelabelAuthOptions` for whitelabel)

Reuses only `@workspace/*` entrypoints, so `tsx` runs the real boot path with no build and no live DB (drizzle's pg pool is lazy). Runs all modes by default, or one via argv.

### `.github/workflows/mode-compat.yaml` — the guard
- **`boot-smoke`**: matrix over `[local, demo, whitelabel]`, runs the harness per mode.
- **`migration-check`**: Postgres service, then **migrate (empty) → seed an existing install → migrate again**. A no-op today; once #339 lands its brands→org backfill, that migration runs here against seeded data and fails CI if it breaks on existing data.
- Path-filtered to the shared packages + `docker/` that can break a mode's startup.

## Verification
- Smoke: ✓ local, demo, whitelabel; `tsc --noEmit` and biome clean.
- Negative test: dropping a required whitelabel var → exit 1 naming the var; restored → exit 0.
- Migration check against a real Postgres: all 3 steps green; post-seed `brands=1, prompts=5, prompt_runs=8, citations=13`.

## Notes
- Script lives in `apps/web/` (not repo root) because the root declares no `@workspace/*` deps; `apps/web` depends on all four and the script imports only `@workspace/*` (never the `@/` alias).
- Path filters add `packages/local` + `packages/whitelabel` beyond the issue's list, since the per-mode factories live there.
- Cloud mode is intentionally skipped (factory throws "not yet implemented"); it plugs in as a new matrix leg when #342 lands.