### PR TITLE
Speed up E2E workflow ~30% (drop free-disk-space, skip worker run, cache Playwright)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -61,6 +61,12 @@ jobs:
       - name: Unit tests
         run: pnpm turbo test
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
         run: pnpm -C apps/web exec playwright install chromium --with-deps
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,18 +34,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      # without this, docker builds run out of space
-      - name: Free Disk Space
+      # Persistent BuildKit layer cache on a Blacksmith sticky disk, so the
+      # docker build below reuses the pnpm-install layer across runs.
+      # (Blacksmith runners have ample disk, so no free-disk-space step is
+      # needed here — publish.yaml builds the same Dockerfile without one.)
+      - name: Setup Blacksmith Docker builder
         if: ${{ !env.ACT }}
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -96,11 +91,20 @@ jobs:
           echo "=== elmo.yaml (services) ==="
           grep -E '^\s{2}\w' e2e/.elmo/elmo.yaml || true
 
-      - name: Start all services
-        run: docker compose -f e2e/.elmo/elmo.yaml up -d --build
+      # Build all images so a broken worker (or db-migrate) Dockerfile fails CI
+      # here, even though we don't run the worker. web/worker/migrate share the
+      # base/deps/builder stages, so BuildKit builds those once — building all
+      # three costs little more than building web alone. postgres is an image
+      # pull, so `build` skips it.
+      - name: Build images
+        run: docker compose -f e2e/.elmo/elmo.yaml build
 
-      - name: Stop worker
-        run: docker compose -f e2e/.elmo/elmo.yaml stop worker
+      # Start only web and its deps (db-migrate, postgres). The worker is
+      # intentionally not started (we skip it to avoid execution costs); it was
+      # only ever started to be immediately stopped, which gave no runtime
+      # safety, so we just don't start it.
+      - name: Start services
+        run: docker compose -f e2e/.elmo/elmo.yaml up -d --no-build web
 
       - name: Wait for web
         run: |
@@ -137,7 +141,3 @@ jobs:
           name: test-results
           path: e2e/test-results/
           retention-days: 7
-
-      - name: Cleanup Docker services
-        if: always()
-        run: docker compose -f e2e/.elmo/elmo.yaml down -v 2>/dev/null || true

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,13 +34,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      # Persistent BuildKit layer cache on a Blacksmith sticky disk, so the
-      # docker build below reuses the pnpm-install layer across runs.
-      # (Blacksmith runners have ample disk, so no free-disk-space step is
-      # needed here — publish.yaml builds the same Dockerfile without one.)
-      - name: Setup Blacksmith Docker builder
-        if: ${{ !env.ACT }}
-        uses: useblacksmith/setup-docker-builder@v1
+      # NB: no free-disk-space step here — it predated the Blacksmith migration
+      # and is unnecessary on these runners (publish.yaml builds the same
+      # Dockerfile without it). We also deliberately do NOT use a buildx
+      # sticky-disk builder: `docker compose build` doesn't wire up its cache,
+      # and the container driver would serialize each image to load it back into
+      # the local daemon for `up` — that export/import tax outweighs any cache
+      # savings for this build-and-run-locally job. The default driver builds
+      # straight into the daemon's image store.
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,8 +26,10 @@ COPY packages/api-spec/package.json ./packages/api-spec/
 # Install dependencies
 RUN pnpm install --frozen-lockfile
 
-# Builder stage
-FROM base AS builder
+# Shared build context: dependencies + source. Built once, then shared by the
+# three per-target build stages below. Splitting the build into independent
+# stages lets BuildKit run them in parallel instead of one sequential stage.
+FROM base AS source
 WORKDIR /app
 
 # Copy dependencies
@@ -45,6 +47,10 @@ COPY --from=deps /app/packages/og/node_modules ./packages/og/node_modules
 # Copy source code
 COPY . .
 
+# Web build (Nitro output). Independent of the deploy stages, so BuildKit builds
+# all three concurrently.
+FROM source AS web-builder
+
 # Build arguments for VITE_ env vars (baked into client bundle)
 ARG DEPLOYMENT_MODE=local
 ARG VITE_DEPLOYMENT_MODE=${DEPLOYMENT_MODE}
@@ -53,9 +59,13 @@ ENV VITE_DEPLOYMENT_MODE=${VITE_DEPLOYMENT_MODE}
 # Build the web application (increase heap for large bundles)
 RUN pnpm --filter @workspace/web build
 
-# Create pruned standalone deployments (only each package's own deps)
+# Pruned standalone deployment for the worker (only its own deps)
 # --legacy: allows deploy without inject-workspace-packages (which breaks Alpine Docker builds)
+FROM source AS worker-builder
 RUN pnpm --filter @workspace/worker deploy --legacy /deploy/worker
+
+# Pruned standalone deployment for migrations (the lib package)
+FROM source AS lib-builder
 RUN pnpm --filter @workspace/lib deploy --legacy /deploy/lib
 
 # Runner stage for web app (Nitro)
@@ -73,7 +83,7 @@ COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Copy Nitro output - this is the entire server bundle
-COPY --from=builder --chown=elmo:nodejs /app/apps/web/.output ./.output
+COPY --from=web-builder --chown=elmo:nodejs /app/apps/web/.output ./.output
 
 USER elmo
 
@@ -88,7 +98,7 @@ CMD ["node", ".output/server/index.mjs"]
 FROM base AS migrate
 WORKDIR /app
 
-COPY --from=builder /deploy/lib ./
+COPY --from=lib-builder /deploy/lib ./
 
 CMD ["npx", "drizzle-kit", "migrate"]
 
@@ -104,7 +114,7 @@ RUN adduser --system --uid 1001 worker
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-COPY --from=builder --chown=worker:nodejs /deploy/worker ./
+COPY --from=worker-builder --chown=worker:nodejs /deploy/worker ./
 
 USER worker
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,10 +26,8 @@ COPY packages/api-spec/package.json ./packages/api-spec/
 # Install dependencies
 RUN pnpm install --frozen-lockfile
 
-# Shared build context: dependencies + source. Built once, then shared by the
-# three per-target build stages below. Splitting the build into independent
-# stages lets BuildKit run them in parallel instead of one sequential stage.
-FROM base AS source
+# Builder stage
+FROM base AS builder
 WORKDIR /app
 
 # Copy dependencies
@@ -47,10 +45,6 @@ COPY --from=deps /app/packages/og/node_modules ./packages/og/node_modules
 # Copy source code
 COPY . .
 
-# Web build (Nitro output). Independent of the deploy stages, so BuildKit builds
-# all three concurrently.
-FROM source AS web-builder
-
 # Build arguments for VITE_ env vars (baked into client bundle)
 ARG DEPLOYMENT_MODE=local
 ARG VITE_DEPLOYMENT_MODE=${DEPLOYMENT_MODE}
@@ -59,13 +53,9 @@ ENV VITE_DEPLOYMENT_MODE=${VITE_DEPLOYMENT_MODE}
 # Build the web application (increase heap for large bundles)
 RUN pnpm --filter @workspace/web build
 
-# Pruned standalone deployment for the worker (only its own deps)
+# Create pruned standalone deployments (only each package's own deps)
 # --legacy: allows deploy without inject-workspace-packages (which breaks Alpine Docker builds)
-FROM source AS worker-builder
 RUN pnpm --filter @workspace/worker deploy --legacy /deploy/worker
-
-# Pruned standalone deployment for migrations (the lib package)
-FROM source AS lib-builder
 RUN pnpm --filter @workspace/lib deploy --legacy /deploy/lib
 
 # Runner stage for web app (Nitro)
@@ -83,7 +73,7 @@ COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Copy Nitro output - this is the entire server bundle
-COPY --from=web-builder --chown=elmo:nodejs /app/apps/web/.output ./.output
+COPY --from=builder --chown=elmo:nodejs /app/apps/web/.output ./.output
 
 USER elmo
 
@@ -98,7 +88,7 @@ CMD ["node", ".output/server/index.mjs"]
 FROM base AS migrate
 WORKDIR /app
 
-COPY --from=lib-builder /deploy/lib ./
+COPY --from=builder /deploy/lib ./
 
 CMD ["npx", "drizzle-kit", "migrate"]
 
@@ -114,7 +104,7 @@ RUN adduser --system --uid 1001 worker
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-COPY --from=worker-builder --chown=worker:nodejs /deploy/worker ./
+COPY --from=builder --chown=worker:nodejs /deploy/worker ./
 
 USER worker
 


### PR DESCRIPTION
## Summary

Speeds up the E2E job from **~298s to ~190–215s (~30%)** by removing work that's vestigial on Blacksmith runners and avoiding a caching approach that backfires for this build-and-run-locally job. No test coverage is lost.

Run-to-run timing varies by ~±20s, almost entirely in the Docker build (`Build images`) step, so treat the numbers as approximate.

## Changes (kept)

- **Remove `jlumbroso/free-disk-space` (~−49s).** Added (2026-02-19) for GitHub-hosted runners' ~14 GB disk, *before* the Blacksmith migration (#159, 2026-04-06). `publish.yaml` builds the same `docker/Dockerfile` on the same `blacksmith-4vcpu` runner with no disk-freeing, so it's safe to drop here.
- **Build all images, then start only `web` (`up -d --no-build web`).** Previously `up --build` built *and started* the worker, then `stop worker` killed it ~10s later — which gave **no worker runtime safety** (`up -d` doesn't wait for health; `stop` on a crashed container is a no-op). We keep worker + db-migrate **build** verification via `docker compose build`, but never start the worker (skipped to avoid execution costs). Drops the ~10s `stop worker` step.
- **Drop the `down -v` cleanup step (~−11s).** The runner is ephemeral.
- **Cache Playwright browsers (~−7s on warm runs).** Keyed on `pnpm-lock.yaml`.

## Tried and dropped (documented so we don't repeat them)

- **Blacksmith sticky-disk Docker layer cache (`useblacksmith/setup-docker-builder`).** `docker compose build` never wires up its cache, so every layer rebuilt anyway — *and* the buildx container driver added ~40s serializing each image to load it back into the local daemon for `up`. Net **slower** (warm build 103s → 162s). The default docker driver builds straight into the daemon's image store, so we use that. (The action is correct for `publish.yaml`, which pushes to a registry and never needs a local load.)
- **Splitting the monolithic `builder` stage into parallel per-target stages.** BuildKit *did* run them concurrently, but the e2e build is gated by a serial chain (`pnpm install → copy source → vite build → image export`); the worker/lib deploys already overlapped the web build, so the split changed nothing (104s vs 103s). Reverted to keep the Dockerfile simple.

## Where the time goes now

`Build images` (~105–115s) dominates and is largely irreducible on a 4-vCPU runner: `pnpm install (~18s) + copy source (~7s) + vite build (~45s) + image export (~13s)`. Further options (8-vCPU runner, Turbo remote build cache) have poor ROI — discussed on the PR thread.

## Net diff

A single file: `.github/workflows/e2e.yaml`. The Dockerfile is unchanged from `main` (the stage-split experiment was reverted).

## Follow-up

- #369 — add runtime worker testing (the worker is built but never exercised end-to-end).
