### PR TITLE
feat(cloud): implement the cloud deployment mode

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { Link } from "@tanstack/react-router";
+import { Link, useRouteContext } from "@tanstack/react-router";
+import type { ClientConfig } from "@workspace/config/types";
 import {
 	IconDashboard,
 	IconChartBar,
@@ -45,8 +46,11 @@ interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
 
 export function AppSidebar({ isAdmin = false, hasReportAccess = false, adminOnly = false, brand, ...props }: AppSidebarProps) {
 	const { setOpenMobile } = useSidebar();
+	const context = useRouteContext({ strict: false }) as { clientConfig?: ClientConfig };
+	// Reports are disabled entirely in cloud; hide the nav entry there.
+	const reportsEnabled = context.clientConfig?.features.reportGeneration ?? true;
 
-	const showAdminSection = isAdmin || hasReportAccess;
+	const showAdminSection = isAdmin || (hasReportAccess && reportsEnabled);
 
 	const groups: NavGroup[] = [];
 
@@ -128,6 +132,12 @@ export function AppSidebar({ isAdmin = false, hasReportAccess = false, adminOnly
 
 	// Admin section
 	if (showAdminSection) {
+		const reportsItem = {
+			title: "Reports",
+			url: "/reports",
+			icon: IconReport,
+			absolute: true,
+		};
 		const adminItems = isAdmin
 			? [
 					{
@@ -136,12 +146,7 @@ export function AppSidebar({ isAdmin = false, hasReportAccess = false, adminOnly
 						icon: IconTable,
 						absolute: true,
 					},
-					{
-						title: "Reports",
-						url: "/reports",
-						icon: IconReport,
-						absolute: true,
-					},
+					...(reportsEnabled ? [reportsItem] : []),
 					{
 						title: "Workflows",
 						url: "/admin/workflows",
@@ -155,14 +160,7 @@ export function AppSidebar({ isAdmin = false, hasReportAccess = false, adminOnly
 						absolute: true,
 					},
 				]
-			: [
-					{
-						title: "Reports",
-						url: "/reports",
-						icon: IconReport,
-						absolute: true,
-					},
-				];
+			: [reportsItem];
 
 		groups.push({
 			label: "Admin",

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -73,6 +73,9 @@ declare global {
 			readonly SENTRY_PROJECT?: string;
 			readonly SENTRY_AUTH_TOKEN?: string;
 			readonly DISABLE_TELEMETRY?: string;
+			readonly STRIPE_SECRET_KEY?: string;
+			readonly STRIPE_WEBHOOK_SECRET?: string;
+			readonly RESEND_API_KEY?: string;
 		}
 	}
 }

--- a/apps/web/src/lib/auth/helpers.ts
+++ b/apps/web/src/lib/auth/helpers.ts
@@ -5,6 +5,7 @@ import { getRequestHeaders } from "@tanstack/react-start/server";
 import { db } from "@workspace/lib/db/db";
 import { member, organization } from "@workspace/lib/db/schema";
 import { eq, and } from "drizzle-orm";
+import { getDeployment } from "@/lib/config/server";
 import { auth } from "./server";
 
 type SessionLike = { user: { id: string; [key: string]: unknown }; session?: unknown };
@@ -25,6 +26,9 @@ export function isAdmin(session: SessionLike): boolean {
 }
 
 export function hasReportAccess(session: SessionLike): boolean {
+	// Report generation is disabled entirely in deployments that don't support
+	// it (cloud), so the per-user flag is ignored there.
+	if (!getDeployment().features.reportGeneration) return false;
 	return session.user.hasReportGeneratorAccess === true;
 }
 

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -49,6 +49,12 @@ function getDeploymentAuthOptions(): CreateAuthOptions | undefined {
 			// bootstrapped in local mode; visitors can only sign in as that
 			// pre-existing user.
 			return { disableSignUp: true };
+		case "cloud":
+			// Public self-serve signup with no single-user guard. Each user
+			// provisions their own org via the create-brand flow (canCreateBrands),
+			// so no user.create hook is needed here. Google OAuth and Resend
+			// email verification are layered on in follow-up cloud work.
+			return {};
 		default:
 			return getLocalAuthOptions();
 	}

--- a/apps/web/src/routes/_authed/reports.tsx
+++ b/apps/web/src/routes/_authed/reports.tsx
@@ -1,11 +1,18 @@
 /**
  * /reports layout route
  *
- * Passthrough layout for the /reports section.
- * Access control is handled at the page level.
+ * Passthrough layout for the /reports section. Per-user access control is
+ * handled at the page level; here we gate the whole subtree on the deployment
+ * feature so cloud (report generation disabled) 404s every /reports/* route,
+ * including the admin-accessible list and the render route.
  */
-import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { createFileRoute, notFound, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_authed/reports")({
+	beforeLoad: ({ context }) => {
+		if (context.clientConfig && !context.clientConfig.features.reportGeneration) {
+			throw notFound();
+		}
+	},
 	component: () => <Outlet />,
 });

--- a/apps/web/src/server/config.ts
+++ b/apps/web/src/server/config.ts
@@ -35,9 +35,10 @@ export const getClientConfig = createServerFn({ method: "GET" }).handler(async (
 
 	const userCount = await countUsers();
 	const hasUsers = userCount > 0;
-	// Register is only reachable in local mode before the first user signs up.
-	// Once the instance is bootstrapped, both the UI and API reject signups.
-	const canRegister = deployment.mode === "local" && !hasUsers;
+	// Cloud is public self-serve, so registration is always open. Otherwise it's
+	// only reachable in local mode before the first user signs up — once the
+	// instance is bootstrapped, both the UI and API reject signups.
+	const canRegister = deployment.features.selfServeSignup || (deployment.mode === "local" && !hasUsers);
 
 	return {
 		mode: deployment.mode,

--- a/apps/web/src/test/mocks/auth.ts
+++ b/apps/web/src/test/mocks/auth.ts
@@ -18,6 +18,9 @@ export const LOCAL_FEATURES: FeaturesConfig = {
 	showOptimizeButton: false,
 	supportsMultiOrg: true,
 	canCreateBrands: true,
+	selfServeSignup: false,
+	billing: false,
+	reportGeneration: true,
 };
 
 export const DEMO_FEATURES: FeaturesConfig = {
@@ -25,6 +28,9 @@ export const DEMO_FEATURES: FeaturesConfig = {
 	showOptimizeButton: false,
 	supportsMultiOrg: true,
 	canCreateBrands: false,
+	selfServeSignup: false,
+	billing: false,
+	reportGeneration: true,
 };
 
 export const WHITELABEL_FEATURES: FeaturesConfig = {
@@ -32,6 +38,19 @@ export const WHITELABEL_FEATURES: FeaturesConfig = {
 	showOptimizeButton: true,
 	supportsMultiOrg: true,
 	canCreateBrands: false,
+	selfServeSignup: false,
+	billing: false,
+	reportGeneration: true,
+};
+
+export const CLOUD_FEATURES: FeaturesConfig = {
+	readOnly: false,
+	showOptimizeButton: false,
+	supportsMultiOrg: true,
+	canCreateBrands: true,
+	selfServeSignup: true,
+	billing: true,
+	reportGeneration: false,
 };
 
 // ============================================================================
@@ -53,12 +72,13 @@ export function createMockSession(overrides: Partial<{ id: string; name: string;
 // Mock Deployment
 // ============================================================================
 
-export type DeploymentMode = "local" | "demo" | "whitelabel";
+export type DeploymentMode = "local" | "demo" | "whitelabel" | "cloud";
 
 const FEATURES_BY_MODE: Record<DeploymentMode, FeaturesConfig> = {
 	local: LOCAL_FEATURES,
 	demo: DEMO_FEATURES,
 	whitelabel: WHITELABEL_FEATURES,
+	cloud: CLOUD_FEATURES,
 };
 
 export interface MockDeploymentOptions {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@sentry/node": "^10.63.0",
+    "@workspace/deployment": "workspace:*",
     "@workspace/lib": "workspace:*",
     "@workspace/whitelabel": "workspace:*",
     "auth0": "^5.13.0",

--- a/apps/worker/src/handlers.ts
+++ b/apps/worker/src/handlers.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/node";
 import type { Job, PgBoss } from "pg-boss";
+import { getDeployment } from "@workspace/deployment";
 import type { OnboardingSuggestion } from "@workspace/lib/onboarding";
 import { processPromptJob, type ProcessPromptData } from "./jobs/process-prompt";
 import { generateReportJob, type GenerateReportData } from "./jobs/generate-report";
@@ -39,12 +40,14 @@ export async function registerHandlers(boss: PgBoss): Promise<void> {
 	);
 	console.log("Registered handler: process-prompt");
 
-	await boss.work<GenerateReportData>(
-		"generate-report",
-		{ localConcurrency: 2 },
-		withSentry("generate-report", generateReportJob),
-	);
-	console.log("Registered handler: generate-report");
+	if (getDeployment().features.reportGeneration) {
+		await boss.work<GenerateReportData>(
+			"generate-report",
+			{ localConcurrency: 2 },
+			withSentry("generate-report", generateReportJob),
+		);
+		console.log("Registered handler: generate-report");
+	}
 
 	// batchSize: 1 keeps the returned suggestion mapped 1:1 to a single job's
 	// output, which the web app reads back via getJobById.

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/node";
+import { getDeployment } from "@workspace/deployment";
 import { getProvider, parseScrapeTargets, validateScrapeTargets } from "@workspace/lib/providers";
 import boss from "./boss";
 import { registerHandlers } from "./handlers";
@@ -39,12 +40,14 @@ async function main() {
 		retryBackoff: true,
 		expireInSeconds: 60 * 15, // 15 minute timeout
 	});
-	await boss.createQueue("generate-report", {
-		retryLimit: 3,
-		retryDelay: 60,
-		retryBackoff: true,
-		expireInSeconds: 60 * 60, // 1 hour timeout for reports
-	});
+	if (getDeployment().features.reportGeneration) {
+		await boss.createQueue("generate-report", {
+			retryLimit: 3,
+			retryDelay: 60,
+			retryBackoff: true,
+			expireInSeconds: 60 * 60, // 1 hour timeout for reports
+		});
+	}
 	await boss.createQueue("analyze-brand", {
 		retryLimit: 1,
 		retryDelay: 10,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,7 @@ COPY packages/config/package.json ./packages/config/
 COPY packages/lib/package.json ./packages/lib/
 COPY packages/local/package.json ./packages/local/
 COPY packages/whitelabel/package.json ./packages/whitelabel/
+COPY packages/cloud/package.json ./packages/cloud/
 COPY packages/deployment/package.json ./packages/deployment/
 COPY packages/og/package.json ./packages/og/
 COPY packages/api-spec/package.json ./packages/api-spec/
@@ -39,6 +40,7 @@ COPY --from=deps /app/packages/config/node_modules ./packages/config/node_module
 COPY --from=deps /app/packages/lib/node_modules ./packages/lib/node_modules
 COPY --from=deps /app/packages/local/node_modules ./packages/local/node_modules
 COPY --from=deps /app/packages/whitelabel/node_modules ./packages/whitelabel/node_modules
+COPY --from=deps /app/packages/cloud/node_modules ./packages/cloud/node_modules
 COPY --from=deps /app/packages/deployment/node_modules ./packages/deployment/node_modules
 COPY --from=deps /app/packages/og/node_modules ./packages/og/node_modules
 

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@workspace/cloud",
+  "version": "0.2.14",
+  "private": true,
+  "license": "MIT",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@workspace/config": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/cloud/src/deployment.test.ts
+++ b/packages/cloud/src/deployment.test.ts
@@ -1,0 +1,41 @@
+import { DEFAULT_APP_ICON, DEFAULT_APP_NAME, DEFAULT_APP_URL } from "@workspace/config/constants";
+import { describe, expect, it } from "vitest";
+import { createCloudDeployment } from "./deployment";
+
+describe("createCloudDeployment", () => {
+	it("reports the cloud mode", () => {
+		expect(createCloudDeployment({}).mode).toBe("cloud");
+	});
+
+	it("enables self-serve signup, multi-org, brand creation, and billing", () => {
+		const { features } = createCloudDeployment({});
+		expect(features.selfServeSignup).toBe(true);
+		expect(features.supportsMultiOrg).toBe(true);
+		expect(features.canCreateBrands).toBe(true);
+		expect(features.billing).toBe(true);
+	});
+
+	it("disables read-only, the optimize button, and report generation", () => {
+		const { features } = createCloudDeployment({});
+		expect(features.readOnly).toBe(false);
+		expect(features.showOptimizeButton).toBe(false);
+		expect(features.reportGeneration).toBe(false);
+	});
+
+	it("uses Elmo branding defaults without VITE_APP_* overrides", () => {
+		const { branding } = createCloudDeployment({
+			VITE_APP_NAME: "Should Be Ignored",
+			VITE_APP_ICON: "https://cdn.example.com/ignored.png",
+		});
+		expect(branding.name).toBe(DEFAULT_APP_NAME);
+		expect(branding.icon).toBe(DEFAULT_APP_ICON);
+	});
+
+	it("reads the public app URL from APP_URL", () => {
+		expect(createCloudDeployment({ APP_URL: "https://app.elmo.com/" }).branding.url).toBe("https://app.elmo.com/");
+	});
+
+	it("falls back to the default app URL when APP_URL is absent (env validation reports it)", () => {
+		expect(createCloudDeployment({}).branding.url).toBe(DEFAULT_APP_URL);
+	});
+});

--- a/packages/cloud/src/deployment.ts
+++ b/packages/cloud/src/deployment.ts
@@ -1,0 +1,39 @@
+/**
+ * Elmo Cloud deployment factory.
+ *
+ * Creates the Deployment for the managed multi-tenant Elmo Cloud offering.
+ *
+ * Feature flags: self-serve signup ON, multi-org ON, Stripe billing ON,
+ * read-only OFF. Report generation is OFF — the one-time report generator is
+ * an internal/whitelabel tool and is disabled entirely in cloud (no worker
+ * scheduling, no UI entry points).
+ *
+ * Branding uses the Elmo defaults, so no VITE_APP_* overrides are needed. Only
+ * the public app URL is deployment-specific and is read from APP_URL (required
+ * for cloud via env validation; the localhost default keeps this factory total
+ * so a missing APP_URL surfaces on the env-validation page rather than throwing).
+ */
+import { DEFAULT_APP_ICON, DEFAULT_APP_NAME, DEFAULT_APP_URL, DEFAULT_CHART_COLORS } from "@workspace/config/constants";
+import { getEnv } from "@workspace/config/env";
+import type { Deployment } from "@workspace/config/types";
+
+export function createCloudDeployment(env: Record<string, string | undefined> = process.env): Deployment {
+	return {
+		mode: "cloud",
+		features: {
+			readOnly: false,
+			showOptimizeButton: false,
+			supportsMultiOrg: true,
+			canCreateBrands: true,
+			selfServeSignup: true,
+			billing: true,
+			reportGeneration: false,
+		},
+		branding: {
+			name: DEFAULT_APP_NAME,
+			icon: DEFAULT_APP_ICON,
+			url: getEnv("APP_URL", DEFAULT_APP_URL, env),
+			chartColors: DEFAULT_CHART_COLORS,
+		},
+	};
+}

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @workspace/cloud - Elmo Cloud deployment package
+ *
+ * Provides the cloud-mode implementation:
+ * - createCloudDeployment() factory (Elmo branding, self-serve signup,
+ *   multi-org, Stripe billing on, report generation off)
+ *
+ * Auth is handled by better-auth; this only provides static config. The
+ * OptimizeButton stub is reused from @workspace/local via the client mapping
+ * in @workspace/deployment/client.
+ */
+
+export { createCloudDeployment } from "./deployment";

--- a/packages/cloud/tsconfig.json
+++ b/packages/cloud/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["esnext", "dom"],
+    "types": ["node"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/packages/config/src/env-registry.ts
+++ b/packages/config/src/env-registry.ts
@@ -38,8 +38,8 @@ export interface EnvVarSpec {
 	description: string;
 }
 
-/** Modes with startup env validation. "cloud" requirements are TODO and intentionally excluded. */
-const VALIDATED_MODES: DeploymentMode[] = ["local", "demo", "whitelabel"];
+/** Modes with startup env validation. */
+const VALIDATED_MODES: DeploymentMode[] = ["local", "demo", "whitelabel", "cloud"];
 
 export const ENV_REGISTRY: EnvVarSpec[] = [
 	{
@@ -51,8 +51,9 @@ export const ENV_REGISTRY: EnvVarSpec[] = [
 	{
 		name: "APP_URL",
 		scope: "server",
-		requiredBy: "optional",
-		description: "Public base URL of the web app (written by `elmo init`).",
+		requiredBy: ["cloud"],
+		description:
+			"Public base URL of the web app. Required in cloud (used for auth, email links, and Stripe redirects); written by `elmo init` for local.",
 	},
 	{
 		name: "BETTER_AUTH_SECRET",
@@ -365,5 +366,26 @@ export const ENV_REGISTRY: EnvVarSpec[] = [
 		scope: "server",
 		requiredBy: "optional",
 		description: "Set to any value to disable telemetry.",
+	},
+	// Cloud-only service credentials. Consumed by the Stripe billing and
+	// Resend transactional-email integrations (implemented in follow-up work);
+	// required here so a cloud deployment fails startup validation without them.
+	{
+		name: "STRIPE_SECRET_KEY",
+		scope: "server",
+		requiredBy: ["cloud"],
+		description: "Stripe secret API key (sk_...) for subscription billing.",
+	},
+	{
+		name: "STRIPE_WEBHOOK_SECRET",
+		scope: "server",
+		requiredBy: ["cloud"],
+		description: "Stripe webhook signing secret (whsec_...) for verifying billing webhooks.",
+	},
+	{
+		name: "RESEND_API_KEY",
+		scope: "server",
+		requiredBy: ["cloud"],
+		description: "Resend API key for transactional email.",
 	},
 ];

--- a/packages/config/src/env.test.ts
+++ b/packages/config/src/env.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { getEnvRequirements, validateEnvRequirements } from "./env";
+
+// Vars required specifically because the deployment is cloud.
+const CLOUD_ONLY_VARS = ["APP_URL", "STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET", "RESEND_API_KEY"];
+// Infra vars every validated mode needs — cloud now among them.
+const CLOUD_SHARED_VARS = ["DATABASE_URL", "BETTER_AUTH_SECRET", "SCRAPE_TARGETS", "DEPLOYMENT_MODE"];
+
+describe("cloud env requirements", () => {
+	const cloudReqs = getEnvRequirements("cloud");
+	const requiredIds = new Set(cloudReqs.map((requirement) => requirement.id));
+
+	it("requires the cloud-specific service credentials", () => {
+		for (const name of CLOUD_ONLY_VARS) {
+			expect(requiredIds.has(name), `${name} should be required in cloud`).toBe(true);
+		}
+	});
+
+	it("requires the shared infra vars", () => {
+		for (const name of CLOUD_SHARED_VARS) {
+			expect(requiredIds.has(name), `${name} should be required in cloud`).toBe(true);
+		}
+	});
+
+	it("flags every cloud var missing on an empty env", () => {
+		const { missing, isValid } = validateEnvRequirements(cloudReqs, {});
+		const missingIds = new Set(missing.map((entry) => entry.id));
+		for (const name of [...CLOUD_ONLY_VARS, ...CLOUD_SHARED_VARS]) {
+			expect(missingIds.has(name), `${name} should be reported missing`).toBe(true);
+		}
+		expect(isValid).toBe(false);
+	});
+
+	it("does not flag the cloud vars once they are set", () => {
+		const env: Record<string, string> = {
+			DEPLOYMENT_MODE: "cloud",
+			DATABASE_URL: "postgres://localhost/elmo",
+			BETTER_AUTH_SECRET: "secret",
+			SCRAPE_TARGETS: "chatgpt:olostep:online",
+			APP_URL: "https://app.elmo.com/",
+			STRIPE_SECRET_KEY: "sk_test_x",
+			STRIPE_WEBHOOK_SECRET: "whsec_x",
+			RESEND_API_KEY: "re_test_x",
+		};
+		const { missing } = validateEnvRequirements(cloudReqs, env);
+		const missingIds = new Set(missing.map((entry) => entry.id));
+		for (const name of [...CLOUD_ONLY_VARS, ...CLOUD_SHARED_VARS]) {
+			expect(missingIds.has(name), `${name} should be satisfied`).toBe(false);
+		}
+	});
+});

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -87,7 +87,7 @@ export const ENV_REQUIREMENTS: Record<DeploymentMode, EnvRequirement[]> = {
 	local: [...buildStaticRequirements("local"), ...buildProviderKeyRequirements()],
 	demo: [...buildStaticRequirements("demo"), ...buildProviderKeyRequirements()],
 	whitelabel: [...buildStaticRequirements("whitelabel"), ...buildProviderKeyRequirements()],
-	cloud: [], // todo
+	cloud: [...buildStaticRequirements("cloud"), ...buildProviderKeyRequirements()],
 };
 
 /**

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -25,10 +25,27 @@ export interface FeaturesConfig {
 	/** Whether multi-org brand switching is supported */
 	supportsMultiOrg: boolean;
 	/**
-	 * Whether the user can create new brands from the UI. True only in local mode —
-	 * whitelabel orgs come from Auth0, demo is read-only.
+	 * Whether the user can create new brands from the UI. True in local and
+	 * cloud modes — whitelabel orgs come from Auth0, demo is read-only.
 	 */
 	canCreateBrands: boolean;
+	/**
+	 * Whether public self-serve registration is available. True only in cloud
+	 * mode. Local allows a single bootstrap signup (see ClientConfig.canRegister);
+	 * demo/whitelabel never expose signup.
+	 */
+	selfServeSignup: boolean;
+	/**
+	 * Whether Stripe subscription billing is active. True only in cloud mode.
+	 * Gates the billing/usage surfaces and plan enforcement.
+	 */
+	billing: boolean;
+	/**
+	 * Whether the one-time report generator is available. True everywhere except
+	 * cloud, where reports are disabled entirely (no worker scheduling, no UI
+	 * entry points, and the per-user hasReportGeneratorAccess flag is ignored).
+	 */
+	reportGeneration: boolean;
 }
 
 /**
@@ -106,8 +123,9 @@ export interface ClientConfig {
 	/** Resolved default prompt cadence (hours) for brands without a delayOverrideHours */
 	defaultDelayHours: number;
 	/**
-	 * Whether /auth/register should be reachable. True only in local mode
-	 * when no user exists yet. Demo/whitelabel always false.
+	 * Whether /auth/register should be reachable. True in cloud mode (self-serve
+	 * signup) and in local mode before the first user is bootstrapped.
+	 * Demo/whitelabel always false.
 	 */
 	canRegister: boolean;
 	/** Whether any user account exists. */

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -9,6 +9,7 @@
     "./client": "./src/client.ts"
   },
   "dependencies": {
+    "@workspace/cloud": "workspace:*",
     "@workspace/config": "workspace:*",
     "@workspace/local": "workspace:*",
     "@workspace/whitelabel": "workspace:*"

--- a/packages/deployment/src/deployment.ts
+++ b/packages/deployment/src/deployment.ts
@@ -8,11 +8,16 @@
  * The singleton is cached at module scope. On Vercel serverless this
  * persists across warm invocations, which is safe because the
  * Deployment object contains no request-scoped state.
+ *
+ * Factories are imported from their component-free entry points so this
+ * module (and anything that imports getDeployment) stays Node-safe — the
+ * worker builds a Deployment without pulling in the React OptimizeButton.
  */
 import { getDeploymentModeFromEnv } from "@workspace/config/env";
 import type { Deployment } from "@workspace/config/types";
+import { createCloudDeployment } from "@workspace/cloud";
 import { createLocalDeployment } from "@workspace/local";
-import { createWhitelabelDeployment } from "@workspace/whitelabel";
+import { createWhitelabelDeployment } from "@workspace/whitelabel/deployment";
 
 let cached: Deployment | null = null;
 
@@ -37,7 +42,8 @@ export function getDeployment(options?: GetDeploymentOptions): Deployment {
 			cached = createWhitelabelDeployment({ env });
 			break;
 		case "cloud":
-			throw new Error("Cloud deployment mode is not yet implemented");
+			cached = createCloudDeployment(env);
+			break;
 	}
 
 	return cached!;

--- a/packages/deployment/src/index.ts
+++ b/packages/deployment/src/index.ts
@@ -2,9 +2,12 @@
  * @workspace/deployment - Deployment facade package
  *
  * Thin switch that picks the active deployment mode based on DEPLOYMENT_MODE
- * and delegates to the appropriate package (@workspace/local, @workspace/whitelabel).
+ * and delegates to the appropriate package (@workspace/local, @workspace/whitelabel,
+ * @workspace/cloud).
+ *
+ * This entry point is Node-safe: it exposes only the server config accessor so
+ * the worker can build a Deployment without loading React. The client-only
+ * OptimizeButton selector lives at "@workspace/deployment/client".
  */
 
 export { getDeployment, resetDeploymentCache, type GetDeploymentOptions } from "./deployment";
-
-export { getOptimizeButtonForMode, type OptimizeButtonProps } from "./client";

--- a/packages/local/src/auth-provider.ts
+++ b/packages/local/src/auth-provider.ts
@@ -20,6 +20,9 @@ export function createLocalDeployment(env: Record<string, string | undefined> = 
 			showOptimizeButton: false,
 			supportsMultiOrg: true,
 			canCreateBrands: !readOnly,
+			selfServeSignup: false,
+			billing: false,
+			reportGeneration: true,
 		},
 		branding: {
 			name: getEnv("APP_NAME", DEFAULT_APP_NAME, env),

--- a/packages/whitelabel/package.json
+++ b/packages/whitelabel/package.json
@@ -6,6 +6,7 @@
   "main": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./deployment": "./src/deployment.ts",
     "./auth-hooks": "./src/auth-hooks.ts",
     "./components/*": "./src/components/*.tsx"
   },

--- a/packages/whitelabel/src/deployment.ts
+++ b/packages/whitelabel/src/deployment.ts
@@ -39,6 +39,9 @@ export function createWhitelabelDeployment(
 			showOptimizeButton: true,
 			supportsMultiOrg: true,
 			canCreateBrands: false,
+			selfServeSignup: false,
+			billing: false,
+			reportGeneration: true,
 		},
 		branding: {
 			name: requireEnv("VITE_APP_NAME", env),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       '@sentry/node':
         specifier: ^10.63.0
         version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))
+      '@workspace/deployment':
+        specifier: workspace:*
+        version: link:../../packages/deployment
       '@workspace/lib':
         specifier: workspace:*
         version: link:../../packages/lib
@@ -466,6 +469,22 @@ importers:
 
   packages/api-spec: {}
 
+  packages/cloud:
+    dependencies:
+      '@workspace/config':
+        specifier: workspace:*
+        version: link:../config
+    devDependencies:
+      '@types/node':
+        specifier: ^26.1.0
+        version: 26.1.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5)(yaml@2.9.0))
+
   packages/config:
     devDependencies:
       '@types/node':
@@ -480,6 +499,9 @@ importers:
 
   packages/deployment:
     dependencies:
+      '@workspace/cloud':
+        specifier: workspace:*
+        version: link:../cloud
       '@workspace/config':
         specifier: workspace:*
         version: link:../config
@@ -11069,7 +11091,7 @@ snapshots:
 
   '@types/readdir-glob@1.1.5':
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 26.1.0
 
   '@types/resolve@1.20.6': {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -51,7 +51,10 @@
     "VITE_SENTRY_DSN",
     "VITE_POSTHOG_KEY",
     "VITE_CHART_COLORS",
-    "DISABLE_TELEMETRY"
+    "DISABLE_TELEMETRY",
+    "STRIPE_SECRET_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+    "RESEND_API_KEY"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
Implements #342 — wires up the previously-unimplemented `cloud` `DeploymentMode` (it existed in the union and factory but threw "not yet implemented"). This is the foundation for the cloud launch; billing/signup/plan work lands in the follow-up issues (#343–#349).

## What's included

**New `@workspace/cloud` package** (`createCloudDeployment`)
- Elmo branding defaults — no `VITE_APP_*` overrides needed. Only the public app URL is deployment-specific (`APP_URL`); the factory stays total (falls back to the default so a missing `APP_URL` surfaces on the env-validation page instead of throwing).
- Feature flags: **self-serve signup ON, multi-org ON, Stripe billing ON, read-only OFF**, brand creation ON, report generation OFF.
- Wired into `getDeployment()`; the `client.ts` OptimizeButton mapping already had a `cloud` entry.

**Feature flags** (`FeaturesConfig`)
- Adds `selfServeSignup`, `billing`, and `reportGeneration`. Existing modes keep their behavior (`selfServeSignup: false`, `billing: false`, `reportGeneration: true`).

**Report generation disabled entirely in cloud** — one source of truth
- The cloud factory declares `features.reportGeneration = false`, and the **worker reads that off a `Deployment` instance** — `getDeployment().features.reportGeneration` gates the `generate-report` queue + handler (`apps/worker/src/{index,handlers}.ts`). Web and worker consult the same object, so they can't drift, and there's no mode string hardcoded in the worker.
- To let the worker build a `Deployment` in a Node process, `@workspace/deployment`'s **server entry is kept Node-safe**: factories are imported from component-free entry points (new `@workspace/whitelabel/deployment` subpath), and the index no longer re-exports the React `OptimizeButton` selector (still available at `@workspace/deployment/client`). So importing `getDeployment` no longer pulls React/UI into the pruned worker image.
- `hasReportAccess()` returns false when `reportGeneration` is off, so every report server fn and the render route are blocked and the per-user `hasReportGeneratorAccess` flag is ignored. The `/reports` layout route `beforeLoad` 404s the whole subtree (covers the admin-accessible list too); the sidebar hides the Reports nav entry.

**Env validation** (registry ↔ `turbo.json` ↔ `env.d.ts` kept in sync)
- Cloud added to `VALIDATED_MODES` (so it requires `DATABASE_URL`, `BETTER_AUTH_SECRET`, `SCRAPE_TARGETS`, `DEPLOYMENT_MODE`).
- `APP_URL` now required in cloud; new `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `RESEND_API_KEY` (consumed by the follow-up Stripe/Resend work, required here so a cloud deploy fails startup validation without them).

**Self-serve signup**
- `canRegister` honors `selfServeSignup`, so the login/register pages open up in cloud.
- Cloud auth options allow unrestricted email signup (no single-user bootstrap guard); each user provisions their own org via the existing create-brand flow.

**Docker**
- `docker/Dockerfile` now bundles `packages/cloud` (deps install + web build), and the worker image resolves `@workspace/deployment` for the report-generation check.

## Compatibility
Pure addition — no behavior change for local/demo/whitelabel.

## Tests
- New `packages/cloud/src/deployment.test.ts` (factory: mode, flags, branding, `APP_URL`).
- New `packages/config/src/env.test.ts` (cloud env requirements present + flagged when missing).
- Existing suites updated (`test/mocks/auth.ts` gains `CLOUD_FEATURES` + the new flags).
- `turbo check-types` ✓, `turbo test` ✓ (config/cloud/web), deployment-mode smoke ✓ (local/demo/whitelabel), plus a runtime check that the worker builds a `Deployment` and reads the flag (cloud → false, local → true). Lint adds no new findings.