### PR TITLE
feat: enforce a configurable per-brand prompt limit (#97)

### DIFF
--- a/.changeset/configurable-prompt-limit.md
+++ b/.changeset/configurable-prompt-limit.md
@@ -1,0 +1,6 @@
+---
+"@workspace/web": patch
+"@workspace/lib": patch
+---
+
+The maximum number of prompts per brand is now enforced server-side (in the dashboard save path and the public `/api/v1/prompts` endpoint), not just in the editor UI, and is configurable via the `MAX_PROMPTS_PER_BRAND` environment variable (defaults to 100).

--- a/apps/web/src/routes/api/v1/prompts/index.ts
+++ b/apps/web/src/routes/api/v1/prompts/index.ts
@@ -8,6 +8,7 @@ import { prompts, brands } from "@workspace/lib/db/schema";
 import { eq, count, desc } from "drizzle-orm";
 import { z } from "zod";
 import { sanitizeUserTags, computeSystemTags } from "@workspace/lib/tag-utils";
+import { getMaxPrompts } from "@workspace/lib/constants";
 import { createPromptJobScheduler } from "@/lib/job-scheduler";
 import { ApiError, createApiHandler } from "@/lib/api/handler";
 
@@ -70,6 +71,22 @@ export const Route = createFileRoute("/api/v1/prompts/")({
 					}
 
 					const brand = brandInfo[0];
+
+					// Enforce the per-brand prompt cap (issue #97).
+					const [promptCountResult] = await db
+						.select({ count: count() })
+						.from(prompts)
+						.where(eq(prompts.brandId, brandId));
+					const promptCount = promptCountResult?.count || 0;
+					const maxPrompts = getMaxPrompts();
+					if (promptCount + 1 > maxPrompts) {
+						throw new ApiError(
+							400,
+							"Validation Error",
+							`Brand already has ${promptCount}/${maxPrompts} prompts. Delete one before adding another.`,
+						);
+					}
+
 					const userTags = tags ? sanitizeUserTags(tags) : [];
 					const systemTags = computeSystemTags(value, brand.name, brand.website);
 

--- a/apps/web/src/server/prompts.ts
+++ b/apps/web/src/server/prompts.ts
@@ -5,6 +5,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
+import { getMaxPrompts } from "@workspace/lib/constants";
 import { db } from "@workspace/lib/db/db";
 import { prompts, promptRuns, brands, competitors, SYSTEM_TAGS } from "@workspace/lib/db/schema";
 import { eq, and, desc, gte, count, sql } from "drizzle-orm";
@@ -538,6 +539,17 @@ export const updatePromptsFn = createServerFn({ method: "POST" })
 			(await db.select({ id: prompts.id }).from(prompts).where(eq(prompts.brandId, data.brandId)))
 				.map((p) => p.id),
 		);
+
+		// Enforce the per-brand prompt cap server-side (issue #97). The editor caps
+		// it client-side, but this server function (and the public API) must not
+		// rely on that. Only brand-new prompts grow the count; updates don't.
+		const toInsertCount = data.prompts.filter((p) => !p.id).length;
+		const maxPrompts = getMaxPrompts();
+		if (existingIds.size + toInsertCount > maxPrompts) {
+			throw new Error(
+				`Cannot add prompts. Maximum of ${maxPrompts} prompts per brand reached (currently ${existingIds.size}, adding ${toInsertCount}).`,
+			);
+		}
 
 		const saved = await db.transaction(async (tx) => {
 			const toUpdate = data.prompts.filter((p) => p.id);

--- a/packages/lib/src/constants.test.ts
+++ b/packages/lib/src/constants.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getMaxPrompts, MAX_PROMPTS } from "./constants";
+
+describe("getMaxPrompts", () => {
+	const original = process.env.MAX_PROMPTS_PER_BRAND;
+	afterEach(() => {
+		if (original === undefined) delete process.env.MAX_PROMPTS_PER_BRAND;
+		else process.env.MAX_PROMPTS_PER_BRAND = original;
+	});
+
+	it("defaults to MAX_PROMPTS when the env var is unset", () => {
+		delete process.env.MAX_PROMPTS_PER_BRAND;
+		expect(getMaxPrompts()).toBe(MAX_PROMPTS);
+	});
+
+	it("uses a valid positive override", () => {
+		process.env.MAX_PROMPTS_PER_BRAND = "250";
+		expect(getMaxPrompts()).toBe(250);
+	});
+
+	it.each(["0", "-5", "abc", ""])(
+		"falls back to MAX_PROMPTS for the invalid value %j",
+		(value) => {
+			process.env.MAX_PROMPTS_PER_BRAND = value;
+			expect(getMaxPrompts()).toBe(MAX_PROMPTS);
+		},
+	);
+});

--- a/packages/lib/src/constants.ts
+++ b/packages/lib/src/constants.ts
@@ -25,6 +25,20 @@ export const MAX_COMPETITORS = 100;
 export const MAX_PROMPTS = 100;
 
 /**
+ * Resolves the maximum number of prompts allowed per brand. Reads
+ * MAX_PROMPTS_PER_BRAND from the environment; falls back to MAX_PROMPTS when
+ * unset, non-numeric, or <= 0. Server-only (process is undefined in browser
+ * bundles) — use this in server functions/API routes that enforce the cap.
+ */
+export function getMaxPrompts(): number {
+	const raw = typeof process !== "undefined" ? process.env.MAX_PROMPTS_PER_BRAND : undefined;
+	if (!raw) return MAX_PROMPTS;
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed) || parsed <= 0) return MAX_PROMPTS;
+	return parsed;
+}
+
+/**
  * Sentinel providers store in `prompt_runs.web_queries` when a web search
  * happened (citations prove it) but the provider doesn't expose the actual
  * query strings (OpenRouter always; BrightData/Olostep on extraction failure).


### PR DESCRIPTION
## Summary
`MAX_PROMPTS` was only enforced in the editor UI; the `updatePrompts` server function and the public `POST /api/v1/prompts` endpoint accepted unlimited prompts.

## Changes
- New `getMaxPrompts()` in `@workspace/lib/constants` — reads `MAX_PROMPTS_PER_BRAND` (positive int), defaults to `MAX_PROMPTS` (100).
- Enforces the cap server-side in both the dashboard save path and the public API, with a clear error.

## Testing
- 6 unit tests for `getMaxPrompts` env parsing/fallbacks; web `tsc --noEmit` passes.

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)
