### PR TITLE
Update AGENTS.md and import it from CLAUDE.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,3 @@ Run `pnpm format` before committing, and `check-types` for the packages you touc
 - Add one only for **user-facing** changes (something an end user of the product would notice). Internal refactors, dependency bumps, and CI tweaks don't get one.
 - Keep it to one short, product-focused sentence; default to `patch`; scope it to the packages actually affected.
 - If a non-package directory (like `e2e/`) breaks Changesets tooling, fix the tooling configuration rather than inventing versions.
-
-## Pull requests
-
-- Don't commit image artifacts (screenshots, videos, Playwright reports) or one-off screenshot scripts — attach proof to the PR description instead.
-- Don't add "screenshot-only" tests whose sole purpose is producing PR images; new tests must make assertions that are valuable long-term.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Full setup instructions are in the developer guide at `packages/docs/content/doc
 - E2E tests need Playwright browsers (`pnpm exec playwright install`) and a running app; they are separate from unit tests
 - shadcn components: always install with the CLI (`pnpm dlx shadcn@latest add <component>`, from `packages/ui` or `apps/www` — each has its own `components.json`) — never hand-create them
 
-Run `pnpm format` before committing, and `check-types` for the packages you touched before opening the PR. Skip `pnpm lint` — CI doesn't gate on it. Only run tests mid-work when they help you iterate (`pnpm --filter <pkg> test` to scope them). Don't commit formatting churn in `apps/www` files you didn't touch — wholesale reformatting buries the real change.
+Run `pnpm format` before committing, and `check-types` for the packages you touched before opening the PR. Skip `pnpm lint` — CI doesn't gate on it. Only run tests mid-work when they help you iterate (`pnpm --filter <pkg> test` to scope them).
 
 ## Package management and supply-chain security
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Elmo is an open-source AI visibility platform (Answer Engine Optimization): it t
 - `packages/ui` — shared UI components
 - Other packages: `docs` (docs content), `og`, `deployment`, `config`, `api-spec`, `whitelabel`, `local`. Playwright tests live in `e2e/`.
 
-Full setup instructions are in the developer guide (`packages/docs/content/docs/developer-guide/`, published at elmohq.com/docs/developer-guide).
+Full setup instructions are in the developer guide at `packages/docs/content/docs/developer-guide/`.
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,5 @@
 # AGENTS.md
 
-Guidance for coding agents working in this repo.
-
 ## What this is
 
 Elmo is an open-source AI visibility platform (Answer Engine Optimization): it tracks how AI answer engines like ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews mention, cite, and describe brands. It is a **pnpm + Turborepo monorepo** on **Node.js 24** (enforced via `engines`), **TypeScript**, and **PostgreSQL**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Full setup instructions are in the developer guide (`packages/docs/content/docs/
 - Migrations: from `packages/lib`, `pnpm exec drizzle-kit migrate`
 - E2E tests need Playwright browsers (`pnpm exec playwright install`) and a running app; they are separate from unit tests
 
-Run `pnpm lint`, `pnpm format`, and `check-types` for the packages you touched once, right before opening the PR — not on every commit. Likewise only run tests mid-work when they help you iterate (`pnpm --filter <pkg> test` to scope them).
+Run `pnpm lint`, `pnpm format`, and `check-types` for the packages you touched once, right before opening the PR — not on every commit. Likewise only run tests mid-work when they help you iterate (`pnpm --filter <pkg> test` to scope them). Don't format `apps/www` files you didn't touch: it isn't format-enforced, and wholesale reformatting buries the real change.
 
 ## Package management and supply-chain security
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,68 +1,66 @@
 # AGENTS.md
 
-## Cursor Cloud specific instructions
+Guidance for coding agents working in this repo. `CLAUDE.md` imports this file.
 
-### Project overview
+## What this is
 
-Elmo is an open-source AI visibility tracking platform (Answer Engine Optimization). It is a **pnpm monorepo** using **Turborepo**, **Node.js 24**, and **PostgreSQL 16**.
+Elmo is an open-source AI visibility platform (Answer Engine Optimization): it tracks how AI answer engines like ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews mention, cite, and describe brands. It is a **pnpm + Turborepo monorepo** on **Node.js 24** (enforced via `engines`), **TypeScript**, and **PostgreSQL**.
 
-Key apps: `apps/web` (TanStack Start dashboard, port 3000), `apps/worker` (pg-boss background jobs), `apps/www` (marketing site, port 3001), `apps/cli` (deployment CLI).
+- `apps/web` — product dashboard (TanStack Start + Vite, port 3000)
+- `apps/worker` — pg-boss background jobs (AI evaluations, citation tracking, reports)
+- `apps/www` — marketing site, docs, and blog (port 3001)
+- `apps/cli` — `@elmohq/cli`, the Docker Compose deployment CLI
+- `packages/lib` — shared logic and the Drizzle schema/migrations
+- `packages/ui` — shared UI components
+- Other packages: `docs` (docs content), `og`, `deployment`, `config`, `api-spec`, `whitelabel`, `local`. Playwright tests live in `e2e/`.
 
-### Running services
+Full setup instructions are in the developer guide (`packages/docs/content/docs/developer-guide/`, published at elmohq.com/docs/developer-guide).
 
-- **PostgreSQL**: Start with `sudo pg_ctlcluster 16 main start`. Verify with `pg_isready`.
-- **Web app dev server**: From repo root, run with env vars loaded (see below). Uses Vite on port 3000.
-- **Worker**: Reads env from `apps/web/.env` via `--env-file`. Only needed for background job processing (AI evaluations, reports).
+## Commands
 
-### Environment variables
-
-The `.env` file must exist at **both** the repo root AND `apps/web/.env` (Vite reads from its project root; the worker reads from `apps/web/.env` via `--env-file`). Required minimum for local mode:
-
-```
-DATABASE_URL=postgres://elmo:elmo@localhost:5432/elmo
-DEPLOYMENT_MODE=local
-VITE_DEPLOYMENT_MODE=local
-BETTER_AUTH_SECRET=<random-hex>
-APP_URL=http://localhost:3000
-VITE_APP_URL=http://localhost:3000
-DISABLE_TELEMETRY=1
-```
-
-For the env validation to pass fully, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DATAFORSEO_LOGIN`, and `DATAFORSEO_PASSWORD` must also be set. Placeholder values work for UI testing.
-
-### Database migrations
-
-Run from `packages/lib`: `DATABASE_URL=... npx drizzle-kit migrate`
-
-### Common commands
-
-See `README.md` for the full commands reference. Key ones:
-
-- `pnpm dev` — start all dev servers (turbo)
-- `pnpm lint` — Biome linter (pre-existing CSS/Tailwind directive warnings are expected)
+- `pnpm dev` — all dev servers (turbo)
+- `pnpm lint` — Biome (pre-existing Tailwind `@apply` warnings in CSS are expected; `apps/www` is not linted)
 - `pnpm test` — Vitest unit tests
 - `pnpm build` — build all packages
-- `pnpm format` — format with Biome
+- `pnpm format` — Biome format
+- Migrations: from `packages/lib`, `pnpm exec drizzle-kit migrate`
+- E2E tests need Playwright browsers (`pnpm exec playwright install`) and a running app; they are separate from unit tests
 
-### Gotchas
+## Package management and supply-chain security
 
-- **Changesets**: Keep changesets short and end-user focused (what changed in the product), not internal implementation details.
-- **PR screenshots**: Do **not** commit before/after screenshots or one-off screenshot capture scripts to the repo. Add proof screenshots as PR artifacts (or attach in the PR description) instead.
+- **Always use pnpm.** Never install or run dependencies with npm, yarn, or `npx` — that sidesteps the workspace's protections.
+- This repo enforces [pnpm supply-chain security](https://pnpm.io/supply-chain-security) via `pnpm-workspace.yaml`: `minimumReleaseAge` (a multi-day cooldown on new releases), `trustPolicy: no-downgrade`, `blockExoticSubdeps`, and an `allowBuilds` allowlist for install scripts.
+- **Never weaken or bypass these controls**: don't add `minimumReleaseAgeExclude` entries, don't flip packages to `true` in `allowBuilds`, don't suppress `pnpm audit` advisories, and don't remove `overrides` (many are scoped security patches or dedup anchors). If an install fails because of these controls, that is the system working — report it instead of working around it.
 
-- **Node.js 24 required**: The repo enforces `engines.node: "24.x"`. Use `nvm use 24`.
-- **Biome CSS lint warnings**: The linter reports Tailwind `@apply` directive warnings in CSS files — these are pre-existing and expected.
-- **pnpm build warnings**: Some dependencies have ignored build scripts (sentry-cli, msw, protobufjs, vue-demi). This is configured via `pnpm.onlyBuiltDependencies` and `pnpm.ignoredBuiltDependencies` in root `package.json`.
-- **E2E tests**: Require Playwright browsers (`pnpm exec playwright install`) and a running app instance. They are separate from unit tests.
-- **Worker env loading**: The worker's `dev` script uses `--env-file=../web/.env`, so the env file must be in `apps/web/`.
+## Environment
 
-## Pull request guidelines
+`.env` must exist at **both** the repo root and `apps/web/.env` (Vite reads its project root; the worker reads `apps/web/.env` via `--env-file`). Minimum for local mode: `DATABASE_URL`, `DEPLOYMENT_MODE=local`, `VITE_DEPLOYMENT_MODE=local`, `BETTER_AUTH_SECRET`, `APP_URL`/`VITE_APP_URL`, `DISABLE_TELEMETRY=1`. Env validation also requires `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DATAFORSEO_LOGIN`, and `DATAFORSEO_PASSWORD` — placeholder values work for UI-only work.
 
-- **Do not commit image artifacts** (screenshots, videos, Playwright reports) to the repo. Generate artifacts locally and embed them in the PR description via `<img src="/opt/cursor/artifacts/..." />` so they are uploaded automatically.
-- **Prefer uploading screenshots as PR artifacts** inline in the PR description (avoid committing files or linking to agent dashboards).
-- **Do not add "screenshot-only" tests** whose sole purpose is to produce PR images. If you add test coverage, make it a real assertion-based test that is valuable long-term.
-- **Do not bump versions** (or add placeholder versions) unless the change explicitly requires a release/versioning action.
+## Git workflow
+
+- Work happens in PRs against `main`.
+- Commit as you go: small, atomic commits that show real progress. Don't rewrite history (amend, rebase, force-push) to make it look tidy afterward.
+- Commit subjects are plain imperative sentences — no conventional-commit prefixes. Write `paginate top cited domains`, not `feat(web): paginate top cited domains`.
+- Never add `Co-Authored-By` or other AI attribution to commits (also enforced via `.claude/settings.json`).
+- Don't bump package versions; releases go through Changesets.
+
+## Code comments
+
+- Comment only to explain **why** or to add context the code can't show. Never restate what the code already says.
+- Don't describe prior behavior ("previously this did X") and don't reference GitHub issues or tickets in code — that context belongs in the commit message or PR.
 
 ## Changesets
 
-- When adding a Changeset, keep it **scoped to the packages actually affected**.
+- Add one only for **user-facing** changes (something an end user of the product would notice). Internal refactors, dependency bumps, and CI tweaks don't get one.
+- Keep it to one short, product-focused sentence; default to `patch`; scope it to the packages actually affected.
 - If a non-package directory (like `e2e/`) breaks Changesets tooling, fix the tooling configuration rather than inventing versions.
+
+## Pull requests
+
+- Don't commit image artifacts (screenshots, videos, Playwright reports) or one-off screenshot scripts — attach proof to the PR description instead.
+- Don't add "screenshot-only" tests whose sole purpose is producing PR images; new tests must make assertions that are valuable long-term.
+
+## Gotchas
+
+- `check-types` and lint miss MDX frontmatter and codegen errors in `apps/www` — run `pnpm --filter @workspace/www build` when touching docs, blog, routes, or `source.config`.
+- User-facing text and URLs write "fan-out" / "Query Fan-Out" with a hyphen; internal identifiers keep `fanout`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ Full setup instructions are in the developer guide (`packages/docs/content/docs/
 - Migrations: from `packages/lib`, `pnpm exec drizzle-kit migrate`
 - E2E tests need Playwright browsers (`pnpm exec playwright install`) and a running app; they are separate from unit tests
 
+Before finishing a change, run `pnpm lint` and `pnpm test`, plus `check-types` (`pnpm --filter <pkg> check-types`) for the packages you touched. Use `pnpm --filter <pkg> <script>` to scope any of these when iterating.
+
 ## Package management and supply-chain security
 
 - **Always use pnpm.** Never install or run dependencies with npm, yarn, or `npx` — that sidesteps the workspace's protections.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,6 @@ Run `pnpm format` before committing, and `check-types` for the packages you touc
 - Work happens in PRs against `main`.
 - Commit as you go: small, atomic commits that show real progress. Don't rewrite history (amend, rebase, force-push) to make it look tidy afterward.
 - Commit subjects are plain imperative sentences — no conventional-commit prefixes. Write `paginate top cited domains`, not `feat(web): paginate top cited domains`.
-- Never add `Co-Authored-By` or other AI attribution to commits (also enforced via `.claude/settings.json`).
 - Don't bump package versions; releases go through Changesets.
 
 ## Comments and docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Full setup instructions are in the developer guide at `packages/docs/content/doc
 - `pnpm test` — Vitest unit tests
 - `pnpm build` — build all packages
 - `pnpm format` — Biome format
-- Migrations: from `packages/lib`, `pnpm exec drizzle-kit migrate`
+- Migrations: from `packages/lib`, `pnpm exec drizzle-kit migrate` (NEVER RUN THESE UNLESS EXPLICITLY INSTRUCTED BY THE USER)
 - E2E tests need Playwright browsers (`pnpm exec playwright install`) and a running app; they are separate from unit tests
 
 Run `pnpm format` before committing, and `check-types` for the packages you touched before opening the PR. Skip `pnpm lint` — CI doesn't gate on it. Only run tests mid-work when they help you iterate (`pnpm --filter <pkg> test` to scope them). Don't commit formatting churn in `apps/www` files you didn't touch — wholesale reformatting buries the real change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,12 @@ Elmo is an open-source AI visibility platform (Answer Engine Optimization): it t
 - `apps/www` — marketing site, docs, and blog (port 3001)
 - `apps/cli` — `@elmohq/cli`, the Docker Compose deployment CLI
 - `packages/lib` — shared logic and the Drizzle schema/migrations
-- `packages/ui` — shared UI components
-- Other packages: `docs` (docs content), `og`, `deployment`, `config`, `api-spec`, `whitelabel`, `local`. Playwright tests live in `e2e/`.
+- `packages/ui` — shared shadcn-based UI components
+- `packages/docs` — user-facing docs content (MDX), rendered by `apps/www`
+- `packages/deployment` — deployment-mode config (reads `DEPLOYMENT_MODE`, exposes per-mode features)
+- `packages/config` — env validation and shared constants/types
+- `packages/api-spec` — OpenAPI spec
+- `e2e/` — Playwright end-to-end tests
 
 Full setup instructions are in the developer guide at `packages/docs/content/docs/developer-guide/`.
 
@@ -22,6 +26,7 @@ Full setup instructions are in the developer guide at `packages/docs/content/doc
 - `pnpm format` — Biome format
 - Migrations: from `packages/lib`, `pnpm exec drizzle-kit migrate` (NEVER RUN THESE UNLESS EXPLICITLY INSTRUCTED BY THE USER)
 - E2E tests need Playwright browsers (`pnpm exec playwright install`) and a running app; they are separate from unit tests
+- shadcn components: always install with the CLI (`pnpm dlx shadcn@latest add <component>`, from `packages/ui` or `apps/www` — each has its own `components.json`) — never hand-create them
 
 Run `pnpm format` before committing, and `check-types` for the packages you touched before opening the PR. Skip `pnpm lint` — CI doesn't gate on it. Only run tests mid-work when they help you iterate (`pnpm --filter <pkg> test` to scope them). Don't commit formatting churn in `apps/www` files you didn't touch — wholesale reformatting buries the real change.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,8 +60,3 @@ Run `pnpm format` before committing, and `check-types` for the packages you touc
 
 - Don't commit image artifacts (screenshots, videos, Playwright reports) or one-off screenshot scripts — attach proof to the PR description instead.
 - Don't add "screenshot-only" tests whose sole purpose is producing PR images; new tests must make assertions that are valuable long-term.
-
-## Gotchas
-
-- `check-types` and lint miss MDX frontmatter and codegen errors in `apps/www` — run `pnpm --filter @workspace/www build` when touching docs, blog, routes, or `source.config`.
-- User-facing text and URLs write "fan-out" / "Query Fan-Out" with a hyphen; internal identifiers keep `fanout`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,14 +19,13 @@ Full setup instructions are in the developer guide at `packages/docs/content/doc
 ## Commands
 
 - `pnpm dev` — all dev servers (turbo)
-- `pnpm lint` — Biome (pre-existing Tailwind `@apply` warnings in CSS are expected; `apps/www` is not linted)
 - `pnpm test` — Vitest unit tests
 - `pnpm build` — build all packages
 - `pnpm format` — Biome format
 - Migrations: from `packages/lib`, `pnpm exec drizzle-kit migrate`
 - E2E tests need Playwright browsers (`pnpm exec playwright install`) and a running app; they are separate from unit tests
 
-Run `pnpm lint`, `pnpm format`, and `check-types` for the packages you touched once, right before opening the PR — not on every commit. Likewise only run tests mid-work when they help you iterate (`pnpm --filter <pkg> test` to scope them). Don't format `apps/www` files you didn't touch: it isn't format-enforced, and wholesale reformatting buries the real change.
+Run `pnpm format` before committing, and `check-types` for the packages you touched before opening the PR. Skip `pnpm lint` — CI doesn't gate on it. Only run tests mid-work when they help you iterate (`pnpm --filter <pkg> test` to scope them). Don't commit formatting churn in `apps/www` files you didn't touch — wholesale reformatting buries the real change.
 
 ## Package management and supply-chain security
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Guidance for coding agents working in this repo. `CLAUDE.md` imports this file.
+Guidance for coding agents working in this repo.
 
 ## What this is
 
@@ -26,7 +26,7 @@ Full setup instructions are in the developer guide (`packages/docs/content/docs/
 - Migrations: from `packages/lib`, `pnpm exec drizzle-kit migrate`
 - E2E tests need Playwright browsers (`pnpm exec playwright install`) and a running app; they are separate from unit tests
 
-Before finishing a change, run `pnpm lint` and `pnpm test`, plus `check-types` (`pnpm --filter <pkg> check-types`) for the packages you touched. Use `pnpm --filter <pkg> <script>` to scope any of these when iterating.
+Run `pnpm lint`, `pnpm format`, and `check-types` for the packages you touched once, right before opening the PR — not on every commit. Likewise only run tests mid-work when they help you iterate (`pnpm --filter <pkg> test` to scope them).
 
 ## Package management and supply-chain security
 
@@ -46,9 +46,10 @@ Before finishing a change, run `pnpm lint` and `pnpm test`, plus `check-types` (
 - Never add `Co-Authored-By` or other AI attribution to commits (also enforced via `.claude/settings.json`).
 - Don't bump package versions; releases go through Changesets.
 
-## Code comments
+## Comments and docs
 
 - Comment only to explain **why** or to add context the code can't show. Never restate what the code already says.
+- The same applies to docs and this file: never write down what's already derivable from the repo (what a file imports, what a script runs, how code is structured).
 - Don't describe prior behavior ("previously this did X") and don't reference GitHub issues or tickets in code — that context belongs in the commit message or PR.
 
 ## Changesets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## What

- Rewrites `AGENTS.md` from a Cursor-Cloud-specific setup doc into a concise, tool-agnostic guide for coding agents: system overview, commands, environment, git workflow, comment/changeset/PR conventions, and gotchas.
- Adds `CLAUDE.md` containing just `@AGENTS.md`, so Claude Code imports the shared file instead of maintaining a duplicate.
- Adds `.claude/settings.json` with empty `attribution` values so Claude Code never adds `Co-Authored-By` lines to commits or attribution footers to PRs, enforcing the rule in settings rather than relying on the instructions alone.

## Notable conventions now written down

- PRs with small, atomic commits that show progress; no history rewriting to tidy up afterward.
- Plain imperative commit subjects, no `fix(www):`-style prefixes.
- pnpm only, and the supply-chain controls in `pnpm-workspace.yaml` (`minimumReleaseAge`, `trustPolicy`, `allowBuilds`, `blockExoticSubdeps`, audit overrides) must never be weakened or bypassed.
- Comments explain *why* only — no restating code, no prior-behavior notes, no ticket references in code.
- Changesets stay user-facing only; kept the existing scoping/tooling guidance.

All Cursor-specific content (artifact paths, `pg_ctlcluster` instructions) is removed. No changeset since this is internal.