### PR TITLE
fix(worker): exclude absence responses from brand/competitor mentions (#5)

### DIFF
--- a/.changeset/absence-mentions.md
+++ b/.changeset/absence-mentions.md
@@ -1,0 +1,6 @@
+---
+"@workspace/worker": patch
+"@workspace/lib": patch
+---
+
+Brand and competitor visibility no longer counts "couldn't find / no information about <name>" style responses as mentions, so absence answers stop inflating share-of-voice.

--- a/apps/worker/src/jobs/process-prompt.ts
+++ b/apps/worker/src/jobs/process-prompt.ts
@@ -11,6 +11,7 @@ import {
 	type Provider,
 } from "@workspace/lib/providers";
 import type { Citation } from "@workspace/lib/text-extraction";
+import { nameMentioned } from "@workspace/lib/mention-detection";
 import boss from "../boss";
 import { trackWorkerEvent } from "../telemetry";
 
@@ -121,19 +122,23 @@ function analyzeMentions(
 } {
 	const contentLower = content.toLowerCase();
 
-	const brandNames = [brand.name, ...(brand.aliases || [])].map((n) => n.toLowerCase());
+	// Name matches use absence-aware detection so responses like "I couldn't find
+	// any information about <brand>" don't count as a mention (issue #5). Domain
+	// matches keep plain substring semantics — a bare domain almost never appears
+	// inside an "I have no info on …" sentence, and it's a strong positive signal.
+	const brandNames = [brand.name, ...(brand.aliases || [])];
 	const brandDomains = [
 		extractDomainFromUrl(brand.website),
 		...(brand.additionalDomains || []).map(extractDomainFromUrl),
 	];
 	const brandMentioned =
-		brandNames.some((n) => contentLower.includes(n)) ||
+		brandNames.some((n) => nameMentioned(content, n)) ||
 		brandDomains.some((d) => contentLower.includes(d));
 
 	const competitorsMentioned = competitorsList
 		.filter((competitor) => {
-			const names = [competitor.name, ...(competitor.aliases || [])].map((n) => n.toLowerCase());
-			const nameMatch = names.some((n) => contentLower.includes(n));
+			const names = [competitor.name, ...(competitor.aliases || [])];
+			const nameMatch = names.some((n) => nameMentioned(content, n));
 			const domainMatch = (competitor.domains || []).some((d) =>
 				contentLower.includes(extractDomainFromUrl(d)),
 			);

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -18,6 +18,7 @@
     "./auth/permissions": "./src/auth/permissions.ts",
     "./constants": "./src/constants.ts",
     "./text-extraction": "./src/text-extraction.ts",
+    "./mention-detection": "./src/mention-detection.ts",
     "./dataforseo": "./src/dataforseo.ts",
     "./onboarding": "./src/onboarding/index.ts",
     "./tag-utils": "./src/tag-utils.ts",

--- a/packages/lib/src/mention-detection.test.ts
+++ b/packages/lib/src/mention-detection.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { nameMentioned, isAbsenceClause, splitClauses } from "./mention-detection";
+
+describe("nameMentioned", () => {
+	it("counts a plain positive mention", () => {
+		expect(nameMentioned("Acme is a leading provider of widgets.", "Acme")).toBe(true);
+	});
+
+	it("is case-insensitive", () => {
+		expect(nameMentioned("acme makes great tools.", "Acme")).toBe(true);
+		expect(nameMentioned("ACME is well known.", "acme")).toBe(true);
+	});
+
+	it("returns false when the name never appears", () => {
+		expect(nameMentioned("Some other company entirely.", "Acme")).toBe(false);
+	});
+
+	it("does NOT count 'I couldn't find any information about <brand>'", () => {
+		expect(nameMentioned("I couldn't find any information about Acme.", "Acme")).toBe(false);
+		expect(nameMentioned("I could not locate Acme in my data.", "Acme")).toBe(false);
+		expect(nameMentioned("There is no information about Acme.", "Acme")).toBe(false);
+		expect(nameMentioned("I don't have any information about Acme.", "Acme")).toBe(false);
+		expect(nameMentioned("I'm not familiar with Acme.", "Acme")).toBe(false);
+		expect(nameMentioned("I've never heard of Acme.", "Acme")).toBe(false);
+	});
+
+	it("still counts a real mention that shares a sentence with an absence clause", () => {
+		expect(
+			nameMentioned("I couldn't find pricing, but Acme is widely used.", "Acme"),
+		).toBe(true);
+	});
+
+	it("counts the brand when one clause is absence and another is a real mention", () => {
+		const content = "I don't have specific information about pricing. That said, Acme is known for reliability.";
+		expect(nameMentioned(content, "Acme")).toBe(true);
+	});
+
+	it("treats a name appearing only inside absence statements as not mentioned", () => {
+		const content = "I couldn't find Acme. I also have no information about Acme's products.";
+		expect(nameMentioned(content, "Acme")).toBe(false);
+	});
+
+	it("does not suppress ordinary prose containing 'no' words", () => {
+		expect(nameMentioned("There's no doubt Acme is the best choice.", "Acme")).toBe(true);
+		expect(nameMentioned("Acme? I don't think there's a better option.", "Acme")).toBe(true);
+	});
+
+	it("handles multi-word names", () => {
+		expect(nameMentioned("Open AI Labs builds models.", "Open AI Labs")).toBe(true);
+		expect(nameMentioned("I couldn't find information about Open AI Labs.", "Open AI Labs")).toBe(false);
+	});
+
+	it("returns false for an empty name", () => {
+		expect(nameMentioned("Acme is great.", "")).toBe(false);
+		expect(nameMentioned("Acme is great.", "   ")).toBe(false);
+	});
+});
+
+describe("isAbsenceClause", () => {
+	it("flags absence phrasing", () => {
+		expect(isAbsenceClause("i couldn't find anything")).toBe(true);
+		expect(isAbsenceClause("no information about it")).toBe(true);
+	});
+
+	it("does not flag normal prose", () => {
+		expect(isAbsenceClause("acme is a great product")).toBe(false);
+	});
+});
+
+describe("splitClauses", () => {
+	it("splits on sentence boundaries and contrastive conjunctions", () => {
+		expect(splitClauses("A. B")).toEqual(["A.", "B"]);
+		expect(splitClauses("no pricing, but Acme rocks")).toEqual(["no pricing", "Acme rocks"]);
+	});
+});

--- a/packages/lib/src/mention-detection.ts
+++ b/packages/lib/src/mention-detection.ts
@@ -1,0 +1,81 @@
+// Detecting whether a brand or competitor is *genuinely* mentioned in a model
+// response — as opposed to merely named inside an "I couldn't find anything
+// about <brand>" style absence statement.
+//
+// Naive substring matching counts "I have no information about Acme" as a brand
+// mention, which inflates visibility/share-of-voice with non-mentions. We treat
+// a name as mentioned only when it appears in at least one clause that is not an
+// explicit absence statement. See issue #5.
+
+// Phrases that signal the model is reporting a *lack* of knowledge about the
+// thing named alongside them. Kept specific (multi-word) so ordinary prose like
+// "no doubt the best" or "I don't think so" doesn't suppress a real mention.
+export const ABSENCE_PHRASES: readonly string[] = [
+	"couldn't find",
+	"could not find",
+	"couldn't locate",
+	"could not locate",
+	"couldn't identify",
+	"could not identify",
+	"didn't find",
+	"did not find",
+	"unable to find",
+	"unable to locate",
+	"unable to identify",
+	"no information about",
+	"no information on",
+	"no information regarding",
+	"no specific information about",
+	"no specific information on",
+	"don't have information",
+	"do not have information",
+	"don't have any information",
+	"do not have any information",
+	"don't have specific information",
+	"do not have specific information",
+	"not aware of",
+	"not familiar with",
+	"never heard of",
+	"no data on",
+	"no data about",
+	"no results for",
+	"no details about",
+	"no details on",
+	"no record of",
+	"no mention of",
+];
+
+// Split a response into clauses. We break on sentence terminators and newlines,
+// and additionally on contrastive conjunctions ("…, but X is great") so that a
+// real mention riding alongside an absence statement in the same sentence
+// ("I couldn't find pricing, but Acme is excellent") is still counted.
+const CLAUSE_SPLIT = /(?<=[.!?])\s+|\n+|;\s*|,?\s+(?:but|however|although|though|whereas|yet)\s+/i;
+
+export function splitClauses(content: string): string[] {
+	return content.split(CLAUSE_SPLIT);
+}
+
+export function isAbsenceClause(clauseLower: string): boolean {
+	return ABSENCE_PHRASES.some((phrase) => clauseLower.includes(phrase));
+}
+
+/**
+ * True if `name` appears in `content` in at least one clause that is not an
+ * explicit absence statement. Returns false when the name never appears, or
+ * appears only inside "couldn't find / no information about" style clauses.
+ *
+ * Case-insensitive; uses substring matching (matching existing behavior) so the
+ * only change versus a naive `includes` is the absence filtering.
+ */
+export function nameMentioned(content: string, name: string): boolean {
+	const nameLower = name.trim().toLowerCase();
+	if (!nameLower) return false;
+
+	for (const clause of splitClauses(content)) {
+		const clauseLower = clause.toLowerCase();
+		if (clauseLower.includes(nameLower) && !isAbsenceClause(clauseLower)) {
+			return true;
+		}
+	}
+	return false;
+}


### PR DESCRIPTION
## Summary
Naive substring matching counted "I couldn't find any information about <brand>" as a brand mention, inflating visibility and share-of-voice.

## Changes
- New `packages/lib/src/mention-detection.ts`: `nameMentioned()` only counts a name when it appears in a clause that isn't an explicit "couldn't find / no information about" absence statement (clause-level so a real mention sharing a sentence with an absence clause still counts).
- Wired into the worker's `analyzeMentions` for brand and competitor names (domain matches keep plain substring semantics).

## Testing
- 13 unit tests in `mention-detection.test.ts`; worker `tsc --noEmit` passes.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
