### PR TITLE
improve competitor screenshot capture (overwrite + verify)

### DIFF
--- a/.claude/skills/add-competitor/SKILL.md
+++ b/.claude/skills/add-competitor/SKILL.md
@@ -74,6 +74,14 @@ This requires `SCREENSHOT_ONE_ACCESS_KEY` and `BLOB_READ_WRITE_TOKEN` in `apps/w
 
 If the script fails, inform the user and continue with the data entry — the screenshot can be added later.
 
+**Verify the capture — don't trust it blindly.** ScreenshotOne uploads whatever the site serves, and sites with bot protection (Cloudflare, etc.) frequently return a captcha or block page to the headless browser, which then gets stored as the "screenshot." After a successful upload, download the blob URL the script printed and actually view the image:
+
+```bash
+curl -s -o /tmp/<slug>.jpg "<blob URL printed by the script>"
+```
+
+Open `/tmp/<slug>.jpg` and confirm it's genuinely the competitor's homepage/product — **not** a bot challenge ("Checking your browser…", "Select all squares with…", "verify you are human"), an access-denied / 403 page, or a blank/error page. If it's a challenge or error page, do NOT keep it: tell the user automated capture was blocked and ask them to send a real screenshot to upload manually (the script sets `allowOverwrite: true`, so re-uploading replaces the bad image).
+
 ## 6. Insert into data.ts
 
 Read `apps/www/src/lib/competitors/data.ts` and insert the new `Competitor` object into the `competitors` array (position in this array doesn't matter for display order).

--- a/apps/www/scripts/screenshot-competitor.mjs
+++ b/apps/www/scripts/screenshot-competitor.mjs
@@ -83,6 +83,7 @@ const blob = await put(`screenshots/${slug}.jpg`, Buffer.from(imageBuffer), {
 	access: "public",
 	contentType: "image/jpeg",
 	addRandomSuffix: false,
+	allowOverwrite: true,
 });
 
 console.log(`Uploaded: ${blob.url}`);


### PR DESCRIPTION
## What
- **`apps/www/scripts/screenshot-competitor.mjs`** — set `allowOverwrite: true` on the Vercel Blob `put`. `@vercel/blob` v2 rejects overwriting an existing blob without it, so re-capturing an already-listed competitor (or manually re-uploading a fixed image) previously failed at the upload step.
- **`add-competitor` skill** — add a "verify the capture" step: after upload, download the blob and actually view it, and reject bot-challenge pages ("Checking your browser…", "Select all squares with…"), 403 / access-denied, and blank/error pages. If blocked, ask the user for a manual screenshot.

## Why
The Semrush comparison page (`/ai-visibility-tools/elmo-vs-semrush-ai-toolkit`) was showing a Cloudflare "select all squares with tractors" captcha instead of a screenshot — ScreenshotOne got bot-challenged capturing `semrush.com` and the script uploaded the challenge page as-is. Nothing in the pipeline caught it.

## Screenshots themselves (already fixed out-of-band; they live in Vercel Blob, not the repo)
- **Semrush** — replaced the captcha with a real screenshot of the AI Visibility / Brand Performance page.
- **scope** — had no screenshot at all (blob 404'd); captured and uploaded.
- Scanned all 108 competitor screenshots via OCR — Semrush was the only captcha.

Tooling/skill only — no changeset needed.