### PR TITLE
align overview trend charts to a shared date window

### DIFF
--- a/.changeset/overview-chart-xaxis.md
+++ b/.changeset/overview-chart-xaxis.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Ensure the overview charts use the same timezone-specific x-axis.

--- a/apps/web/src/hooks/use-dashboard-summary.tsx
+++ b/apps/web/src/hooks/use-dashboard-summary.tsx
@@ -17,7 +17,14 @@ export function useDashboardSummary(brandId?: string, lookback: LookbackPeriod =
 
 	const query = useQuery({
 		queryKey: dashboardKeys.summary(resolvedBrandId || "", lookback),
-		queryFn: () => getDashboardSummaryFn({ data: { brandId: resolvedBrandId!, lookback } }),
+		queryFn: () =>
+			getDashboardSummaryFn({
+				data: {
+					brandId: resolvedBrandId!,
+					lookback,
+					timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+				},
+			}),
 		enabled: !!resolvedBrandId,
 		staleTime: 30_000,
 		refetchOnWindowFocus: true,

--- a/apps/web/src/server/dashboard.ts
+++ b/apps/web/src/server/dashboard.ts
@@ -8,7 +8,8 @@ import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
 import { db } from "@workspace/lib/db/db";
 import { prompts, competitors, brands } from "@workspace/lib/db/schema";
 import { eq, and, count } from "drizzle-orm";
-import { generateDateRange, getDaysFromLookback, applyPerPromptLVCF, applyPerPromptCitationLVCF, type LookbackPeriod } from "@/lib/chart-utils";
+import { generateDateRange, applyPerPromptLVCF, applyPerPromptCitationLVCF, type LookbackPeriod } from "@/lib/chart-utils";
+import { getTimezoneLookbackRange, resolveTimezone } from "@/lib/timezone-utils";
 import {
 	getDashboardSummary,
 	getPerPromptVisibilityTimeSeries,
@@ -50,6 +51,7 @@ export const getDashboardSummaryFn = createServerFn({ method: "GET" })
 		z.object({
 			brandId: z.string(),
 			lookback: z.enum(["1w", "1m", "3m", "6m", "1y", "all"]).default("1m"),
+			timezone: z.string().default("UTC"),
 		}),
 	)
 	.handler(async ({ data }): Promise<DashboardSummaryResponse> => {
@@ -57,18 +59,14 @@ export const getDashboardSummaryFn = createServerFn({ method: "GET" })
 		await requireOrgAccess(session.user.id, data.brandId);
 
 		const lookbackParam = data.lookback as LookbackPeriod;
-		const timezone = "UTC";
+		const timezone = resolveTimezone(data.timezone);
 
-		let fromDateStr: string | null = null;
-		let toDateStr: string | null = null;
-
-		if (lookbackParam !== "all") {
-			const toDate = new Date();
-			const fromDate = new Date(toDate);
-			fromDate.setDate(fromDate.getDate() - getDaysFromLookback(lookbackParam));
-			fromDateStr = fromDate.toISOString().split("T")[0];
-			toDateStr = toDate.toISOString().split("T")[0];
-		}
+		// Same timezone-aware window as the visibility and share-of-voice pages, so
+		// the overview's two trend charts share one date domain (issue #413).
+		// `allStrategy: "1y"` keeps the bounds concrete for every lookback, incl. "all".
+		const { fromDateStr, toDateStr } = getTimezoneLookbackRange(lookbackParam, timezone, {
+			allStrategy: "1y",
+		}) as { fromDateStr: string; toDateStr: string };
 
 		// Get brand info, competitors, and prompts from PostgreSQL
 		const [brandResult, competitorsList, enabledPromptsResult, totalPromptsResult] = await Promise.all([
@@ -94,9 +92,7 @@ export const getDashboardSummaryFn = createServerFn({ method: "GET" })
 		const [summaryResult, perPromptVisibility, perPromptCitations] = await Promise.all([
 			getDashboardSummary(data.brandId, fromDateStr, toDateStr, timezone, enabledPromptIds),
 			getPerPromptVisibilityTimeSeries(data.brandId, fromDateStr, toDateStr, timezone, enabledPromptIds),
-			fromDateStr && toDateStr
-				? getPerPromptDailyCitationStats(data.brandId, fromDateStr, toDateStr, timezone, enabledPromptIds)
-				: Promise.resolve([]),
+			getPerPromptDailyCitationStats(data.brandId, fromDateStr, toDateStr, timezone, enabledPromptIds),
 		]);
 
 		// Process summary
@@ -104,20 +100,9 @@ export const getDashboardSummaryFn = createServerFn({ method: "GET" })
 		const totalRuns = summary ? Number(summary.total_runs) : 0;
 		const lastUpdatedAt = summary?.last_updated || null;
 
-		// Generate date range (needed for LVCF before processing visibility)
-		const rawDates = perPromptVisibility.map((r) => String(r.date)).sort();
-		let startDate: Date, endDate: Date;
-		if (lookbackParam === "all" && rawDates.length > 0) {
-			startDate = new Date(rawDates[0]);
-			endDate = new Date(rawDates[rawDates.length - 1]);
-		} else {
-			const daysToSubtract = getDaysFromLookback(lookbackParam);
-			const currentDateInTimezone = new Date().toLocaleDateString("en-CA", { timeZone: timezone });
-			endDate = new Date(currentDateInTimezone);
-			startDate = new Date(endDate);
-			startDate.setDate(startDate.getDate() - (daysToSubtract - 1));
-		}
-		const dateRange = generateDateRange(startDate, endDate);
+		// Same window as the DB queries above (and as share-of-voice), so LVCF
+		// smoothing and the emitted series cover exactly this date domain.
+		const dateRange = generateDateRange(new Date(fromDateStr), new Date(toDateStr));
 
 		// Process visibility via per-prompt LVCF smoothing
 		const {


### PR DESCRIPTION
Fixes #413.

## Problem

On the dashboard overview, the **AI Visibility** and **Share of Voice** trend charts showed different x-axis date labels even though they cover the same period — e.g. the Visibility axis running `Apr 18 … Jul 7` while Share of Voice ran `Apr 6 … Jul 6` (see the screenshot on #413).

## Root cause

The two charts render through the same `TrendChart` component, but their data comes from two server functions that computed the date window **independently**:

- **Visibility** (`getDashboardSummaryFn`) used a hardcoded `"UTC"` timezone and a fixed `today - getDaysFromLookback()` window.
- **Share of Voice** (`getShareOfVoiceFn`) used the **client** timezone and calendar-based `getTimezoneLookbackRange()` — the same helper the standalone Visibility page already uses.

So the two series spanned different dates (different timezone → different "today"; fixed-day vs. calendar-month math → different span). `TrendChart`'s x-axis is categorical with `minTickGap={50}`, so recharts auto-selects ticks from each series' own points — different domains produce different tick dates.

## Fix

Make `getDashboardSummaryFn` resolve its window exactly like `server/visibility.ts` and `getShareOfVoiceFn`: client timezone + `getTimezoneLookbackRange(lookback, tz, { allStrategy: "1y" })`, threaded through from `useDashboardSummary`. Both overview series are then built over an identical `dateRange`, so the two charts render identical x-axis labels. As a bonus, the overview's visibility chart is now consistent with the dedicated **Visibility** page (which the "View Visibility" link goes to), and the duplicated hand-rolled date math in `dashboard.ts` is removed.

Blast radius is small: `getDashboardSummaryFn` is only consumed by the overview page.

## Testing

- `tsc --noEmit` passes.
- `vitest run --project=unit` — 206 passed.
- `biome lint` on the touched files reports only two pre-existing warnings (unchanged by this PR).