### PR TITLE
don't cache an empty repo-activity commit chart

### DIFF
--- a/apps/www/src/lib/repo-activity/cache.ts
+++ b/apps/www/src/lib/repo-activity/cache.ts
@@ -18,6 +18,8 @@ import type { RepoActivityData } from "./types";
 const DATA_KEY = `repo-activity:data:${REPO}`;
 const FRESH_KEY = `repo-activity:fresh:${REPO}`;
 const FRESH_TTL_SECONDS = 5 * 60;
+/** Shorter freshness when the commit chart is still empty, so it retries soon. */
+const RETRY_TTL_SECONDS = 60;
 const DATA_TTL_SECONDS = 24 * 60 * 60;
 
 function redisClient(): Redis | null {
@@ -39,9 +41,22 @@ export async function getRepoActivityData(): Promise<RepoActivityData> {
 
 	try {
 		const data = await fetchRepoActivityData();
+
+		// `/stats/commit_activity` answers 202 while GitHub computes it, so a fresh
+		// snapshot can arrive with an empty commit series. Don't let that regress a
+		// chart we already had: carry over the last-good week data, and mark the
+		// snapshot fresh for only a short window so it refetches (and heals) soon.
+		const missingCommits = data.commitsByWeek.length === 0;
+		if (missingCommits && lastGood && lastGood.commitsByWeek.length > 0) {
+			data.commitsByWeek = lastGood.commitsByWeek;
+			data.releaseWeeks = lastGood.releaseWeeks;
+			data.kpis.commits = lastGood.kpis.commits;
+		}
+		const stillMissing = data.commitsByWeek.length === 0;
+
 		await Promise.all([
 			redis.set(DATA_KEY, data, { ex: DATA_TTL_SECONDS }),
-			redis.set(FRESH_KEY, 1, { ex: FRESH_TTL_SECONDS }),
+			redis.set(FRESH_KEY, 1, { ex: stillMissing ? RETRY_TTL_SECONDS : FRESH_TTL_SECONDS }),
 		]);
 		return data;
 	} catch (error) {


### PR DESCRIPTION
Follow-up to #421.

The commit chart comes from GitHub's `/stats/commit_activity`, which answers `202` while GitHub (re)computes the weekly series — so on a cold cache a fresh snapshot can arrive with an empty commit array. The SWR cache was storing that as fresh for the full 5-minute window, showing **0 commits** until it expired.

Now, when a refresh comes back with no commit data, the cache:
- carries over the last-good week series (so an already-populated chart never regresses to empty), and
- marks the snapshot fresh for only 60s (vs 5min) so it refetches and heals on the next request.

**Note:** the more common cause of an empty chart is the unauthenticated GitHub rate limit — the endpoint makes a `/stats` call plus ~13 Search-API calls per refresh, which blow the 60/hr + 10/min anonymous limits (especially on Vercel's shared egress IP). Setting `GITHUB_TOKEN` in the www environment (same var `github-roadmap.ts` already reads) is the real fix; this change just makes the cold-cache case recover gracefully.

Verified: `check-types` ✅.
