### PR TITLE
feat(lib,worker): detect text-extraction failures (#106)

### DIFF
--- a/.changeset/text-extraction-failure-detection.md
+++ b/.changeset/text-extraction-failure-detection.md
@@ -1,0 +1,6 @@
+---
+"@workspace/worker": patch
+"@workspace/lib": patch
+---
+
+Text-extraction failures are now detected instead of silently stored: when a provider response can't be parsed into text (e.g. after an upstream schema change), the worker logs an error and emits a telemetry event rather than recording an empty run.

--- a/apps/worker/src/jobs/process-prompt.ts
+++ b/apps/worker/src/jobs/process-prompt.ts
@@ -10,7 +10,7 @@ import {
 	type ModelConfig,
 	type Provider,
 } from "@workspace/lib/providers";
-import type { Citation } from "@workspace/lib/text-extraction";
+import { isExtractionFailure, type Citation } from "@workspace/lib/text-extraction";
 import boss from "../boss";
 import { trackWorkerEvent } from "../telemetry";
 
@@ -234,6 +234,21 @@ async function runModelIteration({
 	console.log(`${logPrefix} AI call completed, textContent length: ${textContent?.length ?? "null"}`);
 
 	const safeTextContent = typeof textContent === "string" ? textContent : "";
+
+	// Surface text-extraction failures loudly (issue #106). When a provider's
+	// response schema drifts, extraction silently returns a placeholder/empty
+	// string and the run is stored looking "successful" but empty. Call it out in
+	// logs and telemetry so the regression is noticed instead of corrupting data.
+	if (isExtractionFailure(safeTextContent)) {
+		console.error(
+			`${logPrefix} Text extraction returned no usable content (provider=${config.provider ?? "unknown"}, model=${config.model}); the provider response schema may have changed.`,
+		);
+		trackWorkerEvent("text_extraction_failed", {
+			brand_id: brand.id,
+			model: config.model,
+			provider: config.provider ?? "unknown",
+		});
+	}
 
 	const { brandMentioned, competitorsMentioned } = analyzeMentions(safeTextContent, brand, competitorsList);
 

--- a/packages/lib/src/text-extraction.test.ts
+++ b/packages/lib/src/text-extraction.test.ts
@@ -7,6 +7,8 @@ import {
 	extractCitationsFromOpenAI,
 	extractCitationsFromGoogle,
 	extractCitations,
+	isExtractionFailure,
+	EXTRACTION_FALLBACK_MESSAGES,
 } from "./text-extraction";
 
 describe("text-extraction", () => {
@@ -409,5 +411,33 @@ describe("text-extraction", () => {
 		it("should return empty array for unknown model group", () => {
 			expect(extractCitations({}, "unknown")).toEqual([]);
 		});
+	});
+});
+
+describe("isExtractionFailure", () => {
+	it.each<[string, string | null | undefined]>([
+		["null", null],
+		["undefined", undefined],
+		["empty string", ""],
+		["whitespace only", "   \n\t"],
+	])("treats %s as a failure", (_label, input) => {
+		expect(isExtractionFailure(input)).toBe(true);
+	});
+
+	it.each(EXTRACTION_FALLBACK_MESSAGES.map((m) => [m] as [string]))(
+		"treats placeholder %j as a failure",
+		(message) => {
+			expect(isExtractionFailure(message)).toBe(true);
+			// Surrounding whitespace shouldn't hide a placeholder.
+			expect(isExtractionFailure(`  ${message}  `)).toBe(true);
+		},
+	);
+
+	it.each<[string]>([
+		["Acme is a leading provider of widgets."],
+		["No content here, but the answer continues with real text."],
+		["The answer is: there is no single best option."],
+	])("treats real content %j as a success", (content) => {
+		expect(isExtractionFailure(content)).toBe(false);
 	});
 });

--- a/packages/lib/src/text-extraction.ts
+++ b/packages/lib/src/text-extraction.ts
@@ -179,6 +179,43 @@ function tryGenericExtraction(rawOutput: any): string {
 }
 
 // ============================================================================
+// Extraction failure detection
+// ============================================================================
+
+// The placeholder strings the extractors above return when they can't find any
+// text. They're indistinguishable from a real (if empty) answer downstream, so
+// when a provider's response schema drifts the extraction silently "succeeds"
+// with a placeholder and the failure goes unnoticed (issue #106). Callers can
+// use `isExtractionFailure` to detect that case and surface it loudly.
+export const EXTRACTION_FALLBACK_MESSAGES: readonly string[] = [
+	"No text content found in OpenAI output.",
+	"No text content found in Anthropic output.",
+	"No AI overview content found.",
+	"No text content found in Mistral output.",
+	"No text content found in OpenRouter output.",
+	"No text content found in Olostep output.",
+	"No content in BrightData output.",
+	"No text content found in BrightData output.",
+	"Error extracting text content.",
+	"No content.",
+	"Unknown provider format - cannot extract text content.",
+];
+
+const EXTRACTION_FALLBACK_SET = new Set(EXTRACTION_FALLBACK_MESSAGES);
+
+/**
+ * True when `text` is empty/whitespace or one of the known extractor placeholder
+ * messages — i.e. extraction produced nothing usable. Used to turn silent
+ * schema drift into a visible, logged failure rather than empty stored data.
+ */
+export function isExtractionFailure(text: string | null | undefined): boolean {
+	if (text == null) return true;
+	const trimmed = text.trim();
+	if (trimmed === "") return true;
+	return EXTRACTION_FALLBACK_SET.has(trimmed);
+}
+
+// ============================================================================
 // Citation extraction by provider
 // ============================================================================
 


### PR DESCRIPTION
## Summary
If a provider's response schema drifts, the per-provider extractors return a placeholder ("No text content found …") or empty string, and the run is stored as a silent, empty "success". This makes that failure visible.

## Changes
- New `isExtractionFailure()` in `packages/lib/src/text-extraction.ts` (matches the known placeholder messages plus empty/whitespace).
- Worker logs an error and emits a `text_extraction_failed` telemetry event when extraction yields nothing usable. Non-breaking — the run is still saved.

## Testing
- New `it.each` tests in `text-extraction.test.ts` (45 pass total); worker `tsc --noEmit` passes.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
