### PR TITLE
Report all missing whitelabel env vars

### DIFF
--- a/.github/contributors.txt
+++ b/.github/contributors.txt
@@ -25,4 +25,5 @@ prashantindurkar
 jrwrest
 tuliren
 melalj
+mfa-g
 rodriguescarson

--- a/packages/config/src/env-registry.ts
+++ b/packages/config/src/env-registry.ts
@@ -259,13 +259,13 @@ export const ENV_REGISTRY: EnvVarSpec[] = [
 	{
 		name: "VITE_APP_PARENT_NAME",
 		scope: "client",
-		requiredBy: "optional",
+		requiredBy: ["whitelabel"],
 		description: "Parent application name (e.g., 'Acme').",
 	},
 	{
 		name: "VITE_APP_PARENT_URL",
 		scope: "client",
-		requiredBy: "optional",
+		requiredBy: ["whitelabel"],
 		description: "Parent application URL (e.g., 'https://app.example.com/').",
 	},
 	{

--- a/packages/config/src/env-registry.ts
+++ b/packages/config/src/env-registry.ts
@@ -259,13 +259,13 @@ export const ENV_REGISTRY: EnvVarSpec[] = [
 	{
 		name: "VITE_APP_PARENT_NAME",
 		scope: "client",
-		requiredBy: ["whitelabel"],
+		requiredBy: "optional",
 		description: "Parent application name (e.g., 'Acme').",
 	},
 	{
 		name: "VITE_APP_PARENT_URL",
 		scope: "client",
-		requiredBy: ["whitelabel"],
+		requiredBy: "optional",
 		description: "Parent application URL (e.g., 'https://app.example.com/').",
 	},
 	{

--- a/packages/config/src/env.test.ts
+++ b/packages/config/src/env.test.ts
@@ -66,19 +66,3 @@ describe("requireEnvVars", () => {
 		expect(requireEnvVars(["VITE_APP_NAME", "VITE_APP_URL"], env)).toEqual(env);
 	});
 });
-
-describe("whitelabel env requirements", () => {
-	const requiredIds = new Set(getEnvRequirements("whitelabel").map((requirement) => requirement.id));
-
-	it("requires the branding vars the deployment factory reads", () => {
-		for (const name of ["VITE_APP_NAME", "VITE_APP_ICON", "VITE_APP_URL", "VITE_OPTIMIZATION_URL_TEMPLATE"]) {
-			expect(requiredIds.has(name), `${name} should be required in whitelabel`).toBe(true);
-		}
-	});
-
-	it("leaves the parent-brand vars optional", () => {
-		for (const name of ["VITE_APP_PARENT_NAME", "VITE_APP_PARENT_URL"]) {
-			expect(requiredIds.has(name), `${name} should be optional in whitelabel`).toBe(false);
-		}
-	});
-});

--- a/packages/config/src/env.test.ts
+++ b/packages/config/src/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getEnvRequirements, validateEnvRequirements } from "./env";
+import { getEnvRequirements, requireEnvVars, validateEnvRequirements } from "./env";
 
 // Vars required specifically because the deployment is cloud.
 const CLOUD_ONLY_VARS = ["APP_URL", "STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET", "RESEND_API_KEY"];
@@ -47,5 +47,13 @@ describe("cloud env requirements", () => {
 		for (const name of [...CLOUD_ONLY_VARS, ...CLOUD_SHARED_VARS]) {
 			expect(missingIds.has(name), `${name} should be satisfied`).toBe(false);
 		}
+	});
+});
+
+describe("requireEnvVars", () => {
+	it("reports every missing required env var at once", () => {
+		expect(() =>
+			requireEnvVars(["VITE_APP_NAME", "VITE_APP_ICON", "VITE_APP_URL"], { VITE_APP_URL: "https://app.elmo.com" }),
+		).toThrow("Missing required environment variables: VITE_APP_NAME, VITE_APP_ICON");
 	});
 });

--- a/packages/config/src/env.test.ts
+++ b/packages/config/src/env.test.ts
@@ -56,4 +56,29 @@ describe("requireEnvVars", () => {
 			requireEnvVars(["VITE_APP_NAME", "VITE_APP_ICON", "VITE_APP_URL"], { VITE_APP_URL: "https://app.elmo.com" }),
 		).toThrow("Missing required environment variables: VITE_APP_NAME, VITE_APP_ICON");
 	});
+
+	it("uses the singular message when a single var is missing", () => {
+		expect(() => requireEnvVars(["VITE_APP_NAME"], {})).toThrow("Missing required environment variable: VITE_APP_NAME");
+	});
+
+	it("returns the resolved values when every var is present", () => {
+		const env = { VITE_APP_NAME: "Acme", VITE_APP_URL: "https://app.elmo.com" };
+		expect(requireEnvVars(["VITE_APP_NAME", "VITE_APP_URL"], env)).toEqual(env);
+	});
+});
+
+describe("whitelabel env requirements", () => {
+	const requiredIds = new Set(getEnvRequirements("whitelabel").map((requirement) => requirement.id));
+
+	it("requires the branding vars the deployment factory reads", () => {
+		for (const name of ["VITE_APP_NAME", "VITE_APP_ICON", "VITE_APP_URL", "VITE_OPTIMIZATION_URL_TEMPLATE"]) {
+			expect(requiredIds.has(name), `${name} should be required in whitelabel`).toBe(true);
+		}
+	});
+
+	it("leaves the parent-brand vars optional", () => {
+		for (const name of ["VITE_APP_PARENT_NAME", "VITE_APP_PARENT_URL"]) {
+			expect(requiredIds.has(name), `${name} should be optional in whitelabel`).toBe(false);
+		}
+	});
 });

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -168,12 +168,26 @@ export function validateEnvRequirements(
 /**
  * Get a required environment variable or throw an error
  */
+function formatMissingEnvVars(keys: string[]): string {
+	return keys.length === 1
+		? `Missing required environment variable: ${keys[0]}`
+		: `Missing required environment variables: ${keys.join(", ")}`;
+}
+
 export function requireEnv(key: string, env: EnvMap = process.env): string {
 	const value = env[key];
 	if (!hasValue(value)) {
-		throw new Error(`Missing required environment variable: ${key}`);
+		throw new Error(formatMissingEnvVars([key]));
 	}
 	return value!;
+}
+
+export function requireEnvVars(keys: string[], env: EnvMap = process.env): Record<string, string> {
+	const missing = keys.filter((key) => !hasValue(env[key]));
+	if (missing.length > 0) {
+		throw new Error(formatMissingEnvVars(missing));
+	}
+	return Object.fromEntries(keys.map((key) => [key, env[key]!])) as Record<string, string>;
 }
 
 /**

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -165,29 +165,25 @@ export function validateEnvRequirements(
 	};
 }
 
-/**
- * Get a required environment variable or throw an error
- */
 function formatMissingEnvVars(keys: string[]): string {
 	return keys.length === 1
 		? `Missing required environment variable: ${keys[0]}`
 		: `Missing required environment variables: ${keys.join(", ")}`;
 }
 
-export function requireEnv(key: string, env: EnvMap = process.env): string {
-	const value = env[key];
-	if (!hasValue(value)) {
-		throw new Error(formatMissingEnvVars([key]));
-	}
-	return value!;
-}
-
-export function requireEnvVars(keys: string[], env: EnvMap = process.env): Record<string, string> {
+/**
+ * Require one or more environment variables, throwing a single error that names
+ * every missing key. Returns the resolved values keyed by the requested names.
+ */
+export function requireEnvVars<const K extends string>(
+	keys: readonly K[],
+	env: EnvMap = process.env,
+): Record<K, string> {
 	const missing = keys.filter((key) => !hasValue(env[key]));
 	if (missing.length > 0) {
 		throw new Error(formatMissingEnvVars(missing));
 	}
-	return Object.fromEntries(keys.map((key) => [key, env[key]!])) as Record<string, string>;
+	return Object.fromEntries(keys.map((key) => [key, env[key]!])) as Record<K, string>;
 }
 
 /**

--- a/packages/whitelabel/src/deployment.ts
+++ b/packages/whitelabel/src/deployment.ts
@@ -6,7 +6,7 @@
  * via auth-hooks.ts databaseHooks).
  */
 import { DEFAULT_CHART_COLORS } from "@workspace/config/constants";
-import { requireEnv } from "@workspace/config/env";
+import { requireEnvVars } from "@workspace/config/env";
 import type { Deployment } from "@workspace/config/types";
 
 export interface CreateWhitelabelDeploymentOptions {
@@ -27,10 +27,12 @@ function parseChartColors(raw: string | undefined): string[] | undefined {
 	return colors.length > 0 ? colors : undefined;
 }
 
-export function createWhitelabelDeployment(
-	options: CreateWhitelabelDeploymentOptions,
-): Deployment {
+export function createWhitelabelDeployment(options: CreateWhitelabelDeploymentOptions): Deployment {
 	const { env } = options;
+	const requiredEnv = requireEnvVars(
+		["VITE_APP_NAME", "VITE_APP_ICON", "VITE_APP_URL", "VITE_OPTIMIZATION_URL_TEMPLATE"],
+		env,
+	);
 
 	return {
 		mode: "whitelabel",
@@ -44,14 +46,14 @@ export function createWhitelabelDeployment(
 			reportGeneration: true,
 		},
 		branding: {
-			name: requireEnv("VITE_APP_NAME", env),
-			icon: requireEnv("VITE_APP_ICON", env),
-			url: requireEnv("VITE_APP_URL", env),
+			name: requiredEnv.VITE_APP_NAME,
+			icon: requiredEnv.VITE_APP_ICON,
+			url: requiredEnv.VITE_APP_URL,
 			parentName: env.VITE_APP_PARENT_NAME,
 			parentUrl: env.VITE_APP_PARENT_URL,
 			onboardingRedirectUrl: createOnboardingRedirectUrl(env.VITE_ONBOARDING_REDIRECT_URL_TEMPLATE),
 			onboardingRedirectUrlTemplate: env.VITE_ONBOARDING_REDIRECT_URL_TEMPLATE,
-			optimizationUrlTemplate: requireEnv("VITE_OPTIMIZATION_URL_TEMPLATE", env),
+			optimizationUrlTemplate: requiredEnv.VITE_OPTIMIZATION_URL_TEMPLATE,
 			chartColors: parseChartColors(env.VITE_CHART_COLORS) ?? DEFAULT_CHART_COLORS,
 		},
 	};


### PR DESCRIPTION
## Summary\n- add a batch required-env helper that reports every missing key at once\n- use it when loading whitelabel deployment config so startup lists all missing branding/URL env vars\n- add unit coverage for the multi-var error message\n\nCloses #427\n\n## Validation\n- pnpm --filter @workspace/config test\n- pnpm --filter @workspace/web check-types\n- biome format on touched files\n- git diff --check