### PR TITLE
Comprehensive API pt.1: GET /brands/{id}/visibility (analytics endpoints)

### DIFF
--- a/.changeset/brand-visibility-analytics-endpoint.md
+++ b/.changeset/brand-visibility-analytics-endpoint.md
@@ -1,0 +1,7 @@
+---
+"@workspace/web": minor
+"@workspace/lib": minor
+"@workspace/api-spec": minor
+---
+
+The API now exposes brand visibility over time at `GET /api/v1/brands/{brandId}/visibility`, returning a daily mention-rate series plus period totals for a given date range. This is the first of a planned set of analytics endpoints exposing the dashboard's metrics via the API, and works with both instance-admin keys and dashboard keys scoped to their brands.

--- a/apps/web/src/lib/api/__tests__/analytics-range.test.ts
+++ b/apps/web/src/lib/api/__tests__/analytics-range.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { parseDateRange } from "../analytics-range";
+import { ApiError } from "../handler";
+
+function params(q: Record<string, string>): URLSearchParams {
+	return new URLSearchParams(q);
+}
+
+describe("parseDateRange", () => {
+	it("parses valid from/to with a default UTC timezone", () => {
+		expect(parseDateRange(params({ from: "2026-06-01", to: "2026-06-30" }))).toEqual({
+			from: "2026-06-01",
+			to: "2026-06-30",
+			timezone: "UTC",
+		});
+	});
+
+	it("keeps an explicit timezone", () => {
+		expect(parseDateRange(params({ from: "2026-06-01", to: "2026-06-30", timezone: "America/New_York" }))).toEqual({
+			from: "2026-06-01",
+			to: "2026-06-30",
+			timezone: "America/New_York",
+		});
+	});
+
+	it("allows an equal from and to (single day)", () => {
+		const r = parseDateRange(params({ from: "2026-06-01", to: "2026-06-01" }));
+		expect(r.from).toBe("2026-06-01");
+		expect(r.to).toBe("2026-06-01");
+	});
+
+	it("throws 400 when from or to is missing", () => {
+		const cases: Record<string, string>[] = [{}, { from: "2026-06-01" }, { to: "2026-06-30" }];
+		for (const q of cases) {
+			try {
+				parseDateRange(params(q));
+				throw new Error("expected parseDateRange to throw");
+			} catch (err) {
+				expect(err).toBeInstanceOf(ApiError);
+				expect((err as ApiError).status).toBe(400);
+				expect((err as ApiError).message).toMatch(/from and to query parameters are required/);
+			}
+		}
+	});
+
+	it("throws 400 for a malformed date", () => {
+		for (const q of [
+			{ from: "2026-6-1", to: "2026-06-30" },
+			{ from: "2026-06-01", to: "06/30/2026" },
+			{ from: "2026-13-01", to: "2026-06-30" },
+			{ from: "not-a-date", to: "2026-06-30" },
+		]) {
+			try {
+				parseDateRange(params(q));
+				throw new Error("expected parseDateRange to throw");
+			} catch (err) {
+				expect(err).toBeInstanceOf(ApiError);
+				expect((err as ApiError).status).toBe(400);
+				expect((err as ApiError).message).toMatch(/valid dates in YYYY-MM-DD/);
+			}
+		}
+	});
+
+	it("throws 400 when from is after to", () => {
+		try {
+			parseDateRange(params({ from: "2026-06-30", to: "2026-06-01" }));
+			throw new Error("expected parseDateRange to throw");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ApiError);
+			expect((err as ApiError).status).toBe(400);
+			expect((err as ApiError).message).toMatch(/from must be before or equal to to/);
+		}
+	});
+});

--- a/apps/web/src/lib/api/analytics-range.ts
+++ b/apps/web/src/lib/api/analytics-range.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared query-parameter parsing for `/api/v1` analytics endpoints.
+ *
+ * Every analytics endpoint takes the same date window: `from` and `to`
+ * (inclusive, `YYYY-MM-DD`, required) plus an optional IANA `timezone` the day
+ * buckets are computed in (default UTC). Centralizing it keeps the convention
+ * identical across endpoints and the validation tested in one place.
+ */
+import { ApiError } from "./handler";
+
+export interface DateRange {
+	from: string;
+	to: string;
+	timezone: string;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function isValidDate(value: string): boolean {
+	if (!DATE_RE.test(value)) return false;
+	const d = new Date(`${value}T00:00:00Z`);
+	if (Number.isNaN(d.getTime())) return false;
+	// Reject values the Date constructor silently rolls over (e.g. 2026-13-01
+	// becomes 2027-01-01), which the regex alone would let through.
+	return d.toISOString().slice(0, 10) === value;
+}
+
+/**
+ * Parse and validate the shared analytics date-range params from a request's
+ * query string. Throws `ApiError(400, ...)` on any problem so the handler's
+ * uniform error envelope applies.
+ */
+export function parseDateRange(searchParams: URLSearchParams): DateRange {
+	const from = searchParams.get("from");
+	const to = searchParams.get("to");
+
+	if (!from || !to) {
+		throw new ApiError(400, "Validation Error", "from and to query parameters are required (YYYY-MM-DD format)");
+	}
+	if (!isValidDate(from) || !isValidDate(to)) {
+		throw new ApiError(400, "Validation Error", "from and to must be valid dates in YYYY-MM-DD format");
+	}
+	if (from > to) {
+		throw new ApiError(400, "Validation Error", "from must be before or equal to to");
+	}
+
+	return { from, to, timezone: searchParams.get("timezone") || "UTC" };
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -51,6 +51,7 @@ import { Route as ApiPlausibleJsScriptIndexRouteImport } from './routes/api/plau
 import { Route as AuthedAppBrandSettingsIndexRouteImport } from './routes/_authed/app/$brand/settings/index'
 import { Route as AuthedAppBrandPromptsIndexRouteImport } from './routes/_authed/app/$brand/prompts/index'
 import { Route as ApiV1PromptsPromptIdSnapshotRouteImport } from './routes/api/v1/prompts/$promptId/snapshot'
+import { Route as ApiV1BrandsBrandIdVisibilityRouteImport } from './routes/api/v1/brands/$brandId/visibility'
 import { Route as AuthedAppBrandSettingsPromptsRouteImport } from './routes/_authed/app/$brand/settings/prompts'
 import { Route as AuthedAppBrandSettingsLlmsRouteImport } from './routes/_authed/app/$brand/settings/llms'
 import { Route as AuthedAppBrandSettingsCompetitorsRouteImport } from './routes/_authed/app/$brand/settings/competitors'
@@ -278,6 +279,12 @@ const ApiV1PromptsPromptIdSnapshotRoute =
     path: '/snapshot',
     getParentRoute: () => ApiV1PromptsPromptIdRoute,
   } as any)
+const ApiV1BrandsBrandIdVisibilityRoute =
+  ApiV1BrandsBrandIdVisibilityRouteImport.update({
+    id: '/visibility',
+    path: '/visibility',
+    getParentRoute: () => ApiV1BrandsBrandIdRoute,
+  } as any)
 const AuthedAppBrandSettingsPromptsRoute =
   AuthedAppBrandSettingsPromptsRouteImport.update({
     id: '/settings/prompts',
@@ -347,7 +354,7 @@ export interface FileRoutesByFullPath {
   '/app/$brand/share-of-voice': typeof AuthedAppBrandShareOfVoiceRoute
   '/app/$brand/visibility': typeof AuthedAppBrandVisibilityRoute
   '/reports/render/$reportId': typeof AuthedReportsRenderReportIdRoute
-  '/api/v1/brands/$brandId': typeof ApiV1BrandsBrandIdRoute
+  '/api/v1/brands/$brandId': typeof ApiV1BrandsBrandIdRouteWithChildren
   '/api/v1/competitors/$competitorId': typeof ApiV1CompetitorsCompetitorIdRoute
   '/api/v1/prompts/$promptId': typeof ApiV1PromptsPromptIdRouteWithChildren
   '/api/v1/reports/$reportId': typeof ApiV1ReportsReportIdRoute
@@ -366,6 +373,7 @@ export interface FileRoutesByFullPath {
   '/app/$brand/settings/competitors': typeof AuthedAppBrandSettingsCompetitorsRoute
   '/app/$brand/settings/llms': typeof AuthedAppBrandSettingsLlmsRoute
   '/app/$brand/settings/prompts': typeof AuthedAppBrandSettingsPromptsRoute
+  '/api/v1/brands/$brandId/visibility': typeof ApiV1BrandsBrandIdVisibilityRoute
   '/api/v1/prompts/$promptId/snapshot': typeof ApiV1PromptsPromptIdSnapshotRoute
   '/app/$brand/prompts/': typeof AuthedAppBrandPromptsIndexRoute
   '/app/$brand/settings/': typeof AuthedAppBrandSettingsIndexRoute
@@ -393,7 +401,7 @@ export interface FileRoutesByTo {
   '/app/$brand/share-of-voice': typeof AuthedAppBrandShareOfVoiceRoute
   '/app/$brand/visibility': typeof AuthedAppBrandVisibilityRoute
   '/reports/render/$reportId': typeof AuthedReportsRenderReportIdRoute
-  '/api/v1/brands/$brandId': typeof ApiV1BrandsBrandIdRoute
+  '/api/v1/brands/$brandId': typeof ApiV1BrandsBrandIdRouteWithChildren
   '/api/v1/competitors/$competitorId': typeof ApiV1CompetitorsCompetitorIdRoute
   '/api/v1/prompts/$promptId': typeof ApiV1PromptsPromptIdRouteWithChildren
   '/api/v1/reports/$reportId': typeof ApiV1ReportsReportIdRoute
@@ -412,6 +420,7 @@ export interface FileRoutesByTo {
   '/app/$brand/settings/competitors': typeof AuthedAppBrandSettingsCompetitorsRoute
   '/app/$brand/settings/llms': typeof AuthedAppBrandSettingsLlmsRoute
   '/app/$brand/settings/prompts': typeof AuthedAppBrandSettingsPromptsRoute
+  '/api/v1/brands/$brandId/visibility': typeof ApiV1BrandsBrandIdVisibilityRoute
   '/api/v1/prompts/$promptId/snapshot': typeof ApiV1PromptsPromptIdSnapshotRoute
   '/app/$brand/prompts': typeof AuthedAppBrandPromptsIndexRoute
   '/app/$brand/settings': typeof AuthedAppBrandSettingsIndexRoute
@@ -445,7 +454,7 @@ export interface FileRoutesById {
   '/_authed/app/$brand/share-of-voice': typeof AuthedAppBrandShareOfVoiceRoute
   '/_authed/app/$brand/visibility': typeof AuthedAppBrandVisibilityRoute
   '/_authed/reports/render/$reportId': typeof AuthedReportsRenderReportIdRoute
-  '/api/v1/brands/$brandId': typeof ApiV1BrandsBrandIdRoute
+  '/api/v1/brands/$brandId': typeof ApiV1BrandsBrandIdRouteWithChildren
   '/api/v1/competitors/$competitorId': typeof ApiV1CompetitorsCompetitorIdRoute
   '/api/v1/prompts/$promptId': typeof ApiV1PromptsPromptIdRouteWithChildren
   '/api/v1/reports/$reportId': typeof ApiV1ReportsReportIdRoute
@@ -464,6 +473,7 @@ export interface FileRoutesById {
   '/_authed/app/$brand/settings/competitors': typeof AuthedAppBrandSettingsCompetitorsRoute
   '/_authed/app/$brand/settings/llms': typeof AuthedAppBrandSettingsLlmsRoute
   '/_authed/app/$brand/settings/prompts': typeof AuthedAppBrandSettingsPromptsRoute
+  '/api/v1/brands/$brandId/visibility': typeof ApiV1BrandsBrandIdVisibilityRoute
   '/api/v1/prompts/$promptId/snapshot': typeof ApiV1PromptsPromptIdSnapshotRoute
   '/_authed/app/$brand/prompts/': typeof AuthedAppBrandPromptsIndexRoute
   '/_authed/app/$brand/settings/': typeof AuthedAppBrandSettingsIndexRoute
@@ -516,6 +526,7 @@ export interface FileRouteTypes {
     | '/app/$brand/settings/competitors'
     | '/app/$brand/settings/llms'
     | '/app/$brand/settings/prompts'
+    | '/api/v1/brands/$brandId/visibility'
     | '/api/v1/prompts/$promptId/snapshot'
     | '/app/$brand/prompts/'
     | '/app/$brand/settings/'
@@ -562,6 +573,7 @@ export interface FileRouteTypes {
     | '/app/$brand/settings/competitors'
     | '/app/$brand/settings/llms'
     | '/app/$brand/settings/prompts'
+    | '/api/v1/brands/$brandId/visibility'
     | '/api/v1/prompts/$promptId/snapshot'
     | '/app/$brand/prompts'
     | '/app/$brand/settings'
@@ -613,6 +625,7 @@ export interface FileRouteTypes {
     | '/_authed/app/$brand/settings/competitors'
     | '/_authed/app/$brand/settings/llms'
     | '/_authed/app/$brand/settings/prompts'
+    | '/api/v1/brands/$brandId/visibility'
     | '/api/v1/prompts/$promptId/snapshot'
     | '/_authed/app/$brand/prompts/'
     | '/_authed/app/$brand/settings/'
@@ -629,7 +642,7 @@ export interface RootRouteChildren {
   ApiManifestIndexRoute: typeof ApiManifestIndexRoute
   ApiOgIndexRoute: typeof ApiOgIndexRoute
   ApiSetupStatusIndexRoute: typeof ApiSetupStatusIndexRoute
-  ApiV1BrandsBrandIdRoute: typeof ApiV1BrandsBrandIdRoute
+  ApiV1BrandsBrandIdRoute: typeof ApiV1BrandsBrandIdRouteWithChildren
   ApiV1CompetitorsCompetitorIdRoute: typeof ApiV1CompetitorsCompetitorIdRoute
   ApiV1PromptsPromptIdRoute: typeof ApiV1PromptsPromptIdRouteWithChildren
   ApiV1ReportsReportIdRoute: typeof ApiV1ReportsReportIdRoute
@@ -939,6 +952,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1PromptsPromptIdSnapshotRouteImport
       parentRoute: typeof ApiV1PromptsPromptIdRoute
     }
+    '/api/v1/brands/$brandId/visibility': {
+      id: '/api/v1/brands/$brandId/visibility'
+      path: '/visibility'
+      fullPath: '/api/v1/brands/$brandId/visibility'
+      preLoaderRoute: typeof ApiV1BrandsBrandIdVisibilityRouteImport
+      parentRoute: typeof ApiV1BrandsBrandIdRoute
+    }
     '/_authed/app/$brand/settings/prompts': {
       id: '/_authed/app/$brand/settings/prompts'
       path: '/settings/prompts'
@@ -1095,6 +1115,17 @@ const AuthedRouteChildren: AuthedRouteChildren = {
 const AuthedRouteWithChildren =
   AuthedRoute._addFileChildren(AuthedRouteChildren)
 
+interface ApiV1BrandsBrandIdRouteChildren {
+  ApiV1BrandsBrandIdVisibilityRoute: typeof ApiV1BrandsBrandIdVisibilityRoute
+}
+
+const ApiV1BrandsBrandIdRouteChildren: ApiV1BrandsBrandIdRouteChildren = {
+  ApiV1BrandsBrandIdVisibilityRoute: ApiV1BrandsBrandIdVisibilityRoute,
+}
+
+const ApiV1BrandsBrandIdRouteWithChildren =
+  ApiV1BrandsBrandIdRoute._addFileChildren(ApiV1BrandsBrandIdRouteChildren)
+
 interface ApiV1PromptsPromptIdRouteChildren {
   ApiV1PromptsPromptIdSnapshotRoute: typeof ApiV1PromptsPromptIdSnapshotRoute
 }
@@ -1116,7 +1147,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiManifestIndexRoute: ApiManifestIndexRoute,
   ApiOgIndexRoute: ApiOgIndexRoute,
   ApiSetupStatusIndexRoute: ApiSetupStatusIndexRoute,
-  ApiV1BrandsBrandIdRoute: ApiV1BrandsBrandIdRoute,
+  ApiV1BrandsBrandIdRoute: ApiV1BrandsBrandIdRouteWithChildren,
   ApiV1CompetitorsCompetitorIdRoute: ApiV1CompetitorsCompetitorIdRoute,
   ApiV1PromptsPromptIdRoute: ApiV1PromptsPromptIdRouteWithChildren,
   ApiV1ReportsReportIdRoute: ApiV1ReportsReportIdRoute,

--- a/apps/web/src/routes/api/v1/brands/$brandId/visibility.ts
+++ b/apps/web/src/routes/api/v1/brands/$brandId/visibility.ts
@@ -1,0 +1,68 @@
+/**
+ * /api/v1/brands/:brandId/visibility — brand AI-visibility over a date range.
+ *
+ * GET  a daily mention-rate series (LVCF smoothed) plus period totals. Backed
+ *      by the same `getBrandVisibility` computation as the dashboard, so the
+ *      API and the UI never report different numbers.
+ *
+ * Scoped like the other brand endpoints: out-of-scope or nonexistent brands
+ * return an identical 404. A read (GET), so read-only keys may call it.
+ */
+import { createFileRoute } from "@tanstack/react-router";
+import { db } from "@workspace/lib/db/db";
+import { brands } from "@workspace/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { parseDateRange } from "@/lib/api/analytics-range";
+import { ApiError, createApiHandler } from "@/lib/api/handler";
+import { canAccessBrand } from "@/lib/api/scope";
+import { getBrandVisibility } from "@/server/analytics-core";
+
+// Out-of-scope access must 404 exactly like a nonexistent brand — same
+// wording as GET /brands/:brandId — so a key can't probe which brands exist.
+function brandNotFound(brandId: string): ApiError {
+	return new ApiError(404, "Not Found", `Brand "${brandId}" not found.`);
+}
+
+export const Route = createFileRoute("/api/v1/brands/$brandId/visibility")({
+	server: {
+		handlers: {
+			GET: createApiHandler({
+				handle: async ({ params, request, auth }) => {
+					const { brandId } = params;
+					if (!canAccessBrand(auth, brandId)) {
+						throw brandNotFound(brandId);
+					}
+					const brand = await db.query.brands.findFirst({
+						where: eq(brands.id, brandId),
+						columns: { id: true },
+					});
+					if (!brand) {
+						throw brandNotFound(brandId);
+					}
+
+					const { searchParams } = new URL(request.url);
+					const range = parseDateRange(searchParams);
+
+					const result = await getBrandVisibility({
+						brandId,
+						fromDate: range.from,
+						toDate: range.to,
+						timezone: range.timezone,
+						model: searchParams.get("model") || undefined,
+						tags: searchParams.get("tags") || undefined,
+					});
+
+					return {
+						brandId,
+						range,
+						currentVisibility: result.currentVisibility,
+						totalRuns: result.totalRuns,
+						totalPrompts: result.totalPrompts,
+						totalCitations: result.totalCitations,
+						series: result.series,
+					};
+				},
+			}),
+		},
+	},
+});

--- a/apps/web/src/server/analytics-core.ts
+++ b/apps/web/src/server/analytics-core.ts
@@ -1,0 +1,108 @@
+/**
+ * Edge-agnostic analytics computations shared by the dashboard server
+ * functions and the `/api/v1` REST endpoints.
+ *
+ * Like `prompt-resolution.ts` and `onboarding-core.ts`, these functions take an
+ * already-authorized brand id (never a session or Request) and return plain
+ * data. Callers authorize at the edge — server functions via `requireOrgAccess`,
+ * REST handlers via the API-key scope check — so the exact same computation
+ * backs the dashboard and the API and the two can't drift.
+ *
+ * This module is imported only from server-fn handlers and server-only route
+ * files, keeping `db` (→ pg → Buffer) out of the client bundle. See issue #68
+ * and the note in `prompt-resolution.ts`.
+ */
+
+import { getEffectiveBrandedStatus } from "@workspace/lib/tag-utils";
+import { getCitationsTotalCount, getVisibilityDailyAggregate } from "@/lib/postgres-read";
+import { resolveFilteredPrompts } from "@/server/prompt-resolution";
+
+export interface VisibilityPoint {
+	date: string;
+	/** Brand mention rate for the day (0–100), or null when no runs were plotted. */
+	visibility: number | null;
+}
+
+export interface BrandVisibility {
+	/** Latest plotted mention rate (the right end of the trend), 0–100. */
+	currentVisibility: number;
+	totalRuns: number;
+	totalPrompts: number;
+	totalCitations: number;
+	series: VisibilityPoint[];
+}
+
+export interface BrandVisibilityOptions {
+	brandId: string;
+	/** Inclusive date bounds, `YYYY-MM-DD`, already resolved by the caller. */
+	fromDate: string;
+	toDate: string;
+	/** IANA timezone the day buckets are computed in. Defaults to UTC. */
+	timezone?: string;
+	/** Restrict to a single model/platform (e.g. "chatgpt"). */
+	model?: string;
+	/** Comma-separated tag filter, matching the dashboard's prompt list. */
+	tags?: string;
+	/** Case-insensitive substring filter on prompt text. */
+	search?: string;
+}
+
+/**
+ * Brand AI-visibility over a date range: a daily mention-rate series (LVCF
+ * smoothed so gaps in individual prompt schedules don't scallop the line) plus
+ * period totals. `currentVisibility` is the last non-null point so a headline
+ * number matches the right end of the series.
+ *
+ * Extracted verbatim from the dashboard's `getFilteredVisibilityFn` so both
+ * edges return identical numbers — the only differences there are the session
+ * auth (moved to the caller) and lookback→date resolution (also the caller's).
+ */
+export async function getBrandVisibility(opts: BrandVisibilityOptions): Promise<BrandVisibility> {
+	const { brandId, fromDate, toDate, timezone = "UTC", model, tags, search } = opts;
+
+	const resolvedPrompts = await resolveFilteredPrompts(brandId, { tags, search });
+	const promptIds = resolvedPrompts.map((p) => p.id);
+	const totalPrompts = promptIds.length;
+
+	if (totalPrompts === 0) {
+		return { currentVisibility: 0, totalRuns: 0, totalPrompts: 0, totalCitations: 0, series: [] };
+	}
+
+	const brandedPromptIds = resolvedPrompts
+		.filter((p) => getEffectiveBrandedStatus(p.systemTags, p.tags).isBranded)
+		.map((p) => p.id);
+
+	const [daily, totalCitations] = await Promise.all([
+		getVisibilityDailyAggregate(brandId, fromDate, toDate, timezone, promptIds, brandedPromptIds, model),
+		getCitationsTotalCount(brandId, fromDate, toDate, timezone, promptIds, model),
+	]);
+
+	// Period run totals come from the raw observation sums (actual_*); the series
+	// uses the per-day LVCF sums so schedule gaps don't scallop the line.
+	let totalBrandedRuns = 0;
+	let totalNonBrandedRuns = 0;
+	const series: VisibilityPoint[] = daily.map((row) => {
+		totalBrandedRuns += row.actual_branded_runs;
+		totalNonBrandedRuns += row.actual_nonbranded_runs;
+		const t = row.lvcf_branded_runs + row.lvcf_nonbranded_runs;
+		const m = row.lvcf_branded_mentioned + row.lvcf_nonbranded_mentioned;
+		return { date: row.date, visibility: t === 0 ? null : Math.round((m / t) * 100) };
+	});
+
+	let currentVisibility = 0;
+	for (let i = series.length - 1; i >= 0; i--) {
+		const v = series[i].visibility;
+		if (v != null) {
+			currentVisibility = v;
+			break;
+		}
+	}
+
+	return {
+		currentVisibility,
+		totalRuns: totalBrandedRuns + totalNonBrandedRuns,
+		totalPrompts,
+		totalCitations,
+		series,
+	};
+}

--- a/apps/web/src/server/visibility.ts
+++ b/apps/web/src/server/visibility.ts
@@ -5,21 +5,16 @@
  *   - apps/web/src/app/api/brands/[id]/filtered-visibility/route.ts
  */
 import { createServerFn } from "@tanstack/react-start";
-import { z } from "zod";
-import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
 import { db } from "@workspace/lib/db/db";
 import { brands, competitors } from "@workspace/lib/db/schema";
 import { eq } from "drizzle-orm";
-import { type LookbackPeriod } from "@/lib/chart-utils";
+import { z } from "zod";
+import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
+import type { LookbackPeriod } from "@/lib/chart-utils";
+import { getBatchChartData, type ProcessedBatchChartDataPoint } from "@/lib/postgres-read";
 import { getTimezoneLookbackRange, resolveTimezone } from "@/lib/timezone-utils";
+import { getBrandVisibility } from "@/server/analytics-core";
 import { resolveFilteredPrompts } from "@/server/prompt-resolution";
-import {
-	getBatchChartData,
-	getVisibilityDailyAggregate,
-	getCitationsTotalCount,
-	type ProcessedBatchChartDataPoint,
-} from "@/lib/postgres-read";
-import { getEffectiveBrandedStatus } from "@workspace/lib/tag-utils";
 
 // ============================================================================
 // Types
@@ -93,11 +88,7 @@ export const getBatchChartDataFn = createServerFn({ method: "GET" })
 
 		// Get brand and competitors from PostgreSQL
 		const [brandResult, competitorsResult] = await Promise.all([
-			db
-				.select({ id: brands.id, name: brands.name })
-				.from(brands)
-				.where(eq(brands.id, data.brandId))
-				.limit(1),
+			db.select({ id: brands.id, name: brands.name }).from(brands).where(eq(brands.id, data.brandId)).limit(1),
 			db
 				.select({ id: competitors.id, name: competitors.name })
 				.from(competitors)
@@ -160,88 +151,32 @@ export const getFilteredVisibilityFn = createServerFn({ method: "GET" })
 
 		await requireOrgAccess(session.user.id, data.brandId);
 
-		// Resolve the in-scope prompts server-side from the filter criteria so
-		// the client never ships the full prompt-id list (issue #68).
-		const resolvedPrompts = await resolveFilteredPrompts(data.brandId, {
-			tags: data.tags,
-			search: data.search,
-		});
-		const promptIds = resolvedPrompts.map((p) => p.id);
-		const totalPrompts = promptIds.length;
-
-		if (totalPrompts === 0) {
-			return {
-				currentVisibility: 0,
-				totalRuns: 0,
-				totalPrompts: 0,
-				totalCitations: 0,
-				visibilityTimeSeries: [],
-				lookback: lookbackParam,
-			};
-		}
-
 		const timezone = resolveTimezone(data.timezone);
-
-		// Determine branded prompt IDs from effective branded status
-		const brandedPromptIds = resolvedPrompts
-			.filter((p) => getEffectiveBrandedStatus(p.systemTags, p.tags).isBranded)
-			.map((p) => p.id);
 
 		// `allStrategy: "1y"` caps the "all" lookback at a one-year window so
 		// the visibility bar matches the chart section. Every other lookback
 		// already returns concrete bounds, so we can destructure without
 		// null-checking.
-		const { fromDateStr: fromDate, toDateStr: toDate } = getTimezoneLookbackRange(
-			lookbackParam,
+		const { fromDateStr: fromDate, toDateStr: toDate } = getTimezoneLookbackRange(lookbackParam, timezone, {
+			allStrategy: "1y",
+		}) as { fromDateStr: string; toDateStr: string };
+
+		const result = await getBrandVisibility({
+			brandId: data.brandId,
+			fromDate,
+			toDate,
 			timezone,
-			{ allStrategy: "1y" },
-		) as { fromDateStr: string; toDateStr: string };
-
-		const [daily, totalCitations] = await Promise.all([
-			getVisibilityDailyAggregate(
-				data.brandId,
-				fromDate,
-				toDate,
-				timezone,
-				promptIds,
-				brandedPromptIds,
-				data.model,
-			),
-			getCitationsTotalCount(data.brandId, fromDate, toDate, timezone, promptIds, data.model),
-		]);
-
-		// Roll the period run totals from the raw observation sums (actual_*);
-		// the visibility time-series uses the per-day LVCF sums so gaps in
-		// individual prompt schedules don't scallop the line.
-		let totalBrandedRuns = 0;
-		let totalNonBrandedRuns = 0;
-		const visibilityTimeSeries: VisibilityTimeSeriesPoint[] = daily.map((row) => {
-			totalBrandedRuns += row.actual_branded_runs;
-			totalNonBrandedRuns += row.actual_nonbranded_runs;
-			const t = row.lvcf_branded_runs + row.lvcf_nonbranded_runs;
-			const m = row.lvcf_branded_mentioned + row.lvcf_nonbranded_mentioned;
-			return { date: row.date, visibility: t === 0 ? null : Math.round((m / t) * 100) };
+			model: data.model,
+			tags: data.tags,
+			search: data.search,
 		});
 
-		const totalRuns = totalBrandedRuns + totalNonBrandedRuns;
-		// "Current" = the latest plotted point (last non-null LVCF day), so the headline
-		// number matches the right end of the trend/sparkline beside it — and the
-		// overview's current-visibility hero — rather than the whole-window average.
-		let currentVisibility = 0;
-		for (let i = visibilityTimeSeries.length - 1; i >= 0; i--) {
-			const v = visibilityTimeSeries[i].visibility;
-			if (v != null) {
-				currentVisibility = v;
-				break;
-			}
-		}
-
 		return {
-			currentVisibility,
-			totalRuns,
-			totalPrompts,
-			totalCitations,
-			visibilityTimeSeries,
+			currentVisibility: result.currentVisibility,
+			totalRuns: result.totalRuns,
+			totalPrompts: result.totalPrompts,
+			totalCitations: result.totalCitations,
+			visibilityTimeSeries: result.series,
 			lookback: lookbackParam,
 		};
 	});

--- a/e2e/tests/api.spec.ts
+++ b/e2e/tests/api.spec.ts
@@ -248,3 +248,61 @@ test.describe("External API - CRUD Operations", () => {
     expect(getResponse.status()).toBe(404);
   });
 });
+
+test.describe("External API - GET /api/v1/brands/:brandId/visibility", () => {
+  // Wide window so it safely covers the seeded prompt runs, which are
+  // inserted relative to "now" rather than at fixed dates.
+  const FROM = "2020-01-01";
+  const TO = "2030-01-01";
+
+  test("returns 400 when from/to are missing", async ({ request }) => {
+    const response = await request.get(`/api/v1/brands/${BRAND_ID}/visibility`, {
+      headers: authHeaders(),
+    });
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+    expect(body.error).toBe("Validation Error");
+  });
+
+  test("returns 200 with visibility series and totals for a valid range", async ({ request }) => {
+    const response = await request.get(`/api/v1/brands/${BRAND_ID}/visibility?from=${FROM}&to=${TO}`, {
+      headers: authHeaders(),
+    });
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body.brandId).toBe(BRAND_ID);
+
+    expect(body.range).toBeDefined();
+    expect(body.range.from).toBe(FROM);
+    expect(body.range.to).toBe(TO);
+    expect(body.range.timezone).toBe("UTC");
+
+    expect(typeof body.currentVisibility).toBe("number");
+    expect(typeof body.totalRuns).toBe("number");
+    expect(typeof body.totalPrompts).toBe("number");
+    expect(typeof body.totalCitations).toBe("number");
+
+    expect(Array.isArray(body.series)).toBeTruthy();
+    for (const point of body.series) {
+      expect(point).toHaveProperty("date");
+      expect(point).toHaveProperty("visibility");
+    }
+  });
+
+  test("returns 404 for a non-existent brand", async ({ request }) => {
+    const response = await request.get(`/api/v1/brands/does-not-exist/visibility?from=${FROM}&to=${TO}`, {
+      headers: authHeaders(),
+    });
+    expect(response.status()).toBe(404);
+
+    const body = await response.json();
+    expect(body.error).toBe("Not Found");
+  });
+
+  test("returns 401 without an API key", async ({ request }) => {
+    const response = await request.get(`/api/v1/brands/${BRAND_ID}/visibility?from=${FROM}&to=${TO}`);
+    expect(response.status()).toBe(401);
+  });
+});

--- a/packages/api-spec/src/openapi.json
+++ b/packages/api-spec/src/openapi.json
@@ -775,6 +775,97 @@
           }
         }
       },
+      "VisibilityPoint": {
+        "type": "object",
+        "description": "One day's plotted mention rate. LVCF-smoothed: a day with no runs carries forward as `null` rather than dropping to zero.",
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Day this point represents (YYYY-MM-DD), in the requested timezone"
+          },
+          "visibility": {
+            "type": "number",
+            "nullable": true,
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Brand mention rate for the day (0-100), or null when no runs were plotted that day"
+          }
+        },
+        "required": [
+          "date",
+          "visibility"
+        ]
+      },
+      "BrandVisibility": {
+        "type": "object",
+        "description": "Brand AI-visibility over a date range: a daily mention-rate series (LVCF-smoothed) plus period totals. Backed by the same computation as the dashboard's visibility chart, so the API and the UI never report different numbers.",
+        "properties": {
+          "brandId": {
+            "type": "string",
+            "description": "Brand identifier"
+          },
+          "range": {
+            "type": "object",
+            "description": "The resolved date range the response covers",
+            "properties": {
+              "from": {
+                "type": "string",
+                "format": "date",
+                "description": "Inclusive start of the window (YYYY-MM-DD)"
+              },
+              "to": {
+                "type": "string",
+                "format": "date",
+                "description": "Inclusive end of the window (YYYY-MM-DD)"
+              },
+              "timezone": {
+                "type": "string",
+                "description": "IANA timezone the day buckets were computed in"
+              }
+            },
+            "required": [
+              "from",
+              "to",
+              "timezone"
+            ]
+          },
+          "currentVisibility": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "The latest plotted mention rate (the right end of the series), 0-100"
+          },
+          "totalRuns": {
+            "type": "integer",
+            "description": "Total number of prompt runs across the window"
+          },
+          "totalPrompts": {
+            "type": "integer",
+            "description": "Total number of prompts included in the window"
+          },
+          "totalCitations": {
+            "type": "integer",
+            "description": "Total number of citations across the window"
+          },
+          "series": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VisibilityPoint"
+            },
+            "description": "Daily mention-rate series covering the requested range"
+          }
+        },
+        "required": [
+          "brandId",
+          "range",
+          "currentVisibility",
+          "totalRuns",
+          "totalPrompts",
+          "totalCitations",
+          "series"
+        ]
+      },
       "PromptSnapshot": {
         "type": "object",
         "properties": {
@@ -1170,6 +1261,130 @@
           },
           "403": {
             "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      }
+    },
+    "/brands/{brandId}/visibility": {
+      "get": {
+        "summary": "Get brand visibility over time",
+        "description": "Brand AI-visibility over a date range: a daily mention-rate series (LVCF-smoothed so gaps don't scallop the line) plus period totals. Backed by the same computation as the dashboard's visibility chart, so the API and the UI never report different numbers. The first of a planned set of analytics endpoints exposing dashboard metrics via the API. Dashboard keys only see brands within their scope; resources outside that scope return 404, identical to a nonexistent brand.",
+        "operationId": "getBrandVisibility",
+        "tags": [
+          "Analytics"
+        ],
+        "parameters": [
+          {
+            "name": "brandId",
+            "in": "path",
+            "required": true,
+            "description": "Brand identifier",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": true,
+            "description": "Inclusive start of the date range (YYYY-MM-DD)",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "example": "2026-06-01"
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": true,
+            "description": "Inclusive end of the date range (YYYY-MM-DD)",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "example": "2026-06-30"
+          },
+          {
+            "name": "timezone",
+            "in": "query",
+            "required": false,
+            "description": "IANA timezone the day buckets are computed in",
+            "schema": {
+              "type": "string",
+              "default": "UTC"
+            },
+            "example": "America/New_York"
+          },
+          {
+            "name": "model",
+            "in": "query",
+            "required": false,
+            "description": "Restrict to a single model/platform",
+            "schema": {
+              "type": "string"
+            },
+            "example": "chatgpt"
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated tag filter, matching the dashboard's prompt list",
+            "schema": {
+              "type": "string"
+            },
+            "example": "branded,pricing"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Brand visibility series and totals for the requested window",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandVisibility"
+                },
+                "example": {
+                  "brandId": "acme",
+                  "range": {
+                    "from": "2026-06-01",
+                    "to": "2026-06-30",
+                    "timezone": "UTC"
+                  },
+                  "currentVisibility": 42,
+                  "totalRuns": 1234,
+                  "totalPrompts": 20,
+                  "totalCitations": 567,
+                  "series": [
+                    {
+                      "date": "2026-06-01",
+                      "visibility": 40
+                    },
+                    {
+                      "date": "2026-06-02",
+                      "visibility": null
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitError"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
           }
         }
       }
@@ -2312,6 +2527,10 @@
     {
       "name": "Snapshots",
       "description": "Aggregated analytics snapshots for prompts"
+    },
+    {
+      "name": "Analytics",
+      "description": "Dashboard metrics (visibility, and more to come) exposed over the API"
     },
     {
       "name": "Reports",

--- a/packages/docs/content/docs/api/index.mdx
+++ b/packages/docs/content/docs/api/index.mdx
@@ -44,7 +44,7 @@ A smaller set of endpoints are **admin-only** and require an instance-admin key 
 - `GET /reports/{reportId}`
 - `POST /tools/analyze`
 
-Everything else — `GET /brands`, `GET`/`PATCH /brands/{brandId}`, all `/prompts` and `/competitors` endpoints, and `GET /prompts/{promptId}/snapshot` — works with dashboard keys, scoped as described above.
+Everything else — `GET /brands`, `GET`/`PATCH /brands/{brandId}`, all `/prompts` and `/competitors` endpoints, `GET /prompts/{promptId}/snapshot`, and `GET /brands/{brandId}/visibility` — works with dashboard keys, scoped as described above.
 
 ### Read-only keys
 
@@ -89,4 +89,5 @@ Browse the available endpoints in the sidebar, grouped by resource:
 - **Prompts** — manage brand prompts
 - **Competitors** — manage brand competitors
 - **Snapshots** — aggregated analytics snapshots for prompts
+- **Analytics** — dashboard metrics (visibility, and more to come) exposed over the API
 - **Reports** — generate and retrieve AI Share of Voice reports


### PR DESCRIPTION
## Comprehensive API, part 1: analytics endpoints — `GET /brands/{id}/visibility`

First step toward a comprehensive production API (#22). Today `/api/v1` is CRUD on brands/prompts/competitors plus one prompt snapshot — but elmo computes a rich analytics layer for its dashboard (visibility over time, share of voice, citation sources, competitor leaderboards, per-model breakdown, query fan-out) that the API doesn't expose at all. This PR adds the first of those endpoints and establishes the conventions the rest will follow.

> Stacked on #403 (the API-key auth work) — it reuses that PR's scope helpers and read-only enforcement. Review/merge #403 first; this PR's base is `jrhizor/elmo-api-keys-external-api`, so its own diff is just the commit below.

### The endpoint

`GET /api/v1/brands/{brandId}/visibility?from=YYYY-MM-DD&to=YYYY-MM-DD[&timezone=&model=&tags=]`

```json
{
  "brandId": "acme",
  "range": { "from": "2026-06-01", "to": "2026-06-30", "timezone": "UTC" },
  "currentVisibility": 42,
  "totalRuns": 1234,
  "totalPrompts": 20,
  "totalCitations": 567,
  "series": [
    { "date": "2026-06-01", "visibility": 40 },
    { "date": "2026-06-02", "visibility": null }
  ]
}
```

A daily LVCF-smoothed mention-rate series (0–100, `null` on days with no plotted runs) plus period totals. `currentVisibility` is the latest plotted point — the same number the dashboard's hero shows.

### Numbers can't drift from the dashboard

The visibility computation (LVCF smoothing, branded/non-branded prompt classification, "current = last plotted point") is **extracted verbatim** from the dashboard's `getFilteredVisibilityFn` into an edge-agnostic `analytics-core.getBrandVisibility`, which both the server function and the new REST route now call. The server fn is a thin wrapper (auth + lookback→date resolution); the REST route is a thin wrapper (scope + date-param parsing). This is the #331 service-layer pattern applied to analytics — the API physically cannot return different numbers than the UI.

### Conventions this locks for the remaining analytics endpoints

- **Path**: `/api/v1/brands/{brandId}/{metric}`.
- **Scope**: brand-scoped, reusing #403's auth. Out-of-scope *and* nonexistent brands both return an identical `404` (`Brand "<id>" not found.`) so a key can't probe which brands exist. Works with dashboard keys scoped to the brand; read-only keys work (it's a GET).
- **Date window**: a shared `parseDateRange` helper — `from`/`to` (required, `YYYY-MM-DD`), optional `timezone` (default UTC) — validated in one place (unit-tested), `400` on missing/malformed/`from>to`.
- **Filters**: optional `model`, `tags`.
- **Envelope**: `{ brandId, range, ...totals, series }`.

### What's next (this PR is deliberately one endpoint)

The same pattern extends to: `share-of-voice`, `sources` (citation domains/URLs), `competitors` (mention leaderboard), `models` (per-platform visibility), `fan-out`, per-prompt `stats`/`visibility`, and a brand `summary`. Each is a thin route over an extracted `analytics-core` function. Shipping one first lets us settle the response/param conventions before fanning out.

### Testing

- `parseDateRange` unit tests (valid/default tz/equal-day/missing/malformed incl. rollover dates like `2026-13-01`/`from>to`).
- e2e cases: `400` on missing dates, `200` shape for the seeded brand, `404` for a nonexistent brand, `401` without a key.
- The dashboard server-fn refactor is behavior-preserving (same output shape, same computation). `check-types`, full unit suite, production build, and `license-check` all green.
- OpenAPI spec (new `Analytics` tag + `BrandVisibility`/`VisibilityPoint` schemas), API docs, and a changeset included.

Toward #22. Related: #331 (this establishes the shared-analytics-core pattern the CRUD service layer will follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
