### PR TITLE
fix(web): prevent citation category tabs from overflowing the card

### DIFF
--- a/apps/web/src/components/citations/shared.tsx
+++ b/apps/web/src/components/citations/shared.tsx
@@ -1,13 +1,12 @@
 import {
-	type CitationCategory,
 	CATEGORY_CONFIG,
 	CITATION_CATEGORIES,
 	CITATION_PAGE_TYPES,
+	type CitationCategory,
 	PAGE_TYPE_CONFIG,
 } from "@/lib/domain-categories";
 
-export const getCategoryLabel = (category: string) =>
-	CATEGORY_CONFIG[category as CitationCategory]?.label ?? category;
+export const getCategoryLabel = (category: string) => CATEGORY_CONFIG[category as CitationCategory]?.label ?? category;
 
 export const getCategoryColorClass = (category: string) =>
 	CATEGORY_CONFIG[category as CitationCategory]?.badgeClass ?? "bg-gray-500/90 text-white";
@@ -74,13 +73,13 @@ export function UnderlineTabs<T extends string>({
 	onSelect: (key: T) => void;
 }) {
 	return (
-		<nav className="-mb-px flex gap-4 border-b border-border" aria-label="Tabs">
+		<nav className="-mb-px flex gap-4 overflow-x-auto border-b border-border" aria-label="Tabs">
 			{tabs.map(({ key, label }) => (
 				<button
 					key={key}
 					type="button"
 					onClick={() => onSelect(key)}
-					className={`cursor-pointer whitespace-nowrap pb-2.5 text-xs font-medium transition-colors border-b-2 ${
+					className={`shrink-0 cursor-pointer whitespace-nowrap pb-2.5 text-xs font-medium transition-colors border-b-2 ${
 						activeKey === key
 							? "border-foreground text-foreground"
 							: "border-transparent text-muted-foreground hover:text-foreground hover:border-border"


### PR DESCRIPTION
Closes #394

## Problem

On `/app/*/citations`, the **Top Cited Domains** and **Top Cited URLs** category tabs (`UnderlineTabs`) render as a non-wrapping flex row. On narrow desktop or mobile widths there isn't room for all the tabs, so the row overflows past the right edge of the card.

## Fix

Make the tab `<nav>` horizontally scrollable and keep each tab at its natural width:

- `overflow-x-auto` on the nav so the tabs scroll within the card instead of spilling out.
- `shrink-0` on each tab button so they don't compress/clip (they're already `whitespace-nowrap`), which is what lets the row scroll rather than overflow.

CSS-only change to the shared `UnderlineTabs` component; behavior and markup are otherwise unchanged.

## Verification

- `pnpm --filter web check-types` passes.
- `biome lint` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)