### PR TITLE
fix 30-day commit count for the repo activity graphic

### DIFF
--- a/apps/www/src/lib/repo-activity/github.ts
+++ b/apps/www/src/lib/repo-activity/github.ts
@@ -87,10 +87,11 @@ async function ghStats<T>(
 async function searchCount(
 	query: string,
 	token: string | undefined,
+	index: "issues" | "commits" = "issues",
 ): Promise<number | null> {
 	try {
 		const res = await fetch(
-			`https://api.github.com/search/issues?q=${encodeURIComponent(query)}&per_page=1`,
+			`https://api.github.com/search/${index}?q=${encodeURIComponent(query)}&per_page=1`,
 			{ headers: ghHeaders(token) },
 		);
 		if (!res.ok) return null;
@@ -206,6 +207,7 @@ export async function fetchRepoActivityData(
 		issuesOpened,
 		issuesOpenTotal,
 		issuesClosedTotal,
+		commitCount,
 	] = await Promise.all([
 		ghJson<RepoCore>(API, token).catch(() => null),
 		ghStats<Array<{ week: number; total: number }>>("/stats/commit_activity", token),
@@ -222,6 +224,11 @@ export async function fetchRepoActivityData(
 		searchCount(q(`is:issue created:>=${sinceIso}`), token),
 		searchCount(q("is:issue is:open"), token),
 		searchCount(q("is:issue is:closed"), token),
+		// Exact commits on the default branch in the window — same live basis as
+		// the other KPIs. The weekly commit_activity stat lags and is week-aligned,
+		// so it can read lower than "PRs merged" even though every squash-merge is a
+		// commit; this keeps the number honest.
+		searchCount(q(`committer-date:>=${sinceIso}`), token, "commits"),
 	]);
 
 	const commitsByWeek: WeekPoint[] = (commitActivity ?? [])
@@ -263,7 +270,9 @@ export async function fetchRepoActivityData(
 		avatarDataUri: avatarUris[i],
 	}));
 
-	const commitsInWindow = commitsByWeek
+	// Fallback for the commit KPI if the commit search is unavailable (e.g. no
+	// token): sum the whole weeks inside the window from commit_activity.
+	const commitsFromWeeks = commitsByWeek
 		.filter((p) => p.week >= windowStartSec)
 		.reduce((sum, p) => sum + p.total, 0);
 	const releasesInWindow = releases.filter(
@@ -283,7 +292,7 @@ export async function fetchRepoActivityData(
 		churnByWeek,
 		releaseWeeks: [...releaseWeekSet],
 		kpis: {
-			commits: commitsInWindow,
+			commits: commitCount ?? commitsFromWeeks,
 			prsMerged: prsMerged ?? 0,
 			prsOpened: prsOpened ?? 0,
 			issuesClosed: issuesClosed ?? 0,


### PR DESCRIPTION
Follow-up. Fixes the "how are there fewer commits than PRs merged?" oddity.

The repo is **squash-merge only**, so every merged PR is exactly one commit on `main` — the Commits number should therefore be **≥** PRs merged. It wasn't (e.g. 34 commits vs 47–50 PRs) because the Commits KPI was derived from GitHub's weekly `/stats/commit_activity`:
- it's **week-aligned** (I summed 4 whole ISO weeks ≈ 28 days, not the exact 30-day window the other KPIs use), and
- it's an **async, cached stat that lags/undercounts** — it reported 37 for those weeks vs the true **54**.

So it was a stale-weekly-stat-vs-live-exact-search mismatch, not a real "fewer commits than PRs."

**Fix:** count commits via the Search API's `commits` index over the same rolling 30-day window (`committer-date:>=…`), falling back to the weekly sum only when that search is unavailable (e.g. no token). The weekly `commit_activity` series is still used for the trend chart, which is what it's good at.

Verified live: **commits=54, prsMerged=50** (was 34). `check-types` ✅.
