### PR TITLE
Scope brands to organizations (#339)

### DIFF
--- a/apps/web/src/components/prompts-display.tsx
+++ b/apps/web/src/components/prompts-display.tsx
@@ -192,6 +192,7 @@ function ChartSection({
 	const brandForProvider: Brand | null = batchChartData?.brand
 		? {
 				id: batchChartData.brand.id,
+				organizationId: batchChartData.brand.id,
 				name: batchChartData.brand.name,
 				website: "",
 				additionalDomains: [],

--- a/apps/web/src/lib/auth/__tests__/policies.test.ts
+++ b/apps/web/src/lib/auth/__tests__/policies.test.ts
@@ -19,6 +19,7 @@ import {
 	evaluateAuthedRouteGuard,
 	evaluateBrandRouteGuard,
 	evaluateDeploymentPolicy,
+	evaluateOrgScope,
 	evaluateReadOnly,
 	evaluateRequireAdmin,
 	evaluateRequireCanCreateBrands,
@@ -409,6 +410,39 @@ describe("evaluateRequireOrgAccess", () => {
 
 	it("allows when user has org access", () => {
 		expect(evaluateRequireOrgAccess(true)).toBe("allow");
+	});
+});
+
+// Brand/prompt/run/citation org scoping (issue #339). A brand's
+// organization_id is the tenancy boundary; membership is the access mechanism.
+describe("evaluateOrgScope", () => {
+	const ORG_A = "org-a";
+	const ORG_B = "org-b";
+
+	it("allows a member to access their own org's resource", () => {
+		expect(evaluateOrgScope([ORG_A], ORG_A)).toBe("allow");
+	});
+
+	it("denies a member of org A from accessing org B's resource", () => {
+		expect(evaluateOrgScope([ORG_A], ORG_B)).toBe("deny");
+	});
+
+	it("allows access for any org the user belongs to (multi-org member)", () => {
+		expect(evaluateOrgScope([ORG_A, ORG_B], ORG_B)).toBe("allow");
+	});
+
+	it("denies a resource in an org the multi-org user does not belong to", () => {
+		expect(evaluateOrgScope([ORG_A, ORG_B], "org-c")).toBe("deny");
+	});
+
+	it("denies when the user has no memberships", () => {
+		expect(evaluateOrgScope([], ORG_A)).toBe("deny");
+	});
+
+	it("does not treat the brand id as an org membership by itself", () => {
+		// Pre-#339 access leaned on brand.id == org.id; scoping must be driven
+		// by actual membership, not by the resource naming itself.
+		expect(evaluateOrgScope([], "org-a")).toBe("deny");
 	});
 });
 

--- a/apps/web/src/lib/auth/policies.ts
+++ b/apps/web/src/lib/auth/policies.ts
@@ -222,6 +222,24 @@ export function evaluateRequireOrgAccess(
 }
 
 /**
+ * Evaluate org-scoped resource access — the pure core of the brand / prompt /
+ * promptRun / citation scoping (issue #339).
+ *
+ * Every brand carries an `organization_id`; a user may only read or mutate a
+ * resource whose owning org they are a member of. This mirrors the runtime
+ * checks — `checkOrgAccess` for a single resource and the
+ * `brands.organization_id IN (member orgs)` filter in `getBrands` — as a
+ * side-effect-free function, so the cross-tenant isolation guarantee ("a member
+ * of org A is denied org B's resources") is locked in by tests.
+ */
+export function evaluateOrgScope(
+	memberOrgIds: readonly string[],
+	resourceOrgId: string,
+): "allow" | "deny" {
+	return memberOrgIds.includes(resourceOrgId) ? "allow" : "deny";
+}
+
+/**
  * Evaluate read-only mode enforcement.
  * Used by `readOnlyMiddleware` for server functions.
  */

--- a/apps/web/src/lib/auth/policies.ts
+++ b/apps/web/src/lib/auth/policies.ts
@@ -222,15 +222,16 @@ export function evaluateRequireOrgAccess(
 }
 
 /**
- * Evaluate org-scoped resource access — the pure core of the brand / prompt /
- * promptRun / citation scoping (issue #339).
+ * Org-scoped resource access rule (issue #339), in pure form.
  *
  * Every brand carries an `organization_id`; a user may only read or mutate a
- * resource whose owning org they are a member of. This mirrors the runtime
- * checks — `checkOrgAccess` for a single resource and the
- * `brands.organization_id IN (member orgs)` filter in `getBrands` — as a
- * side-effect-free function, so the cross-tenant isolation guarantee ("a member
- * of org A is denied org B's resources") is locked in by tests.
+ * resource whose owning org they belong to. The runtime enforces this directly
+ * in SQL — `checkOrgAccess` for a single resource and the
+ * `brands.organization_id IN (member orgs)` filter in `getBrands`. This function
+ * is the canonical statement of that same rule, unit-tested in isolation
+ * (mirroring the sibling `evaluateRequireOrgAccess`); it documents and pins the
+ * "a member of org A is denied org B's resources" invariant, but is not itself
+ * the runtime gate.
  */
 export function evaluateOrgScope(
 	memberOrgIds: readonly string[],

--- a/apps/web/src/server/brands.ts
+++ b/apps/web/src/server/brands.ts
@@ -10,7 +10,7 @@ import { getDeployment } from "@/lib/config/server";
 import { db } from "@workspace/lib/db/db";
 import { brands, prompts, competitors, type BrandWithPrompts, type Brand } from "@workspace/lib/db/schema";
 import { provisionAdditionalLocalOrg } from "@workspace/lib/db/provisioning";
-import { eq, and, count, sql } from "drizzle-orm";
+import { eq, and, count, sql, inArray } from "drizzle-orm";
 import { MAX_COMPETITORS } from "@workspace/lib/constants";
 import { cleanAndValidateDomain } from "@/lib/domain-categories";
 import { validateWebsiteUrl } from "@/lib/brand-website";
@@ -98,26 +98,32 @@ async function getBrandWithPromptsFromDb(
 // ============================================================================
 
 /**
- * Get all brands the current user has access to
+ * Get all brands the current user has access to.
+ *
+ * Org scoping is the access-control mechanism: we resolve the orgs the user is
+ * a member of and return only brands owned by those orgs (`brands.organization_id
+ * IN (...)`). A user in org A never sees org B's brands.
  */
 export const getBrands = createServerFn({ method: "GET" }).handler(async () => {
 	const session = await requireAuthSession();
-	const userBrands = await listUserOrganizations(session.user.id);
+	const userOrgs = await listUserOrganizations(session.user.id);
+	const orgIds = userOrgs.map((o) => o.id);
 
-	if (!userBrands || userBrands.length === 0) {
+	if (orgIds.length === 0) {
 		return [];
 	}
 
+	const scopedBrands = await db.query.brands.findMany({
+		where: inArray(brands.organizationId, orgIds),
+	});
+
 	const brandsData = await Promise.all(
-		userBrands.map(async (userBrand) => {
-			const dbBrand = await getBrandWithPromptsFromDb(userBrand.id);
-			return dbBrand ? { ...dbBrand, name: dbBrand.name } : null;
-		}),
+		scopedBrands.map((brand) => getBrandWithPromptsFromDb(brand.id)),
 	);
 
 	return brandsData.filter(
 		(brand): brand is BrandWithPrompts & { effectiveModels: string[]; effectiveModelConfigs: ModelConfig[] } =>
-			brand !== null,
+			brand !== undefined,
 	);
 });
 
@@ -164,6 +170,9 @@ export const createBrandFn = createServerFn({ method: "POST" })
 			.insert(brands)
 			.values({
 				id: data.brandId,
+				// brandId is the org id from the URL (access verified above); the
+				// brand belongs to that org.
+				organizationId: data.brandId,
 				name: data.brandName,
 				website: urlValidation.formattedUrl,
 				enabled: true,
@@ -225,6 +234,7 @@ export const createBrandWithOrgFn = createServerFn({ method: "POST" })
 
 		await db.insert(brands).values({
 			id: orgId,
+			organizationId: orgId,
 			name: trimmedName,
 			website: urlValidation.formattedUrl,
 			enabled: true,

--- a/apps/web/src/server/onboarding-core.ts
+++ b/apps/web/src/server/onboarding-core.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import { eq, count } from "drizzle-orm";
 import { db } from "@workspace/lib/db/db";
 import { brands, prompts, competitors } from "@workspace/lib/db/schema";
+import { ensureOrganization } from "@workspace/lib/db/provisioning";
 import { MAX_COMPETITORS } from "@workspace/lib/constants";
 import { computeSystemTags, sanitizeUserTags } from "@workspace/lib/tag-utils";
 import { dedupeDomains, dedupeAliases } from "@/lib/domain-categories";
@@ -301,10 +302,17 @@ export async function createBrand(input: CreateBrandInput): Promise<BrandResult>
 	const additionalDomains = dedupeDomains(input.additionalDomains ?? []).filter((d) => d !== websiteHost);
 	const aliases = dedupeAliases(input.aliases ?? []);
 
+	// Brands are hard-scoped to an org via a NOT NULL FK. This create path (the
+	// admin API) supplies the brand id directly and historically created brands
+	// whose id == the org id, so materialize that org first. No-op when it
+	// already exists (e.g. a whitelabel org already synced from Auth0).
+	await ensureOrganization({ id: input.id, name: input.name });
+
 	const [inserted] = await db
 		.insert(brands)
 		.values({
 			id: input.id,
+			organizationId: input.id,
 			name: input.name,
 			website: formattedWebsite,
 			additionalDomains,

--- a/e2e/seed.ts
+++ b/e2e/seed.ts
@@ -66,11 +66,18 @@ async function seed() {
     await client.query("DELETE FROM brands");
 
     // -----------------------------------------------------------------------
-    // 1. Brand
+    // 1. Brand (scoped to an organization that shares its id)
     // -----------------------------------------------------------------------
+    // Signup provisions the "default" org as well, but the seed re-creates the
+    // brand independently — ensure the org exists for the NOT NULL FK.
     await client.query(
-      `INSERT INTO brands (id, name, website, enabled, onboarded, created_at, updated_at)
-       VALUES ($1, $2, $3, true, true, NOW(), NOW())`,
+      `INSERT INTO organization (id, name, slug, created_at)
+       VALUES ($1, $2, $1, NOW()) ON CONFLICT (id) DO NOTHING`,
+      [TEST_BRAND_ID, TEST_BRAND_NAME]
+    );
+    await client.query(
+      `INSERT INTO brands (id, organization_id, name, website, enabled, onboarded, created_at, updated_at)
+       VALUES ($1, $1, $2, $3, true, true, NOW(), NOW())`,
       [TEST_BRAND_ID, TEST_BRAND_NAME, TEST_BRAND_WEBSITE]
     );
     console.log("  Created brand:", TEST_BRAND_ID);

--- a/packages/lib/src/db/migrations/0010_scope_brands_to_orgs.sql
+++ b/packages/lib/src/db/migrations/0010_scope_brands_to_orgs.sql
@@ -6,11 +6,12 @@
 -- metering, and enforcement) instead of relying on the implicit `brand.id ==
 -- organization.id` convention.
 --
--- Backfill assigns every brand to the org that shares its id, so existing
+-- Backfill assigns every brand to the org that shares its id (1:1), so existing
 -- local / demo / whitelabel installs upgrade with zero manual steps and keep
--- behaving identically (each brand stays mapped to its own org — NOT collapsed
--- into a single shared default org, which would hide brands from their members
--- in multi-org whitelabel / multi-brand local deployments).
+-- behaving identically — each brand stays mapped to its own org, NOT collapsed
+-- into a single shared default org (which would hide brands from their members
+-- in multi-org whitelabel / multi-brand local deployments). Every brand already
+-- has a matching org row, so the FK below holds with no extra work.
 
 -- Fail fast rather than queue behind a long-running query / worker insert.
 SET lock_timeout = '5s';
@@ -20,23 +21,10 @@ SET statement_timeout = '15min';
 -- NOT NULL + FK constraints are enforced. No default -> metadata-only, instant.
 ALTER TABLE "brands" ADD COLUMN "organization_id" text;--> statement-breakpoint
 
--- Step 2: ensure every brand has a matching organization row. In all current
--- deployments a brand's id already equals an existing org id, so this inserts
--- nothing. The defensive case is a brand created via the admin API before its
--- org was synced (whitelabel, where orgs arrive from Auth0 on first login): we
--- materialize the missing org (id == slug == brand id) so the FK holds and the
--- brand stays mapped to its own org. Whitelabel Auth0 sync later upserts the
--- same id idempotently (correcting name/slug) and attaches membership.
-INSERT INTO "organization" ("id", "name", "slug", "created_at")
-SELECT b."id", b."name", b."id", now()
-FROM "brands" b
-WHERE NOT EXISTS (SELECT 1 FROM "organization" o WHERE o."id" = b."id")
-ON CONFLICT DO NOTHING;--> statement-breakpoint
-
--- Step 3: backfill — each brand belongs to the org that shares its id.
+-- Step 2: backfill — each brand belongs to the org that shares its id.
 UPDATE "brands" SET "organization_id" = "id" WHERE "organization_id" IS NULL;--> statement-breakpoint
 
--- Step 4: enforce going forward.
+-- Step 3: enforce going forward.
 ALTER TABLE "brands" ALTER COLUMN "organization_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "brands" ADD CONSTRAINT "brands_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "brands_organization_id_idx" ON "brands" USING btree ("organization_id");

--- a/packages/lib/src/db/migrations/0010_scope_brands_to_orgs.sql
+++ b/packages/lib/src/db/migrations/0010_scope_brands_to_orgs.sql
@@ -1,0 +1,42 @@
+-- Scope brands to organizations (issue #339).
+--
+-- Adds brands.organization_id as a hard FK to the better-auth `organization`
+-- table. Org membership is already the access-control mechanism; this makes the
+-- brand -> org relationship explicit (the prerequisite for cloud entitlements,
+-- metering, and enforcement) instead of relying on the implicit `brand.id ==
+-- organization.id` convention.
+--
+-- Backfill assigns every brand to the org that shares its id, so existing
+-- local / demo / whitelabel installs upgrade with zero manual steps and keep
+-- behaving identically (each brand stays mapped to its own org — NOT collapsed
+-- into a single shared default org, which would hide brands from their members
+-- in multi-org whitelabel / multi-brand local deployments).
+
+-- Fail fast rather than queue behind a long-running query / worker insert.
+SET lock_timeout = '5s';
+SET statement_timeout = '15min';
+
+-- Step 1: add the column nullable so existing rows can be backfilled before the
+-- NOT NULL + FK constraints are enforced. No default -> metadata-only, instant.
+ALTER TABLE "brands" ADD COLUMN "organization_id" text;--> statement-breakpoint
+
+-- Step 2: ensure every brand has a matching organization row. In all current
+-- deployments a brand's id already equals an existing org id, so this inserts
+-- nothing. The defensive case is a brand created via the admin API before its
+-- org was synced (whitelabel, where orgs arrive from Auth0 on first login): we
+-- materialize the missing org (id == slug == brand id) so the FK holds and the
+-- brand stays mapped to its own org. Whitelabel Auth0 sync later upserts the
+-- same id idempotently (correcting name/slug) and attaches membership.
+INSERT INTO "organization" ("id", "name", "slug", "created_at")
+SELECT b."id", b."name", b."id", now()
+FROM "brands" b
+WHERE NOT EXISTS (SELECT 1 FROM "organization" o WHERE o."id" = b."id")
+ON CONFLICT DO NOTHING;--> statement-breakpoint
+
+-- Step 3: backfill — each brand belongs to the org that shares its id.
+UPDATE "brands" SET "organization_id" = "id" WHERE "organization_id" IS NULL;--> statement-breakpoint
+
+-- Step 4: enforce going forward.
+ALTER TABLE "brands" ALTER COLUMN "organization_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "brands" ADD CONSTRAINT "brands_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "brands_organization_id_idx" ON "brands" USING btree ("organization_id");

--- a/packages/lib/src/db/migrations/meta/0010_snapshot.json
+++ b/packages/lib/src/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1730 @@
+{
+  "id": "0a10c0de-0010-4010-8010-000000000010",
+  "prevId": "6928b84e-36c9-4daf-a7e2-059ec1cd35a0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.brand_opportunities": {
+      "name": "brand_opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report": {
+          "name": "report",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brand_opportunities_brand_id_created_at_idx": {
+          "name": "brand_opportunities_brand_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_opportunities_brand_id_brands_id_fk": {
+          "name": "brand_opportunities_brand_id_brands_id_fk",
+          "tableFrom": "brand_opportunities",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.brands": {
+      "name": "brands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additional_domains": {
+          "name": "additional_domains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "onboarded": {
+          "name": "onboarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "delay_override_hours": {
+          "name": "delay_override_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled_models": {
+          "name": "enabled_models",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brands_organization_id_idx": {
+          "name": "brands_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brands_organization_id_organization_id_fk": {
+          "name": "brands_organization_id_organization_id_fk",
+          "tableFrom": "brands",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.citations": {
+      "name": "citations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "prompt_run_id": {
+          "name": "prompt_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citation_index": {
+          "name": "citation_index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_citations_brand_analytics": {
+          "name": "idx_citations_brand_analytics",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "citations_prompt_id_created_at_idx": {
+          "name": "citations_prompt_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "prompt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "citations_domain_idx": {
+          "name": "citations_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "citations_prompt_run_id_prompt_runs_id_fk": {
+          "name": "citations_prompt_run_id_prompt_runs_id_fk",
+          "tableFrom": "citations",
+          "tableTo": "prompt_runs",
+          "columnsFrom": [
+            "prompt_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "citations_prompt_id_prompts_id_fk": {
+          "name": "citations_prompt_id_prompts_id_fk",
+          "tableFrom": "citations",
+          "tableTo": "prompts",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "citations_brand_id_brands_id_fk": {
+          "name": "citations_brand_id_brands_id_fk",
+          "tableFrom": "citations",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.competitors": {
+      "name": "competitors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domains": {
+          "name": "domains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "competitors_brand_id_brands_id_fk": {
+          "name": "competitors_brand_id_brands_id_fk",
+          "tableFrom": "competitors",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.prompt_runs": {
+      "name": "prompt_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "web_search_enabled": {
+          "name": "web_search_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_output": {
+          "name": "raw_output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "web_queries": {
+          "name": "web_queries",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "brand_mentioned": {
+          "name": "brand_mentioned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competitors_mentioned": {
+          "name": "competitors_mentioned",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "prompt_runs_prompt_id_created_at_idx": {
+          "name": "prompt_runs_prompt_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "prompt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_runs_created_at_idx": {
+          "name": "prompt_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_runs_web_search_created_at_idx": {
+          "name": "prompt_runs_web_search_created_at_idx",
+          "columns": [
+            {
+              "expression": "web_search_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_runs_web_search_model_created_at_idx": {
+          "name": "prompt_runs_web_search_model_created_at_idx",
+          "columns": [
+            {
+              "expression": "web_search_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_runs_provider_idx": {
+          "name": "prompt_runs_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_runs_model_created_at_idx": {
+          "name": "prompt_runs_model_created_at_idx",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prompt_runs_prompt_id_prompts_id_fk": {
+          "name": "prompt_runs_prompt_id_prompts_id_fk",
+          "tableFrom": "prompt_runs",
+          "tableTo": "prompts",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_runs_brand_id_brands_id_fk": {
+          "name": "prompt_runs_brand_id_brands_id_fk",
+          "tableFrom": "prompt_runs",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.prompts": {
+      "name": "prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "system_tags": {
+          "name": "system_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "prompts_brand_id_idx": {
+          "name": "prompts_brand_id_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompts_brand_id_enabled_idx": {
+          "name": "prompts_brand_id_enabled_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prompts_brand_id_brands_id_fk": {
+          "name": "prompts_brand_id_brands_id_fk",
+          "tableFrom": "prompts",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brand_name": {
+          "name": "brand_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_website": {
+          "name": "brand_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "raw_output": {
+          "name": "raw_output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reports_created_at_idx": {
+          "name": "reports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_report_generator_access": {
+          "name": "has_report_generator_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.report_status": {
+      "name": "report_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/lib/src/db/migrations/meta/_journal.json
+++ b/packages/lib/src/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1780782746840,
       "tag": "0009_brand_opportunities",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1784000000000,
+      "tag": "0010_scope_brands_to_orgs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/lib/src/db/provisioning.ts
+++ b/packages/lib/src/db/provisioning.ts
@@ -113,6 +113,43 @@ async function findUniqueOrgId(baseSlug: string): Promise<string> {
 }
 
 /**
+ * Ensure an organization row exists for a brand created outside the normal
+ * signup / Auth0 flows — specifically the admin API (`POST /api/v1/brands`),
+ * which accepts a caller-supplied brand id and no longer has a session/org to
+ * lean on. Brands are hard-scoped to an org via a NOT NULL FK, so the org must
+ * exist before the brand is inserted.
+ *
+ * No-op when the org already exists: we never overwrite an org that was synced
+ * from Auth0 (whitelabel) or created on signup. The brand id is reused as the
+ * org id (the long-standing convention), with a collision-free slug.
+ */
+export async function ensureOrganization(input: { id: string; name: string }): Promise<void> {
+	const [existing] = await db
+		.select({ id: organization.id })
+		.from(organization)
+		.where(eq(organization.id, input.id))
+		.limit(1);
+	if (existing) return;
+
+	const baseSlug = slugifyOrgName(input.name);
+	let slug = baseSlug;
+	for (let suffix = 2; ; suffix++) {
+		const [conflict] = await db
+			.select({ id: organization.id })
+			.from(organization)
+			.where(eq(organization.slug, slug))
+			.limit(1);
+		if (!conflict) break;
+		slug = `${baseSlug}-${suffix}`;
+	}
+
+	await db
+		.insert(organization)
+		.values({ id: input.id, name: input.name, slug, createdAt: new Date() })
+		.onConflictDoNothing();
+}
+
+/**
  * Provision an additional organization for an existing local-mode user — used
  * by the multi-brand "create new brand" flow. The id is a slug derived from
  * `name`, with a numeric suffix on collision, and is reused as the org slug

--- a/packages/lib/src/db/provisioning.ts
+++ b/packages/lib/src/db/provisioning.ts
@@ -143,10 +143,15 @@ export async function ensureOrganization(input: { id: string; name: string }): P
 		slug = `${baseSlug}-${suffix}`;
 	}
 
+	// Target the id explicitly: the early-return above already handles "org
+	// exists", so this only guards a concurrent insert of the same id (no-op).
+	// An untargeted onConflictDoNothing would also swallow a slug-unique
+	// collision, silently skip the insert, and leave the caller's brand FK to
+	// fail with a confusing error instead.
 	await db
 		.insert(organization)
 		.values({ id: input.id, name: input.name, slug, createdAt: new Date() })
-		.onConflictDoNothing();
+		.onConflictDoNothing({ target: organization.id });
 }
 
 /**

--- a/packages/lib/src/db/schema.ts
+++ b/packages/lib/src/db/schema.ts
@@ -1,4 +1,7 @@
 import { pgEnum, pgTable, uuid, text, timestamp, boolean, json, index, integer, smallint } from "drizzle-orm/pg-core";
+// `organization` is referenced by the brands FK below; the re-export makes it
+// (and the rest of the auth schema) visible to `import * as schema` consumers.
+import { organization } from "./schema-auth";
 
 // Better-auth tables & relations — re-exported so `import * as schema` sees everything.
 // Source file is auto-generated; run `pnpm run generate:auth-schema` to refresh.
@@ -10,22 +13,36 @@ export * from "./schema-auth";
 
 export const reportStatusEnum = pgEnum("report_status", ["pending", "processing", "completed", "failed"]);
 
-export const brands = pgTable("brands", {
-	id: text("id").primaryKey().notNull(),
-	name: text("name").notNull(),
-	website: text("website").notNull(),
-	additionalDomains: text("additional_domains").array().notNull().default([]),
-	aliases: text("aliases").array().notNull().default([]),
-	enabled: boolean("enabled").default(true).notNull(),
-	onboarded: boolean("onboarded").default(false).notNull(),
-	delayOverrideHours: integer("delay_override_hours"),
-	enabledModels: text("enabled_models").array(),
-	createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
-	updatedAt: timestamp("updated_at", { withTimezone: true })
-		.defaultNow()
-		.$onUpdate(() => new Date())
-		.notNull(),
-}).enableRLS();
+export const brands = pgTable(
+	"brands",
+	{
+		id: text("id").primaryKey().notNull(),
+		name: text("name").notNull(),
+		website: text("website").notNull(),
+		additionalDomains: text("additional_domains").array().notNull().default([]),
+		aliases: text("aliases").array().notNull().default([]),
+		enabled: boolean("enabled").default(true).notNull(),
+		onboarded: boolean("onboarded").default(false).notNull(),
+		delayOverrideHours: integer("delay_override_hours"),
+		enabledModels: text("enabled_models").array(),
+		// Hard tenancy scope. Every brand belongs to exactly one better-auth
+		// organization; org membership (the `member` table) is the access-control
+		// mechanism — see apps/web/src/lib/auth/helpers.ts. Historically `brand.id`
+		// equalled `organization.id`; the 0010 backfill makes that mapping explicit
+		// so cloud entitlements/metering/enforcement can join on it.
+		organizationId: text("organization_id")
+			.references(() => organization.id)
+			.notNull(),
+		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+		updatedAt: timestamp("updated_at", { withTimezone: true })
+			.defaultNow()
+			.$onUpdate(() => new Date())
+			.notNull(),
+	},
+	(table) => ({
+		organizationIdIdx: index("brands_organization_id_idx").on(table.organizationId),
+	}),
+).enableRLS();
 
 export const prompts = pgTable(
 	"prompts",


### PR DESCRIPTION
Fixes #339.

## What

Adds `brands.organization_id` as a hard FK to the better-auth `organization` table, making the previously-**implicit** brand→org relationship explicit. This is the prerequisite for cloud entitlements, metering, and enforcement.

### Background: the implicit mapping today
Today there is no `organization_id`. Access is implicit through a `brand.id === organization.id` convention: the `/app/$brand` URL param *is* the org id, and `requireOrgAccess(userId, brandId)` checks membership in the org whose id equals the brand id. A user in org A already cannot reach org B's brand — this PR makes that boundary an explicit, joinable column instead of an id coincidence.

## Changes
- **Schema** (`packages/lib/src/db/schema.ts`): `brands.organization_id text NOT NULL` → `organization.id`, plus an index. `.enableRLS()` is unchanged; **no `CREATE POLICY` rules added** — isolation stays in the app layer, per the issue.
- **Migration** (`0010_scope_brands_to_orgs.sql`): add the column nullable → straight **1:1 backfill** `organization_id = id` → enforce `NOT NULL` + FK + index. Every existing brand already has a matching org row, so the FK holds directly.
- **Brand-create paths** populate `organization_id` (`createBrandFn`, `createBrandWithOrgFn`, and the admin-API `createBrand`, which `ensureOrganization` first so the runtime FK is always satisfiable even if a whitelabel brand is created before its Auth0 org syncs).
- **`getBrands`** now scopes by `organization_id IN (member orgs)` — org membership is the access-control mechanism.
- **`evaluateOrgScope`** pure policy + tests asserting org A cannot read/mutate org B's resources.
- **e2e seed** creates the org row and sets `organization_id`.

## Key design decision (please note)
The issue suggested "assign existing brands to a *default* organization." I deliberately did **not** collapse everything into one shared org, because that would hide brands from their members in **multi-org whitelabel** and **multi-brand local** deployments — a regression. Instead each brand keeps its own existing org (`organization_id = brand.id`), preserving identical behavior across all four modes.

## Compatibility — no regressions
- **local / demo**: every brand already has a matching org (`default`, or slug orgs from the multi-brand flow) → 1:1 backfill maps each to its own org; identical behavior.
- **whitelabel**: Auth0-synced orgs are preserved 1:1; access controls are unchanged — `checkOrgAccess`/`requireOrgAccess` and the Auth0→`member` sync are untouched, and `getBrands` returns the same set because `organization_id == brand.id`. New org rows (`ensureOrganization`) never grant membership, so they don't change who can access what.
- **worker**: untouched — it processes all brands by `brandId` with no session/org context, and inherits org scoping transitively through `brandId`.

## Verification
- `check-types`: web / worker / cli / www / lib ✅
- unit tests: `@workspace/lib` 181 ✅, `@workspace/web` 183 ✅ (incl. new org-isolation tests)
- biome: changed files clean (no new findings)
- No changeset: behavior is identical for end users (internal tenancy/data-model change).

## ⚠️ Migration must be run manually
I did **not** run any migration or modify the database. After merge, run `drizzle-kit migrate` (the `db-migrate` init container) against each environment. The migration is online-safe (`lock_timeout`/`statement_timeout` guards).