### PR TITLE
test(web): extract and cover brand-settings normalization (#107)

### DIFF
--- a/apps/web/src/lib/__tests__/brand-settings.test.ts
+++ b/apps/web/src/lib/__tests__/brand-settings.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { normalizeBrandUpdate } from "@/lib/brand-settings";
+
+describe("normalizeBrandUpdate", () => {
+	it("returns an empty update set when no fields are provided", () => {
+		const result = normalizeBrandUpdate({});
+		expect(result).toEqual({ ok: true, updates: {} });
+	});
+
+	it("only touches fields that are present (partial edit)", () => {
+		const result = normalizeBrandUpdate({ name: "Acme" });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.updates).toEqual({ name: "Acme" });
+			expect(result.updates).not.toHaveProperty("website");
+			expect(result.updates).not.toHaveProperty("aliases");
+		}
+	});
+
+	describe("name", () => {
+		it("trims surrounding whitespace", () => {
+			const result = normalizeBrandUpdate({ name: "  Acme  " });
+			expect(result).toEqual({ ok: true, updates: { name: "Acme" } });
+		});
+
+		it.each([["empty string", ""], ["whitespace only", "   "]])(
+			"rejects a %s name",
+			(_label, name) => {
+				expect(normalizeBrandUpdate({ name })).toEqual({
+					ok: false,
+					error: "Brand name must be a non-empty string",
+				});
+			},
+		);
+	});
+
+	describe("website", () => {
+		it("normalizes a bare domain to an origin URL", () => {
+			const result = normalizeBrandUpdate({ website: "acme.com/products" });
+			expect(result).toEqual({ ok: true, updates: { website: "https://acme.com/" } });
+		});
+
+		it("rejects an invalid website", () => {
+			const result = normalizeBrandUpdate({ website: "not a url" });
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.error).toMatch(/valid/i);
+		});
+	});
+
+	describe("additionalDomains", () => {
+		it("cleans and de-duplicates valid domains", () => {
+			const result = normalizeBrandUpdate({
+				additionalDomains: ["https://www.acme.com/path", "acme.com", "blog.acme.io"],
+			});
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.updates.additionalDomains).toEqual(["acme.com", "blog.acme.io"]);
+			}
+		});
+
+		it("reports every invalid domain in the input", () => {
+			const result = normalizeBrandUpdate({
+				additionalDomains: ["acme.com", "not a domain", "also bad"],
+			});
+			expect(result).toEqual({
+				ok: false,
+				error: "Invalid domain(s): not a domain, also bad",
+			});
+		});
+
+		it("accepts an empty list", () => {
+			const result = normalizeBrandUpdate({ additionalDomains: [] });
+			expect(result).toEqual({ ok: true, updates: { additionalDomains: [] } });
+		});
+	});
+
+	describe("aliases", () => {
+		it("trims, drops empties, and de-duplicates", () => {
+			const result = normalizeBrandUpdate({ aliases: ["Acme", "  Acme Inc ", "", "  ", "Acme"] });
+			expect(result.ok).toBe(true);
+			if (result.ok) expect(result.updates.aliases).toEqual(["Acme", "Acme Inc"]);
+		});
+	});
+
+	it("validates all provided fields together", () => {
+		const result = normalizeBrandUpdate({
+			name: " Acme ",
+			website: "acme.com",
+			additionalDomains: ["acme.io", "acme.io"],
+			aliases: [" Acme ", "Acme"],
+		});
+		expect(result).toEqual({
+			ok: true,
+			updates: {
+				name: "Acme",
+				website: "https://acme.com/",
+				additionalDomains: ["acme.io"],
+				aliases: ["Acme"],
+			},
+		});
+	});
+});

--- a/apps/web/src/lib/brand-settings.ts
+++ b/apps/web/src/lib/brand-settings.ts
@@ -1,0 +1,69 @@
+import { validateWebsiteUrl } from "@/lib/brand-website";
+import { cleanAndValidateDomain } from "@/lib/domain-categories";
+
+/**
+ * Pure normalization/validation for the "edit brand settings" flow, extracted
+ * from the updateBrand server function so the rules can be unit-tested without a
+ * database or auth session (issue #107). The server function applies auth and
+ * persistence; this owns the field-level rules:
+ *
+ *  - name: trimmed; must be non-empty when provided
+ *  - website: validated + normalized to an origin URL
+ *  - additionalDomains: each cleaned/validated (hard error listing the invalid
+ *    ones), then de-duplicated
+ *  - aliases: trimmed, empties dropped, de-duplicated
+ *
+ * Only keys present on the input are touched, so a partial edit leaves the rest
+ * of the brand untouched.
+ */
+export interface BrandUpdateInput {
+	name?: string;
+	website?: string;
+	additionalDomains?: string[];
+	aliases?: string[];
+}
+
+export interface BrandUpdateFields {
+	name?: string;
+	website?: string;
+	additionalDomains?: string[];
+	aliases?: string[];
+}
+
+export type NormalizeBrandUpdateResult =
+	| { ok: true; updates: BrandUpdateFields }
+	| { ok: false; error: string };
+
+export function normalizeBrandUpdate(input: BrandUpdateInput): NormalizeBrandUpdateResult {
+	const updates: BrandUpdateFields = {};
+
+	if (input.name !== undefined) {
+		if (!input.name.trim()) {
+			return { ok: false, error: "Brand name must be a non-empty string" };
+		}
+		updates.name = input.name.trim();
+	}
+
+	if (input.website !== undefined) {
+		const urlValidation = validateWebsiteUrl(input.website);
+		if (!urlValidation.isValid) {
+			return { ok: false, error: urlValidation.error };
+		}
+		updates.website = urlValidation.formattedUrl;
+	}
+
+	if (input.additionalDomains !== undefined) {
+		const cleaned = input.additionalDomains.map((d) => cleanAndValidateDomain(d));
+		const invalid = input.additionalDomains.filter((_, i) => !cleaned[i]);
+		if (invalid.length > 0) {
+			return { ok: false, error: `Invalid domain(s): ${invalid.join(", ")}` };
+		}
+		updates.additionalDomains = [...new Set(cleaned.filter(Boolean) as string[])];
+	}
+
+	if (input.aliases !== undefined) {
+		updates.aliases = [...new Set(input.aliases.map((a) => a.trim()).filter(Boolean))];
+	}
+
+	return { ok: true, updates };
+}

--- a/apps/web/src/server/brands.ts
+++ b/apps/web/src/server/brands.ts
@@ -14,6 +14,7 @@ import { eq, and, count, sql } from "drizzle-orm";
 import { MAX_COMPETITORS } from "@workspace/lib/constants";
 import { cleanAndValidateDomain } from "@/lib/domain-categories";
 import { validateWebsiteUrl } from "@/lib/brand-website";
+import { normalizeBrandUpdate } from "@/lib/brand-settings";
 import { parseScrapeTargets, selectTargetsForBrand } from "@workspace/lib/providers";
 import type { ModelConfig } from "@workspace/lib/providers";
 
@@ -251,35 +252,16 @@ export const updateBrandFn = createServerFn({ method: "POST" })
 		const session = await requireAuthSession();
 		await requireOrgAccess(session.user.id, data.brandId);
 
-		const updateData: Partial<Pick<Brand, "name" | "website" | "additionalDomains" | "aliases">> = {};
-
-		if (data.name !== undefined) {
-			if (!data.name.trim()) {
-				throw new Error("Brand name must be a non-empty string");
-			}
-			updateData.name = data.name.trim();
+		const normalized = normalizeBrandUpdate({
+			name: data.name,
+			website: data.website,
+			additionalDomains: data.additionalDomains,
+			aliases: data.aliases,
+		});
+		if (!normalized.ok) {
+			throw new Error(normalized.error);
 		}
-
-		if (data.website !== undefined) {
-			const urlValidation = validateWebsiteUrl(data.website);
-			if (!urlValidation.isValid) {
-				throw new Error(urlValidation.error);
-			}
-			updateData.website = urlValidation.formattedUrl;
-		}
-
-		if (data.additionalDomains !== undefined) {
-			const cleaned = data.additionalDomains.map((d) => cleanAndValidateDomain(d));
-			const invalid = data.additionalDomains.filter((_, i) => !cleaned[i]);
-			if (invalid.length > 0) {
-				throw new Error(`Invalid domain(s): ${invalid.join(", ")}`);
-			}
-			updateData.additionalDomains = [...new Set(cleaned.filter(Boolean) as string[])];
-		}
-
-		if (data.aliases !== undefined) {
-			updateData.aliases = [...new Set(data.aliases.map((a) => a.trim()).filter(Boolean))];
-		}
+		const updateData = normalized.updates;
 
 		const result = await db
 			.update(brands)


### PR DESCRIPTION
## Summary
The "edit brand settings" validation (name / website / additionalDomains / aliases normalization) lived inline in the `updateBrand` server function, untestable without a DB + auth session.

## Changes
- Extracts the rules verbatim into a pure `normalizeBrandUpdate()` in `@/lib/brand-settings`; `updateBrandFn` now calls it.
- Adds unit tests covering trimming, website normalization, domain validation/dedup with invalid-domain reporting, and alias dedup. No behavior change.

## Testing
- 12 unit tests in `brand-settings.test.ts`; web `tsc --noEmit` passes.

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)
