### PR TITLE
Serve the repo-activity image from cache, refresh it on a Vercel cron

### DIFF
--- a/apps/www/src/lib/repo-activity/cache.ts
+++ b/apps/www/src/lib/repo-activity/cache.ts
@@ -1,25 +1,21 @@
 /**
- * Upstash-backed cache for the repo-activity snapshot, using a stale-while-
- * revalidate pattern:
- *  - `FRESH_KEY` (5 min TTL) marks the data as fresh; while set, we serve the
- *    cached copy without touching GitHub.
- *  - `DATA_KEY` (24 h TTL) holds the last-good snapshot. When the freshness flag
- *    expires we refetch; if GitHub errors (rate limit, outage) we keep serving
- *    the last-good copy rather than an empty graphic.
+ * Upstash-backed store for the repo-activity snapshot.
  *
- * With no Upstash env configured it falls back to fetching directly per request.
+ * Serving (`readRepoActivitySnapshot`) only ever reads `DATA_KEY`, so
+ * `/repo-activity.svg` responds instantly and never blocks on GitHub — otherwise
+ * the slow refetch rides on the request GitHub's Camo proxy is waiting for and it
+ * times out to a broken image. A Vercel cron calls `refreshRepoActivitySnapshot`
+ * to recompute and persist the snapshot out of band.
+ *
+ * With no Upstash env configured (local dev) both paths fetch directly.
  */
 
 import { Redis } from "@upstash/redis";
-import { CACHE_TTL_SECONDS, REPO } from "./constants";
+import { REPO } from "./constants";
 import { fetchRepoActivityData } from "./github";
 import type { RepoActivityData } from "./types";
 
 const DATA_KEY = `repo-activity:data:${REPO}`;
-const FRESH_KEY = `repo-activity:fresh:${REPO}`;
-const FRESH_TTL_SECONDS = CACHE_TTL_SECONDS;
-/** Shorter freshness when the commit chart is still empty, so it retries soon. */
-const RETRY_TTL_SECONDS = 60;
 const DATA_TTL_SECONDS = 24 * 60 * 60;
 
 function redisClient(): Redis | null {
@@ -29,38 +25,37 @@ function redisClient(): Redis | null {
 	return new Redis({ url, token });
 }
 
-export async function getRepoActivityData(): Promise<RepoActivityData> {
+/**
+ * Read-only serving path: the warm snapshot the cron maintains, or `null` when it's
+ * missing (cold start before the first cron run, or eviction) so the caller can fall
+ * back to a placeholder rather than fetch on the request. Fetches directly only when
+ * Upstash isn't configured (local dev), where Camo timeouts don't apply.
+ */
+export async function readRepoActivitySnapshot(): Promise<RepoActivityData | null> {
 	const redis = redisClient();
 	if (!redis) return fetchRepoActivityData();
+	return redis.get<RepoActivityData>(DATA_KEY);
+}
 
-	const [lastGood, fresh] = await Promise.all([
-		redis.get<RepoActivityData>(DATA_KEY),
-		redis.get<number>(FRESH_KEY),
-	]);
-	if (lastGood && fresh) return lastGood;
+/** Cron path: recompute from GitHub and persist. Throws (leaving the last-good snapshot
+ * intact) if the fetch fails, so a bad refresh never blanks the served image. */
+export async function refreshRepoActivitySnapshot(): Promise<RepoActivityData> {
+	const redis = redisClient();
+	const data = await fetchRepoActivityData();
+	if (!redis) return data;
 
-	try {
-		const data = await fetchRepoActivityData();
-
-		// `/stats/commit_activity` answers 202 while GitHub computes it, so a fresh
-		// snapshot can arrive with an empty commit series. Don't let that regress a
-		// chart we already had: carry over the last-good week data, and mark the
-		// snapshot fresh for only a short window so it refetches (and heals) soon.
-		const missingCommits = data.commitsByWeek.length === 0;
-		if (missingCommits && lastGood && lastGood.commitsByWeek.length > 0) {
+	// `/stats/commit_activity` answers 202 (empty body) while GitHub recomputes it, so
+	// a fresh snapshot can arrive with no commit series. Don't regress a chart we already
+	// had: carry the last-good week data forward until a later refresh heals it.
+	if (data.commitsByWeek.length === 0) {
+		const lastGood = await redis.get<RepoActivityData>(DATA_KEY);
+		if (lastGood && lastGood.commitsByWeek.length > 0) {
 			data.commitsByWeek = lastGood.commitsByWeek;
 			data.releaseWeeks = lastGood.releaseWeeks;
 			data.kpis.commits = lastGood.kpis.commits;
 		}
-		const stillMissing = data.commitsByWeek.length === 0;
-
-		await Promise.all([
-			redis.set(DATA_KEY, data, { ex: DATA_TTL_SECONDS }),
-			redis.set(FRESH_KEY, 1, { ex: stillMissing ? RETRY_TTL_SECONDS : FRESH_TTL_SECONDS }),
-		]);
-		return data;
-	} catch (error) {
-		if (lastGood) return lastGood;
-		throw error;
 	}
+
+	await redis.set(DATA_KEY, data, { ex: DATA_TTL_SECONDS });
+	return data;
 }

--- a/apps/www/src/lib/repo-activity/constants.ts
+++ b/apps/www/src/lib/repo-activity/constants.ts
@@ -5,9 +5,9 @@ import { DEFAULT_CHART_COLORS } from "@workspace/config/constants";
 export const REPO = "elmohq/elmo";
 
 /**
- * Snapshot lifetime: drives both the Upstash freshness window and the response
- * `Cache-Control` max-age, so GitHub's Camo image proxy refreshes the README at
- * the same cadence we recompute the data (instead of holding a stale copy).
+ * Response `Cache-Control` max-age: how often GitHub's Camo image proxy revalidates
+ * the README image. A Vercel cron refreshes the underlying data on its own cadence,
+ * so this only controls how promptly Camo picks up a newer snapshot.
  */
 export const CACHE_TTL_SECONDS = 5 * 60;
 

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -36,6 +36,7 @@ import { Route as BlogRssDotxmlRouteImport } from './routes/blog/rss[.]xml'
 import { Route as BlogSplatRouteImport } from './routes/blog/$'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
 import { Route as ApiOpenapiDotjsonRouteImport } from './routes/api/openapi[.]json'
+import { Route as ApiRepoActivityRefreshRouteImport } from './routes/api/repo-activity/refresh'
 import { Route as AiVisibilityToolsSlugRouteImport } from './routes/ai-visibility-tools/$slug'
 import { Route as AiSearchSlugRouteImport } from './routes/ai-search/$slug'
 import { Route as AeoForSlugRouteImport } from './routes/aeo-for/$slug'
@@ -188,6 +189,11 @@ const ApiOpenapiDotjsonRoute = ApiOpenapiDotjsonRouteImport.update({
   path: '/api/openapi.json',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiRepoActivityRefreshRoute = ApiRepoActivityRefreshRouteImport.update({
+  id: '/api/repo-activity/refresh',
+  path: '/api/repo-activity/refresh',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AiVisibilityToolsSlugRoute = AiVisibilityToolsSlugRouteImport.update({
   id: '/ai-visibility-tools/$slug',
   path: '/ai-visibility-tools/$slug',
@@ -323,6 +329,7 @@ export interface FileRoutesByFullPath {
   '/ai-visibility-tools/features/': typeof AiVisibilityToolsFeaturesIndexRoute
   '/api/plausible/event/': typeof ApiPlausibleEventIndexRoute
   '/api/plausible/js/script/': typeof ApiPlausibleJsScriptIndexRoute
+  '/api/repo-activity/refresh': typeof ApiRepoActivityRefreshRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -368,6 +375,7 @@ export interface FileRoutesByTo {
   '/ai-visibility-tools/features': typeof AiVisibilityToolsFeaturesIndexRoute
   '/api/plausible/event': typeof ApiPlausibleEventIndexRoute
   '/api/plausible/js/script': typeof ApiPlausibleJsScriptIndexRoute
+  '/api/repo-activity/refresh': typeof ApiRepoActivityRefreshRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -414,6 +422,7 @@ export interface FileRoutesById {
   '/ai-visibility-tools/features/': typeof AiVisibilityToolsFeaturesIndexRoute
   '/api/plausible/event/': typeof ApiPlausibleEventIndexRoute
   '/api/plausible/js/script/': typeof ApiPlausibleJsScriptIndexRoute
+  '/api/repo-activity/refresh': typeof ApiRepoActivityRefreshRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -461,6 +470,7 @@ export interface FileRouteTypes {
     | '/ai-visibility-tools/features/'
     | '/api/plausible/event/'
     | '/api/plausible/js/script/'
+    | '/api/repo-activity/refresh'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -506,6 +516,7 @@ export interface FileRouteTypes {
     | '/ai-visibility-tools/features'
     | '/api/plausible/event'
     | '/api/plausible/js/script'
+    | '/api/repo-activity/refresh'
   id:
     | '__root__'
     | '/'
@@ -551,6 +562,7 @@ export interface FileRouteTypes {
     | '/ai-visibility-tools/features/'
     | '/api/plausible/event/'
     | '/api/plausible/js/script/'
+    | '/api/repo-activity/refresh'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -574,6 +586,7 @@ export interface RootRouteChildren {
   AiVisibilityToolsSlugRoute: typeof AiVisibilityToolsSlugRoute
   ApiOpenapiDotjsonRoute: typeof ApiOpenapiDotjsonRoute
   ApiSearchRoute: typeof ApiSearchRoute
+  ApiRepoActivityRefreshRoute: typeof ApiRepoActivityRefreshRoute
   BlogSplatRoute: typeof BlogSplatRoute
   BlogRssDotxmlRoute: typeof BlogRssDotxmlRoute
   DocsSplatRoute: typeof DocsSplatRoute
@@ -783,6 +796,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiSearchRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/repo-activity/refresh': {
+      id: '/api/repo-activity/refresh'
+      path: '/api/repo-activity/refresh'
+      fullPath: '/api/repo-activity/refresh'
+      preLoaderRoute: typeof ApiRepoActivityRefreshRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/openapi.json': {
       id: '/api/openapi.json'
       path: '/api/openapi.json'
@@ -926,6 +946,7 @@ const rootRouteChildren: RootRouteChildren = {
   AiVisibilityToolsSlugRoute: AiVisibilityToolsSlugRoute,
   ApiOpenapiDotjsonRoute: ApiOpenapiDotjsonRoute,
   ApiSearchRoute: ApiSearchRoute,
+  ApiRepoActivityRefreshRoute: ApiRepoActivityRefreshRoute,
   BlogSplatRoute: BlogSplatRoute,
   BlogRssDotxmlRoute: BlogRssDotxmlRoute,
   DocsSplatRoute: DocsSplatRoute,

--- a/apps/www/src/routes/api/repo-activity/refresh.ts
+++ b/apps/www/src/routes/api/repo-activity/refresh.ts
@@ -1,0 +1,37 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { refreshRepoActivitySnapshot } from "@/lib/repo-activity/cache";
+
+/**
+ * Cron target (Vercel Cron): recomputes the repo-activity snapshot and writes it to
+ * Upstash so `/repo-activity.svg` only ever reads a warm cache and never blocks a
+ * request on GitHub's API — the slow refetch is what makes Camo time out and show a
+ * broken image on the README.
+ *
+ * Vercel sends `Authorization: Bearer $CRON_SECRET` on cron invocations; reject
+ * anything else so the ~14-call GitHub refresh can't be triggered by the public.
+ *
+ *   /api/repo-activity/refresh
+ */
+export const Route = createFileRoute("/api/repo-activity/refresh")({
+	server: {
+		handlers: {
+			GET: async ({ request }) => {
+				const secret = process.env.CRON_SECRET;
+				if (!secret || request.headers.get("authorization") !== `Bearer ${secret}`) {
+					return new Response("Unauthorized", { status: 401 });
+				}
+
+				try {
+					const data = await refreshRepoActivitySnapshot();
+					return new Response(
+						JSON.stringify({ ok: true, commitWeeks: data.commitsByWeek.length }),
+						{ headers: { "Content-Type": "application/json" } },
+					);
+				} catch (error) {
+					console.error("repo-activity refresh failed", error);
+					return new Response("Refresh failed", { status: 500 });
+				}
+			},
+		},
+	},
+});

--- a/apps/www/src/routes/repo-activity[.]svg.ts
+++ b/apps/www/src/routes/repo-activity[.]svg.ts
@@ -1,12 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { getRepoActivityData } from "@/lib/repo-activity/cache";
+import { readRepoActivitySnapshot } from "@/lib/repo-activity/cache";
 import { CACHE_TTL_SECONDS } from "@/lib/repo-activity/constants";
 import { renderFallback, renderRepoActivity } from "@/lib/repo-activity/svg";
 
 /**
- * Self-hosted, brand-matched repository-activity SVG — a replacement for the
- * external Repobeats embed that caches in Upstash (5-minute freshness) and
- * filters out bot contributors.
+ * Self-hosted, brand-matched repository-activity SVG for the README — a replacement
+ * for the external Repobeats embed. Serves a warm Upstash snapshot that a Vercel cron
+ * keeps fresh, so the response is instant and never blocks on GitHub (a slow refetch
+ * on the request is what makes Camo time out to a broken image).
  *
  *   /repo-activity.svg
  */
@@ -16,8 +17,8 @@ export const Route = createFileRoute("/repo-activity.svg")({
 			GET: async () => {
 				let svg: string;
 				try {
-					const data = await getRepoActivityData();
-					svg = renderRepoActivity(data);
+					const data = await readRepoActivitySnapshot();
+					svg = data ? renderRepoActivity(data) : renderFallback();
 				} catch {
 					svg = renderFallback();
 				}
@@ -25,9 +26,10 @@ export const Route = createFileRoute("/repo-activity.svg")({
 				return new Response(svg, {
 					headers: {
 						"Content-Type": "image/svg+xml; charset=utf-8",
-						// Match our snapshot lifetime so GitHub's Camo proxy refreshes the
-						// README at the same cadence. No long stale-while-revalidate — that
-						// let Camo serve a day-old image after max-age expired.
+						// max-age is how often Camo revalidates the README image; the cron keeps
+						// the snapshot warm so each revalidation reads instantly. No long
+						// stale-while-revalidate — that let Camo serve a day-old image after
+						// max-age expired.
 						"Cache-Control": `public, max-age=${CACHE_TTL_SECONDS}, s-maxage=${CACHE_TTL_SECONDS}`,
 					},
 				});

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -51,6 +51,13 @@ export default defineConfig({
 						minimumCacheTTL: 31536000,
 						formats: ["image/webp"],
 					},
+					// Keeps the README repo-activity snapshot warm in Upstash so
+					// `/repo-activity.svg` only ever reads cache. Every 15 min stays
+					// well under GitHub's 30/min Search API limit (~14 search calls
+					// per refresh).
+					crons: [
+						{ path: "/api/repo-activity/refresh", schedule: "*/15 * * * *" },
+					],
 				},
 			},
 		}),


### PR DESCRIPTION
## Problem

Loading the GitHub repo page sometimes renders the README's repo-activity image as a broken-image icon. The handler for `/repo-activity.svg` refetched from GitHub **inline** whenever the Upstash freshness flag expired (every 5 min). That refetch is ~14 GitHub Search API calls plus inlining 12 contributor avatars — fired on the very request GitHub's Camo image proxy is waiting on. It blows past Camo's short fetch timeout, so Camo shows the error image.

## Fix

Take GitHub off the serving path entirely and move refresh to a Vercel cron.

- **Serving (`readRepoActivitySnapshot`)** now only reads the cached `DATA_KEY` snapshot and returns instantly. On a cold cache (before the first cron run, or eviction) it renders the existing placeholder SVG instead of fetching — so the response is *always* fast and Camo never times out. (With no Upstash configured, i.e. local dev, it still fetches directly since Camo isn't involved there.)
- **Refresh (`refreshRepoActivitySnapshot`)** recomputes from GitHub and writes the snapshot. It's exposed at `GET /api/repo-activity/refresh`, gated by `CRON_SECRET` (Vercel sends `Authorization: Bearer $CRON_SECRET` on cron invocations), and invoked by a Vercel cron **every 15 minutes**.

### Why 15 minutes

The binding constraint is GitHub's authenticated **Search API limit of 30 requests/minute**, and one refresh bursts ~14 of them concurrently. 15-min cadence has large headroom, and the underlying data (30-day / 30-week rolling aggregates) changes far too slowly for anyone to notice finer freshness. The response `Cache-Control: max-age=300` is unchanged — it just controls how often Camo revalidates; the cron keeps the snapshot warm so each revalidation reads instantly.

## Notes

- Cron is declared via the Nitro Vercel preset (`vite.config.ts` → `nitro.vercel.config.crons`), which lands in the Build Output API `config.json`. **After deploy, verify it appears under Vercel → Settings → Cron Jobs.**
- `CRON_SECRET` is already set on Vercel.
- No changeset — this is internal infra for the README image, not a product-user-facing change.
- `routeTree.gen.ts` was updated by hand to register the new route (the generator will reproduce it on the next `vite build`).