### PR TITLE
run brand analysis as a background job

### DIFF
--- a/.changeset/resilient-onboarding-analysis.md
+++ b/.changeset/resilient-onboarding-analysis.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Onboarding brand analysis now runs in the background and is more resilient to failures, avoiding timeouts on slow analyses.

--- a/.github/contributors.txt
+++ b/.github/contributors.txt
@@ -23,3 +23,4 @@
 jrhizor
 prashantindurkar
 tuliren
+melalj

--- a/apps/web/src/components/prompt-wizard.tsx
+++ b/apps/web/src/components/prompt-wizard.tsx
@@ -5,8 +5,8 @@
  * and edits before saving. Replaces the prior 4-step wizard that required
  * DataForSEO + Anthropic in tandem.
  */
-import { useState, useCallback, memo, useMemo } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useState, useCallback, useEffect, memo, useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { Button } from "@workspace/ui/components/button";
 import { Input } from "@workspace/ui/components/input";
@@ -17,8 +17,12 @@ import { useBrand, brandKeys } from "@/hooks/use-brands";
 import { citationKeys } from "@/hooks/use-citations";
 import { dashboardKeys } from "@/hooks/use-dashboard-summary";
 import { promptsSummaryKeys } from "@/hooks/use-prompts-summary";
-import { startAnalyzeBrandFn, getAnalyzeBrandStatusFn, updateOnboardedBrandFn } from "@/server/onboarding";
-import type { OnboardingSuggestion } from "@workspace/lib/onboarding";
+import {
+	startAnalyzeBrandFn,
+	getAnalyzeBrandStatusFn,
+	cancelAnalyzeBrandFn,
+	updateOnboardedBrandFn,
+} from "@/server/onboarding";
 import { trackEvent } from "@/lib/posthog";
 import { CompetitorsEditor, newCompetitorEntry, type CompetitorEntry } from "@/components/competitors-editor";
 import { PromptsListEditor, newPromptEntry, type EditablePrompt } from "@/components/prompts-list-editor";
@@ -26,6 +30,12 @@ import { PromptsListEditor, newPromptEntry, type EditablePrompt } from "@/compon
 interface PromptWizardProps {
 	onComplete: () => void;
 }
+
+/** Brand analysis runs in the worker (LLM + web search, ~1 min); the client polls for the result. */
+const POLL_INTERVAL_MS = 2000;
+const ANALYZE_TIMEOUT_MS = 6 * 60 * 1000; // give up after ~6 minutes
+
+const analyzeStatusKey = (brandId: string) => ["analyze-brand", "status", brandId] as const;
 
 interface WizardData {
 	brandName: string;
@@ -84,38 +94,67 @@ export default function PromptWizard({ onComplete }: PromptWizardProps) {
 		prompts: [],
 	});
 
-	const handleAnalyze = useCallback(async () => {
-		if (!brand?.website) return;
-		setError(null);
-		setPhase("analyzing");
-		try {
-			// Brand analysis runs in the worker (LLM + web search, ~1 min), so we
-			// enqueue it and poll instead of holding one long request open — a
-			// long inline request gets killed by the reverse proxy (504).
-			const { jobId } = await startAnalyzeBrandFn({
-				data: {
-					website: brand.website,
-					brandName: brand.name,
-				},
-			});
+	const brandId = brand?.id;
 
-			const POLL_INTERVAL_MS = 2000;
-			const MAX_ATTEMPTS = 180; // ~6 minutes
-			let suggestion: OnboardingSuggestion | null = null;
-			for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-				await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-				const result = await getAnalyzeBrandStatusFn({ data: { jobId } });
-				if (result.status === "failed") {
-					throw new Error(result.error);
-				}
-				if (result.status === "done") {
-					suggestion = result.suggestion;
-					break;
-				}
+	// Stop polling, drop the cached status so the next run starts clean, and
+	// (best-effort) cancel the worker job. `errorMessage` surfaces a reason
+	// (timeout); a bare cancel passes null.
+	const stopAnalyzing = useCallback(
+		(errorMessage: string | null) => {
+			setPhase("idle");
+			setError(errorMessage);
+			if (brandId) {
+				queryClient.removeQueries({ queryKey: analyzeStatusKey(brandId) });
+				cancelAnalyzeBrandFn({ data: { brandId } }).catch(() => {});
 			}
-			if (!suggestion) {
-				throw new Error("Brand analysis timed out. Please try again.");
-			}
+		},
+		[brandId, queryClient],
+	);
+
+	const { mutate: enqueueAnalysis, isSuccess: analysisEnqueued } = useMutation({
+		mutationFn: (vars: { brandId: string; website: string; brandName?: string }) =>
+			startAnalyzeBrandFn({ data: vars }),
+		onError: (err) => {
+			setError(err instanceof Error ? err.message : "Analysis failed");
+			setPhase("idle");
+		},
+	});
+
+	// Poll the job status while analyzing. The query stops itself once the job
+	// reaches a terminal state (refetchInterval returns false), and is disabled
+	// the moment we leave the analyzing phase.
+	const statusQuery = useQuery({
+		queryKey: analyzeStatusKey(brandId ?? "none"),
+		queryFn: () => getAnalyzeBrandStatusFn({ data: { brandId: brandId! } }),
+		// Only poll once the job is actually enqueued.
+		enabled: phase === "analyzing" && analysisEnqueued && !!brandId,
+		staleTime: 0,
+		gcTime: 0,
+		refetchInterval: (query) => (query.state.data?.status === "pending" ? POLL_INTERVAL_MS : false),
+		refetchIntervalInBackground: true,
+	});
+
+	const handleAnalyze = useCallback(() => {
+		if (!brand?.website || !brand?.id) return;
+		setError(null);
+		// Clear any stale status from a previous run before we start polling.
+		queryClient.removeQueries({ queryKey: analyzeStatusKey(brand.id) });
+		setPhase("analyzing");
+		enqueueAnalysis({ brandId: brand.id, website: brand.website, brandName: brand.name });
+	}, [brand?.website, brand?.id, brand?.name, queryClient, enqueueAnalysis]);
+
+	// React to status transitions while analyzing.
+	const statusData = statusQuery.data;
+	useEffect(() => {
+		if (phase !== "analyzing" || !statusData) return;
+		if (statusData.status === "failed") {
+			setError(statusData.error);
+			setPhase("idle");
+			if (brandId) queryClient.removeQueries({ queryKey: analyzeStatusKey(brandId) });
+			return;
+		}
+		if (statusData.status === "done") {
+			const suggestion = statusData.suggestion;
 			setData({
 				brandName: suggestion.brandName || brand?.name || "",
 				website: brand?.website || suggestion.website || "",
@@ -138,12 +177,19 @@ export default function PromptWizard({ onComplete }: PromptWizardProps) {
 				competitor_count: suggestion.competitors.length,
 				prompt_count: suggestion.suggestedPrompts.length,
 			});
-		} catch (err) {
-			const message = err instanceof Error ? err.message : "Analysis failed";
-			setError(message);
-			setPhase("idle");
+			if (brandId) queryClient.removeQueries({ queryKey: analyzeStatusKey(brandId) });
 		}
-	}, [brand?.website, brand?.name]);
+	}, [phase, statusData, brandId, brand?.name, brand?.website, queryClient]);
+
+	// Give up on a stuck analysis instead of polling forever.
+	useEffect(() => {
+		if (phase !== "analyzing") return;
+		const timer = window.setTimeout(
+			() => stopAnalyzing("Brand analysis timed out. Please try again."),
+			ANALYZE_TIMEOUT_MS,
+		);
+		return () => window.clearTimeout(timer);
+	}, [phase, stopAnalyzing]);
 
 	const updateBrandName = useCallback((brandName: string) => setData((p) => ({ ...p, brandName })), []);
 	const updateWebsite = useCallback((website: string) => setData((p) => ({ ...p, website })), []);
@@ -230,21 +276,28 @@ export default function PromptWizard({ onComplete }: PromptWizardProps) {
 						<span>{error}</span>
 					</div>
 				)}
-				<Button
-					onClick={handleAnalyze}
-					disabled={phase === "analyzing"}
-					className="flex items-center gap-2 cursor-pointer"
-				>
-					{phase === "analyzing" ? (
-						<>
-							<Loader2 className="h-4 w-4 animate-spin" /> Analyzing brand…
-						</>
-					) : (
-						<>
-							<Play className="h-4 w-4" /> Analyze brand
-						</>
+				<div className="flex items-center gap-2">
+					<Button
+						onClick={handleAnalyze}
+						disabled={phase === "analyzing"}
+						className="flex items-center gap-2 cursor-pointer"
+					>
+						{phase === "analyzing" ? (
+							<>
+								<Loader2 className="h-4 w-4 animate-spin" /> Analyzing brand…
+							</>
+						) : (
+							<>
+								<Play className="h-4 w-4" /> Analyze brand
+							</>
+						)}
+					</Button>
+					{phase === "analyzing" && (
+						<Button variant="outline" onClick={() => stopAnalyzing(null)} className="cursor-pointer">
+							Cancel
+						</Button>
 					)}
-				</Button>
+				</div>
 			</div>
 		);
 	}

--- a/apps/web/src/components/prompt-wizard.tsx
+++ b/apps/web/src/components/prompt-wizard.tsx
@@ -17,7 +17,8 @@ import { useBrand, brandKeys } from "@/hooks/use-brands";
 import { citationKeys } from "@/hooks/use-citations";
 import { dashboardKeys } from "@/hooks/use-dashboard-summary";
 import { promptsSummaryKeys } from "@/hooks/use-prompts-summary";
-import { analyzeBrandFn, updateOnboardedBrandFn } from "@/server/onboarding";
+import { startAnalyzeBrandFn, getAnalyzeBrandStatusFn, updateOnboardedBrandFn } from "@/server/onboarding";
+import type { OnboardingSuggestion } from "@workspace/lib/onboarding";
 import { trackEvent } from "@/lib/posthog";
 import { CompetitorsEditor, newCompetitorEntry, type CompetitorEntry } from "@/components/competitors-editor";
 import { PromptsListEditor, newPromptEntry, type EditablePrompt } from "@/components/prompts-list-editor";
@@ -88,12 +89,33 @@ export default function PromptWizard({ onComplete }: PromptWizardProps) {
 		setError(null);
 		setPhase("analyzing");
 		try {
-			const suggestion = await analyzeBrandFn({
+			// Brand analysis runs in the worker (LLM + web search, ~1 min), so we
+			// enqueue it and poll instead of holding one long request open — a
+			// long inline request gets killed by the reverse proxy (504).
+			const { jobId } = await startAnalyzeBrandFn({
 				data: {
 					website: brand.website,
 					brandName: brand.name,
 				},
 			});
+
+			const POLL_INTERVAL_MS = 2000;
+			const MAX_ATTEMPTS = 180; // ~6 minutes
+			let suggestion: OnboardingSuggestion | null = null;
+			for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+				await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+				const result = await getAnalyzeBrandStatusFn({ data: { jobId } });
+				if (result.status === "failed") {
+					throw new Error(result.error);
+				}
+				if (result.status === "done") {
+					suggestion = result.suggestion;
+					break;
+				}
+			}
+			if (!suggestion) {
+				throw new Error("Brand analysis timed out. Please try again.");
+			}
 			setData({
 				brandName: suggestion.brandName || brand?.name || "",
 				website: brand?.website || suggestion.website || "",

--- a/apps/web/src/lib/analyze-brand-job.ts
+++ b/apps/web/src/lib/analyze-brand-job.ts
@@ -1,0 +1,131 @@
+/**
+ * Server-only helpers for the async brand-analysis job.
+ *
+ * All pg-boss coupling for the onboarding analysis lives here so the server
+ * functions in `@/server/onboarding` stay thin (and free of direct db
+ * imports). The web app enqueues the work and then polls the job's result
+ * *by brand* — the brand id is the org id, so callers prove access to the
+ * brand and we never hand a job's output to someone outside that org.
+ *
+ * Reading the result goes straight at pg-boss's `pgboss.job` table rather than
+ * `getJobById`, because the client polls by brand (not by an opaque job id it
+ * has to round-trip). The columns used here (`name`, `data`, `state`,
+ * `output`, `created_on`) are stable across the pinned pg-boss v12 line.
+ */
+import { sql } from "drizzle-orm";
+import { db } from "@workspace/lib/db/db";
+import type { OnboardingSuggestion } from "@workspace/lib/onboarding";
+import { getBoss } from "@/lib/boss-client";
+import { extractDomain } from "@/lib/domain-categories";
+
+const ANALYZE_BRAND_QUEUE = "analyze-brand";
+
+/**
+ * Shown to the user when a job ends in a failed/cancelled state. The real
+ * error (provider messages, stack traces) is already captured server-side by
+ * the worker's Sentry wrapper; we never forward it to the browser.
+ */
+const GENERIC_FAILURE = "Brand analysis failed. Please try again.";
+
+/** Discriminated status returned to the wizard while it polls. */
+export type AnalyzeBrandStatus =
+	| { status: "pending" }
+	| { status: "done"; suggestion: OnboardingSuggestion }
+	| { status: "failed"; error: string };
+
+export interface AnalyzeBrandInput {
+	/** Brand id (== org id) the analysis belongs to. Must be access-checked by the caller. */
+	brandId: string;
+	website: string;
+	brandName?: string;
+}
+
+interface JobRow {
+	id: string;
+	state: string;
+	data: { website?: string } | null;
+	output: unknown;
+}
+
+/** The most recent analyze-brand job for a brand, regardless of state. */
+async function latestJobForBrand(brandId: string): Promise<JobRow | undefined> {
+	const result = await db.execute(sql`
+		SELECT id, state, data, output
+		FROM pgboss.job
+		WHERE name = ${ANALYZE_BRAND_QUEUE} AND data->>'brandId' = ${brandId}
+		ORDER BY created_on DESC
+		LIMIT 1
+	`);
+	return result.rows[0] as unknown as JobRow | undefined;
+}
+
+const IN_FLIGHT_STATES = new Set(["created", "active", "retry"]);
+
+/**
+ * Enqueue a brand analysis, deduped by the brand + domain it runs for.
+ *
+ * If an analysis for this domain is already in flight we reuse it instead of
+ * paying for a second run; once a job reaches a terminal state a fresh analysis
+ * is allowed again (so "try again" works).
+ *
+ * We guard with an explicit in-flight check rather than pg-boss's `singletonKey`
+ * because that would be a no-op here: `singleton_key` only enforces uniqueness
+ * under a non-standard queue policy (short/singleton/stately) or with a
+ * `singletonSeconds` window, and this queue uses the default `standard` policy
+ * with no window. The check-then-send isn't atomic, but the analyze button is a
+ * deliberate, low-frequency action (and disabled while running), so the worst
+ * case — two near-simultaneous clicks racing past the check — is rare and
+ * merely costs a duplicate run.
+ */
+export async function enqueueAnalyzeBrand(input: AnalyzeBrandInput): Promise<void> {
+	const boss = await getBoss();
+	const domain = extractDomain(input.website);
+
+	const latest = await latestJobForBrand(input.brandId);
+	if (latest && IN_FLIGHT_STATES.has(latest.state) && extractDomain(latest.data?.website ?? "") === domain) {
+		return;
+	}
+
+	await boss.send(ANALYZE_BRAND_QUEUE, input);
+}
+
+/** Poll the status/result of the latest brand-analysis job for a brand. */
+export async function getAnalyzeBrandStatus(brandId: string): Promise<AnalyzeBrandStatus> {
+	const job = await latestJobForBrand(brandId);
+
+	// No job yet — the enqueue may not be visible, or the worker hasn't picked
+	// it up. Either way the client should keep polling.
+	if (!job) {
+		return { status: "pending" };
+	}
+	if (job.state === "completed") {
+		return { status: "done", suggestion: job.output as OnboardingSuggestion };
+	}
+	if (job.state === "failed" || job.state === "cancelled") {
+		console.error("[analyze-brand] job ended without a result", {
+			brandId,
+			jobId: job.id,
+			state: job.state,
+		});
+		return { status: "failed", error: GENERIC_FAILURE };
+	}
+	return { status: "pending" };
+}
+
+/**
+ * Best-effort cancel of an in-flight analysis for a brand. Used when the user
+ * backs out of the wizard so the worker doesn't keep grinding on a result
+ * nobody is waiting for.
+ */
+export async function cancelAnalyzeBrand(brandId: string): Promise<void> {
+	const job = await latestJobForBrand(brandId);
+	if (!job || !IN_FLIGHT_STATES.has(job.state)) {
+		return;
+	}
+	const boss = await getBoss();
+	try {
+		await boss.cancel(ANALYZE_BRAND_QUEUE, job.id);
+	} catch {
+		// Job may have completed between the read and the cancel — nothing to do.
+	}
+}

--- a/apps/web/src/lib/auth/__tests__/policies.test.ts
+++ b/apps/web/src/lib/auth/__tests__/policies.test.ts
@@ -273,7 +273,7 @@ describe("evaluateDeploymentPolicy", () => {
 		});
 
 		it("blocks POST /_server/* analyze server fn (no LLM access via wizard either)", () => {
-			const result = evaluateDeploymentPolicy(features, req("POST", "/_server/analyzeBrandFn"));
+			const result = evaluateDeploymentPolicy(features, req("POST", "/_server/startAnalyzeBrandFn"));
 			expect(result).toMatchObject({ action: "block", status: 403, error: "Demo Mode" });
 		});
 	});

--- a/apps/web/src/lib/auth/__tests__/policies.test.ts
+++ b/apps/web/src/lib/auth/__tests__/policies.test.ts
@@ -276,6 +276,11 @@ describe("evaluateDeploymentPolicy", () => {
 			const result = evaluateDeploymentPolicy(features, req("POST", "/_server/startAnalyzeBrandFn"));
 			expect(result).toMatchObject({ action: "block", status: 403, error: "Demo Mode" });
 		});
+
+		it("blocks POST /_server/* analyze status poll (it is a POST, so demo mode rejects it)", () => {
+			const result = evaluateDeploymentPolicy(features, req("POST", "/_server/getAnalyzeBrandStatusFn"));
+			expect(result).toMatchObject({ action: "block", status: 403, error: "Demo Mode" });
+		});
 	});
 
 	// ────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/boss-client.ts
+++ b/apps/web/src/lib/boss-client.ts
@@ -45,6 +45,12 @@ export async function getBoss(): Promise<PgBoss> {
 			retryBackoff: true,
 			expireInSeconds: 60 * 60,
 		});
+		await boss.createQueue("analyze-brand", {
+			retryLimit: 1,
+			retryDelay: 10,
+			retryBackoff: false,
+			expireInSeconds: 60 * 15,
+		});
 
 		bossInstance = boss;
 		return boss;

--- a/apps/web/src/server/onboarding.ts
+++ b/apps/web/src/server/onboarding.ts
@@ -13,12 +13,28 @@
  */
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
-import { analyzeBrand } from "@workspace/lib/onboarding";
+import type { OnboardingSuggestion } from "@workspace/lib/onboarding";
+import { getBoss } from "@/lib/boss-client";
 import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
 import { saveWizardOnboarding, wizardOnboardingInputSchema } from "@/server/onboarding-core";
 
-/** Run brand analysis without saving anything. */
-export const analyzeBrandFn = createServerFn({ method: "POST" })
+const ANALYZE_BRAND_QUEUE = "analyze-brand";
+
+/** Discriminated status returned to the wizard while it polls. */
+type AnalyzeBrandStatus =
+	| { status: "pending" }
+	| { status: "done"; suggestion: OnboardingSuggestion }
+	| { status: "failed"; error: string };
+
+/**
+ * Kick off brand analysis as a background job and return its id immediately.
+ *
+ * Brand analysis is an LLM + web-search call that routinely runs ~1 minute,
+ * which blows past reverse-proxy read timeouts when executed inline (the user
+ * gets a 504 even though the work succeeds). The worker processes the job; the
+ * client polls `getAnalyzeBrandStatusFn` for the result.
+ */
+export const startAnalyzeBrandFn = createServerFn({ method: "POST" })
 	.validator(
 		z.object({
 			website: z.string().min(1),
@@ -29,12 +45,34 @@ export const analyzeBrandFn = createServerFn({ method: "POST" })
 	)
 	.handler(async ({ data }) => {
 		await requireAuthSession();
-		return analyzeBrand({
-			website: data.website,
-			brandName: data.brandName,
-			maxCompetitors: data.maxCompetitors,
-			maxPrompts: data.maxPrompts,
-		});
+		const boss = await getBoss();
+		const jobId = await boss.send(ANALYZE_BRAND_QUEUE, data);
+		if (!jobId) {
+			throw new Error("Failed to enqueue brand analysis");
+		}
+		return { jobId };
+	});
+
+/** Poll the status/result of a brand-analysis job started by startAnalyzeBrandFn. */
+export const getAnalyzeBrandStatusFn = createServerFn({ method: "GET" })
+	.validator(z.object({ jobId: z.string().min(1) }))
+	.handler(async ({ data }): Promise<AnalyzeBrandStatus> => {
+		await requireAuthSession();
+		const boss = await getBoss();
+		const job = await boss.getJobById<OnboardingSuggestion>(ANALYZE_BRAND_QUEUE, data.jobId);
+
+		// A just-enqueued job may not be visible yet — treat as pending.
+		if (!job) {
+			return { status: "pending" };
+		}
+		if (job.state === "completed") {
+			return { status: "done", suggestion: job.output as OnboardingSuggestion };
+		}
+		if (job.state === "failed" || job.state === "cancelled") {
+			const output = job.output as { message?: string } | null;
+			return { status: "failed", error: output?.message || "Brand analysis failed" };
+		}
+		return { status: "pending" };
 	});
 
 /**

--- a/apps/web/src/server/onboarding.ts
+++ b/apps/web/src/server/onboarding.ts
@@ -13,66 +13,65 @@
  */
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
-import type { OnboardingSuggestion } from "@workspace/lib/onboarding";
-import { getBoss } from "@/lib/boss-client";
 import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
+import {
+	cancelAnalyzeBrand,
+	enqueueAnalyzeBrand,
+	getAnalyzeBrandStatus,
+	type AnalyzeBrandStatus,
+} from "@/lib/analyze-brand-job";
 import { saveWizardOnboarding, wizardOnboardingInputSchema } from "@/server/onboarding-core";
 
-const ANALYZE_BRAND_QUEUE = "analyze-brand";
-
-/** Discriminated status returned to the wizard while it polls. */
-type AnalyzeBrandStatus =
-	| { status: "pending" }
-	| { status: "done"; suggestion: OnboardingSuggestion }
-	| { status: "failed"; error: string };
-
 /**
- * Kick off brand analysis as a background job and return its id immediately.
+ * Kick off brand analysis as a background job.
  *
  * Brand analysis is an LLM + web-search call that routinely runs ~1 minute,
  * which blows past reverse-proxy read timeouts when executed inline (the user
  * gets a 504 even though the work succeeds). The worker processes the job; the
- * client polls `getAnalyzeBrandStatusFn` for the result.
+ * client polls `getAnalyzeBrandStatusFn` (by brand) for the result.
+ *
+ * Scoped to the brand (== org): the caller must have access to the brand both
+ * to start an analysis and to read it back, so a job's output never leaks
+ * outside the org that requested it.
  */
 export const startAnalyzeBrandFn = createServerFn({ method: "POST" })
 	.validator(
 		z.object({
+			brandId: z.string().min(1),
 			website: z.string().min(1),
 			brandName: z.string().optional(),
-			maxCompetitors: z.number().int().min(0).optional(),
-			maxPrompts: z.number().int().min(0).optional(),
 		}),
 	)
 	.handler(async ({ data }) => {
-		await requireAuthSession();
-		const boss = await getBoss();
-		const jobId = await boss.send(ANALYZE_BRAND_QUEUE, data);
-		if (!jobId) {
-			throw new Error("Failed to enqueue brand analysis");
-		}
-		return { jobId };
+		const session = await requireAuthSession();
+		await requireOrgAccess(session.user.id, data.brandId);
+		await enqueueAnalyzeBrand(data);
+		return { ok: true };
 	});
 
-/** Poll the status/result of a brand-analysis job started by startAnalyzeBrandFn. */
-export const getAnalyzeBrandStatusFn = createServerFn({ method: "GET" })
-	.validator(z.object({ jobId: z.string().min(1) }))
+/**
+ * Poll the status/result of the latest brand-analysis job for a brand.
+ *
+ * POST (not GET) on purpose: the response changes on every poll, so we don't
+ * want a browser/CDN/reverse-proxy caching an early `pending` and starving the
+ * wizard of the eventual result.
+ */
+export const getAnalyzeBrandStatusFn = createServerFn({ method: "POST" })
+	.validator(z.object({ brandId: z.string().min(1) }))
 	.handler(async ({ data }): Promise<AnalyzeBrandStatus> => {
-		await requireAuthSession();
-		const boss = await getBoss();
-		const job = await boss.getJobById<OnboardingSuggestion>(ANALYZE_BRAND_QUEUE, data.jobId);
+		const session = await requireAuthSession();
+		await requireOrgAccess(session.user.id, data.brandId);
+		return getAnalyzeBrandStatus(data.brandId);
+	});
 
-		// A just-enqueued job may not be visible yet — treat as pending.
-		if (!job) {
-			return { status: "pending" };
-		}
-		if (job.state === "completed") {
-			return { status: "done", suggestion: job.output as OnboardingSuggestion };
-		}
-		if (job.state === "failed" || job.state === "cancelled") {
-			const output = job.output as { message?: string } | null;
-			return { status: "failed", error: output?.message || "Brand analysis failed" };
-		}
-		return { status: "pending" };
+/** Cancel the in-flight brand-analysis job for a brand (e.g. user backs out). */
+export const cancelAnalyzeBrandFn = createServerFn({ method: "POST" })
+	.validator(z.object({ brandId: z.string().min(1) }))
+	.handler(async ({ data }) => {
+		const session = await requireAuthSession();
+		await requireOrgAccess(session.user.id, data.brandId);
+		await cancelAnalyzeBrand(data.brandId);
+		return { ok: true };
 	});
 
 /**

--- a/apps/web/src/stories/_mocks/server-onboarding.ts
+++ b/apps/web/src/stories/_mocks/server-onboarding.ts
@@ -24,13 +24,22 @@ export function setMockOnboardingError(message: string | null) {
 	_shouldThrow = message;
 }
 
-export const analyzeBrandFn = async (_args: { data: unknown }) => {
-	if (_delayMs > 0) await new Promise((r) => setTimeout(r, _delayMs));
-	if (_shouldThrow) throw new Error(_shouldThrow);
+let _readyAt = 0;
+
+export const startAnalyzeBrandFn = async (_args: { data: unknown }) => {
+	// Mirror the real async flow: enqueue returns immediately; the result
+	// becomes available after the configured delay and is read by polling.
+	_readyAt = Date.now() + _delayMs;
+	return { jobId: "mock-analyze-job" };
+};
+
+export const getAnalyzeBrandStatusFn = async (_args: { data: unknown }) => {
+	if (_shouldThrow) return { status: "failed" as const, error: _shouldThrow };
+	if (Date.now() < _readyAt) return { status: "pending" as const };
 	if (!_suggestion) {
 		throw new Error("setMockOnboardingSuggestion() not called");
 	}
-	return _suggestion;
+	return { status: "done" as const, suggestion: _suggestion };
 };
 
 export const updateOnboardedBrandFn = async (_args: { data: unknown }) => {

--- a/apps/web/src/stories/_mocks/server-onboarding.ts
+++ b/apps/web/src/stories/_mocks/server-onboarding.ts
@@ -25,21 +25,29 @@ export function setMockOnboardingError(message: string | null) {
 }
 
 let _readyAt = 0;
+let _cancelled = false;
 
 export const startAnalyzeBrandFn = async (_args: { data: unknown }) => {
 	// Mirror the real async flow: enqueue returns immediately; the result
 	// becomes available after the configured delay and is read by polling.
 	_readyAt = Date.now() + _delayMs;
-	return { jobId: "mock-analyze-job" };
+	_cancelled = false;
+	return { ok: true as const };
 };
 
 export const getAnalyzeBrandStatusFn = async (_args: { data: unknown }) => {
+	if (_cancelled) return { status: "pending" as const };
 	if (_shouldThrow) return { status: "failed" as const, error: _shouldThrow };
 	if (Date.now() < _readyAt) return { status: "pending" as const };
 	if (!_suggestion) {
 		throw new Error("setMockOnboardingSuggestion() not called");
 	}
 	return { status: "done" as const, suggestion: _suggestion };
+};
+
+export const cancelAnalyzeBrandFn = async (_args: { data: unknown }) => {
+	_cancelled = true;
+	return { ok: true as const };
 };
 
 export const updateOnboardedBrandFn = async (_args: { data: unknown }) => {

--- a/apps/web/src/stories/prompt-wizard.stories.tsx
+++ b/apps/web/src/stories/prompt-wizard.stories.tsx
@@ -12,7 +12,8 @@
  * the mocks at bundle time.
  */
 import { useEffect } from "react";
-import type { Meta } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { within, userEvent, expect, waitFor } from "storybook/test";
 import BrandOnboarding from "@/components/brand-onboarding";
 import PromptWizard from "@/components/prompt-wizard";
 import { setMockBrand } from "./_mocks/use-brands";
@@ -138,12 +139,16 @@ export const Review = () => {
 	);
 };
 
-/** Analyze fails (e.g. provider not configured) — the error renders inline. */
+/**
+ * Analyze fails — the wizard surfaces a generic, user-safe message inline. The
+ * real provider/stack detail stays server-side (captured by the worker's
+ * Sentry wrapper) and is never forwarded to the browser.
+ */
 export const AnalyzeError = () => {
 	useWizardSetup({
 		brand: MOCK_BRAND,
 		suggestion: RICH_SUGGESTION,
-		error: "Onboarding requires at least one LLM provider. Configure ANTHROPIC_API_KEY or similar.",
+		error: "Brand analysis failed. Please try again.",
 	});
 	return (
 		<>
@@ -151,4 +156,31 @@ export const AnalyzeError = () => {
 			<AutoAnalyze />
 		</>
 	);
+};
+
+/**
+ * Cancel mid-analysis. The analysis is mocked to take a long time so the
+ * "Analyzing brand…" loader and its Cancel button are visible; the play
+ * function clicks Analyze, then Cancel, and asserts the wizard returns to the
+ * idle state (analyze button enabled again, cancel button gone).
+ */
+export const Cancel: StoryObj = {
+	render: () => {
+		useWizardSetup({ brand: MOCK_BRAND, suggestion: RICH_SUGGESTION, delayMs: 60_000 });
+		return <PromptWizard onComplete={() => {}} />;
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await userEvent.click(await canvas.findByRole("button", { name: /analyze brand/i }));
+
+		// Cancel only appears while analyzing.
+		await userEvent.click(await canvas.findByRole("button", { name: /^cancel$/i }));
+
+		// Back to idle: analyze is enabled again and the cancel button is gone.
+		await waitFor(() => {
+			expect(canvas.getByRole("button", { name: /analyze brand/i })).toBeEnabled();
+		});
+		expect(canvas.queryByRole("button", { name: /^cancel$/i })).toBeNull();
+	},
 };

--- a/apps/worker/src/handlers.ts
+++ b/apps/worker/src/handlers.ts
@@ -1,18 +1,23 @@
 import * as Sentry from "@sentry/node";
 import type { Job, PgBoss } from "pg-boss";
+import type { OnboardingSuggestion } from "@workspace/lib/onboarding";
 import { processPromptJob, type ProcessPromptData } from "./jobs/process-prompt";
 import { generateReportJob, type GenerateReportData } from "./jobs/generate-report";
 import { scheduleMaintenanceJob, type ScheduleMaintenanceData } from "./jobs/schedule-maintenance";
 import { syncAuth0MembershipsJob, type SyncAuth0MembershipsData } from "./jobs/sync-auth0-memberships";
+import { analyzeBrandJob, type AnalyzeBrandData } from "./jobs/analyze-brand";
 
-/** Wraps a pg-boss handler to report errors to Sentry before re-throwing. */
-function withSentry<T>(
+/**
+ * Wraps a pg-boss handler to report errors to Sentry before re-throwing.
+ * Preserves the handler's return value (stored by pg-boss as the job output).
+ */
+function withSentry<T, R>(
 	queueName: string,
-	handler: (jobs: Job<T>[]) => Promise<void>,
-): (jobs: Job<T>[]) => Promise<void> {
+	handler: (jobs: Job<T>[]) => Promise<R>,
+): (jobs: Job<T>[]) => Promise<R> {
 	return async (jobs) => {
 		try {
-			await handler(jobs);
+			return await handler(jobs);
 		} catch (error) {
 			Sentry.withScope((scope) => {
 				scope.setTag("queue", queueName);
@@ -40,6 +45,15 @@ export async function registerHandlers(boss: PgBoss): Promise<void> {
 		withSentry("generate-report", generateReportJob),
 	);
 	console.log("Registered handler: generate-report");
+
+	// batchSize: 1 keeps the returned suggestion mapped 1:1 to a single job's
+	// output, which the web app reads back via getJobById.
+	await boss.work<AnalyzeBrandData, OnboardingSuggestion>(
+		"analyze-brand",
+		{ batchSize: 1, localConcurrency: 2 },
+		withSentry("analyze-brand", analyzeBrandJob),
+	);
+	console.log("Registered handler: analyze-brand");
 
 	await boss.work<ScheduleMaintenanceData>(
 		"schedule-maintenance",

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -45,6 +45,12 @@ async function main() {
 		retryBackoff: true,
 		expireInSeconds: 60 * 60, // 1 hour timeout for reports
 	});
+	await boss.createQueue("analyze-brand", {
+		retryLimit: 1,
+		retryDelay: 10,
+		retryBackoff: false,
+		expireInSeconds: 60 * 15, // 15 minute timeout for onboarding brand analysis
+	});
 	await boss.createQueue("schedule-maintenance", {
 		retryLimit: 3,
 		retryDelay: 300, // 5 minutes between retries

--- a/apps/worker/src/jobs/analyze-brand.ts
+++ b/apps/worker/src/jobs/analyze-brand.ts
@@ -1,0 +1,31 @@
+import type { Job } from "pg-boss";
+import { analyzeBrand, type OnboardingSuggestion } from "@workspace/lib/onboarding";
+
+export interface AnalyzeBrandData {
+	website: string;
+	brandName?: string;
+	maxCompetitors?: number;
+	maxPrompts?: number;
+}
+
+/**
+ * Run brand analysis as a background job.
+ *
+ * The onboarding wizard used to call analyzeBrand() synchronously inside the
+ * HTTP request. That call is an LLM + web-search round trip that routinely
+ * takes ~1 minute, so it gets killed by reverse-proxy read timeouts (the user
+ * sees a 504 even though the work finishes). Running it here lets the request
+ * return immediately; the web app polls the job's `output` via getJobById.
+ *
+ * The queue is registered with batchSize: 1, so `jobs` always holds exactly
+ * one job and the returned suggestion becomes that job's output.
+ */
+export async function analyzeBrandJob(jobs: Job<AnalyzeBrandData>[]): Promise<OnboardingSuggestion> {
+	const [job] = jobs;
+	if (!job) {
+		throw new Error("analyze-brand handler received an empty batch");
+	}
+
+	const { website, brandName, maxCompetitors, maxPrompts } = job.data;
+	return analyzeBrand({ website, brandName, maxCompetitors, maxPrompts });
+}

--- a/apps/worker/src/jobs/analyze-brand.ts
+++ b/apps/worker/src/jobs/analyze-brand.ts
@@ -2,6 +2,8 @@ import type { Job } from "pg-boss";
 import { analyzeBrand, type OnboardingSuggestion } from "@workspace/lib/onboarding";
 
 export interface AnalyzeBrandData {
+	/** Brand id (== org id) the analysis belongs to; the web app reads results back by brand. */
+	brandId: string;
 	website: string;
 	brandName?: string;
 	maxCompetitors?: number;


### PR DESCRIPTION
First off — thank you for building and open-sourcing Elmo 🙏. A self-hostable, fully-auditable AEO/GEO tracker is genuinely valuable, and the codebase was a pleasure to work in — the existing pg-boss worker pattern made this fix straightforward to slot in.

## Problem

When self-hosting behind a reverse proxy (CapRover/nginx in my case), the onboarding **"Analyze brand"** step returns a `504 Gateway Time-out`, even though the analysis actually succeeds server-side. The worker log tells the story:

```
[onboarding] analyzeBrand done: https://2sync.com/ in 55915ms (brand="2sync", competitors=10, prompts=24)
```

`analyzeBrand()` runs **synchronously inside the `analyzeBrandFn` server function** and takes ~1 minute (LLM + web search). nginx's default `proxy_read_timeout` is 60s, so the proxy gives up before the response comes back. Raising the proxy timeout is only a band-aid — a ~1-minute synchronous request is fragile by design.

## Fix

Move brand analysis onto the existing pg-boss worker and let the wizard poll for the result, so the HTTP request returns in milliseconds.

- **worker** — new `analyze-brand` queue + handler (`apps/worker/src/jobs/analyze-brand.ts`). The handler returns the `OnboardingSuggestion`, which pg-boss stores as the job output. Registered with `batchSize: 1` (see note).
- **web** — `startAnalyzeBrandFn` enqueues and returns a `jobId` immediately; `getAnalyzeBrandStatusFn` reads job state/output via `getJobById`.
- **wizard** (`prompt-wizard.tsx`) — enqueues, then polls every 2s (up to ~6 min), reusing the existing "Analyzing brand…" UI. On worker/DB trouble it surfaces a clean "timed out, please try again" instead of a 504.

**No DB migration** — the result rides in the pg-boss job output.

## Design notes

- **`batchSize: 1` is load-bearing, not cosmetic.** In pg-boss v12 (`manager.js`), the handler's return value is persisted as the job output only for single-job batches:
  ```js
  await this.complete(name, jobIds, jobIds.length === 1 ? result : undefined);
  ```
  With a larger batch the output would be dropped (and the wizard would poll until timeout), so the queue is registered with `batchSize: 1`.
- **Scope kept intentionally tight.** The public API route (`/api/v1/tools/analyze`) and the admin re-run still call `analyzeBrand` directly — different consumers with their own timeout expectations. Happy to convert those the same way if you'd like.
- `withSentry` is now generic over the handler's return type (was hard-coded to `Promise<void>`); existing handlers are unaffected.

## Testing

- `pnpm --filter @workspace/worker check-types` and `--filter @workspace/web check-types` — both clean.
- `policies.test.ts` — 85/85 (updated the representative path from `/_server/analyzeBrandFn` → `/_server/startAnalyzeBrandFn`).
- **Live smoke test** against a real `postgres:16-alpine` with the pinned `pg-boss@12.19.1`, replicating the exact wiring:
  - enqueue → worker returns suggestion → `getJobById` output deep-equals the suggestion ✅
  - handler throws → `state=failed`, `output.message` readable (the failed branch of `getAnalyzeBrandStatusFn`) ✅

Not yet exercised end-to-end: the full HTTP + React polling path with the real LLM call (existing, unchanged code).

## Notes / open questions

- Glad to adjust polling cadence/UX, add a worker unit test (there are no worker tests yet, so I didn't want to set a pattern without your steer), or wire the public API route the same way. If you'd prefer an issue first for a change of this size, just say so.
- **CLA:** signed — `melalj` added to `.github/contributors.txt` in this PR.

Thanks again for the project! 🐳
