### PR TITLE
feat(web): categorize more well-known citation domains (#115)

### DIFF
--- a/.changeset/domain-categorization-additions.md
+++ b/.changeset/domain-categorization-additions.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Citation domain categorization now recognizes more well-known sites: online IDE / coding-practice platforms (CodePen, CodeSandbox, Replit, StackBlitz, JSFiddle, LeetCode, HackerRank, Codewars) as "developer" and additional networks (OK.ru, XING, SoundCloud) as "social", instead of bucketing them as "other".

--- a/apps/web/src/lib/__tests__/domain-categories.test.ts
+++ b/apps/web/src/lib/__tests__/domain-categories.test.ts
@@ -91,6 +91,24 @@ describe("categorizeDomain priority", () => {
 		expect(cat("bhphotovideo.com")).toBe("ecommerce");
 	});
 
+	it.each<[string, string]>([
+		// Online IDEs / playgrounds + coding-practice platforms (were "other")
+		["codepen.io", "developer"],
+		["codesandbox.io", "developer"],
+		["replit.com", "developer"],
+		["stackblitz.com", "developer"],
+		["jsfiddle.net", "developer"],
+		["leetcode.com", "developer"],
+		["hackerrank.com", "developer"],
+		["codewars.com", "developer"],
+		// Additional social / creator networks (were "other")
+		["ok.ru", "social"],
+		["xing.com", "social"],
+		["soundcloud.com", "social"],
+	])("categorizes newly-added %s as %s", (domain, expected) => {
+		expect(cat(domain)).toBe(expected);
+	});
+
 	it("brand and competitor always win over list categories", () => {
 		const b = new Set(["amazon.com"]); // hypothetically the brand's own domain
 		const c = new Set(["github.com", "g2.com"]); // hypothetically tracked competitors

--- a/apps/web/src/lib/domain-categories.server.ts
+++ b/apps/web/src/lib/domain-categories.server.ts
@@ -17,6 +17,8 @@ const SOCIAL_MEDIA_DOMAINS = new Set([
 	"meetup.com", "rumble.com", "kick.com", "bilibili.com", "imgur.com",
 	// General Q&A (developer Q&A lives under "developer")
 	"quora.com",
+	// More networks / creator platforms
+	"ok.ru", "xing.com", "soundcloud.com",
 ]);
 
 // Code hosting, package registries, developer Q&A, docs, and model hubs.
@@ -38,6 +40,9 @@ const DEVELOPER_DOMAINS = new Set([
 	// More code hosts + package registries (Wikipedia: source-code hosting facilities)
 	"gitee.com", "launchpad.net", "savannah.gnu.org", "dev.azure.com",
 	"anaconda.org", "metacpan.org", "rosettacode.org",
+	// Online IDEs / playgrounds + coding-practice platforms
+	"codepen.io", "codesandbox.io", "replit.com", "stackblitz.com", "jsfiddle.net",
+	"leetcode.com", "hackerrank.com", "codewars.com",
 ]);
 
 // Press-release distribution wires — small, finite, unambiguous.


### PR DESCRIPTION
## Summary
Several widely-cited sites fell through to the "other" citation category.

## Changes
- Adds coding-platform domains (codepen, codesandbox, replit, stackblitz, jsfiddle, leetcode, hackerrank, codewars) to the `developer` list and OK.ru / XING / SoundCloud to `social`.
- Data-driven tests; the existing mutual-exclusivity test guards against cross-list collisions.

## Testing
- 34 tests in `domain-categories.test.ts` pass (incl. the exclusivity guard).

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
