### PR TITLE
Auto-update www home page version badge from package.json

### DIFF
--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -64,7 +64,7 @@ export function Footer() {
 						</p>
 						<div className="mt-5 inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-2.5 py-1 font-mono text-[11px] text-zinc-700">
 							<span className="size-1.5 rounded-full bg-emerald-500" />
-							v0.2.6
+							v{__APP_VERSION__}
 						</div>
 					</div>
 					<div className="grid grid-cols-2 gap-10 md:col-span-9 md:grid-cols-4">

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -121,7 +121,7 @@ export function Hero() {
 						<div className="flex flex-wrap items-center gap-2">
 							<span className="inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-2.5 py-1 font-mono text-[11px] text-zinc-700">
 								<span className="size-1.5 rounded-full bg-emerald-500" />
-								v0.2.6
+								v{__APP_VERSION__}
 							</span>
 							<a
 								href="https://github.com/elmohq/elmo"

--- a/apps/www/src/env.d.ts
+++ b/apps/www/src/env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+
+// App version injected by Vite `define` (see vite.config.ts) from this
+// package's package.json, which shares the fixed workspace release version.
+declare const __APP_VERSION__: string;

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -10,6 +10,7 @@ import tailwindcss from "@tailwindcss/vite";
 import mdx from "fumadocs-mdx/vite";
 import { embedBinaries } from "@workspace/og/vite-plugin";
 import * as MdxConfig from "./source.config";
+import pkg from "./package.json" with { type: "json" };
 
 const tslibEsm = fileURLToPath(import.meta.resolve("tslib/tslib.es6.mjs"));
 const require = createRequire(import.meta.url);
@@ -29,6 +30,11 @@ const takumiNativeBindings = Object.keys(
 export default defineConfig({
 	server: {
 		port: 3001,
+	},
+	define: {
+		// Injected from this package's manifest, which shares the fixed
+		// workspace release version, so version badges auto-update on release.
+		__APP_VERSION__: JSON.stringify(pkg.version),
 	},
 	resolve: {
 		tsconfigPaths: true,


### PR DESCRIPTION
The hero and footer version badges on the marketing site were hardcoded to `v0.2.6` and never tracked releases. This injects `__APP_VERSION__` at build time via Vite `define` (mirroring `apps/web`), reading from `apps/www/package.json` — which is part of the fixed workspace version group, so the badge now auto-updates on every release. A new `src/env.d.ts` declares the `__APP_VERSION__` global for type-checking. Validated with `tsc --noEmit` and a production build; the SSR HTML renders the current version (`0.2.14`).
