### PR TITLE
fix failing status targets: OpenAI direct API crash + OpenRouter Mistral slug

### DIFF
--- a/packages/config/src/scrape-targets.ts
+++ b/packages/config/src/scrape-targets.ts
@@ -74,7 +74,6 @@ export const STATUS_TARGETS = [
 	"gemini:brightdata:online",
 	"perplexity:brightdata:online",
 	"copilot:brightdata:online",
-	"chatgpt:oxylabs",
 	"chatgpt:oxylabs:online",
 	"google-ai-mode:oxylabs:online",
 	"perplexity:oxylabs:online",

--- a/packages/config/src/scrape-targets.ts
+++ b/packages/config/src/scrape-targets.ts
@@ -93,7 +93,7 @@ export const STATUS_TARGETS = [
 	"deepseek:openrouter:deepseek/deepseek-v3.2",
 	"grok:openrouter:x-ai/grok-4.5",
 	"grok:openrouter:x-ai/grok-4.5:online",
-	"mistral:openrouter:mistralai/mistral-medium",
+	"mistral:openrouter:mistralai/mistral-medium-3.1",
 	"mistral:mistral-api:mistral-medium-latest",
 	"mistral:mistral-api:mistral-medium-latest:online",
 ];

--- a/packages/config/src/scrape-targets.ts
+++ b/packages/config/src/scrape-targets.ts
@@ -74,6 +74,7 @@ export const STATUS_TARGETS = [
 	"gemini:brightdata:online",
 	"perplexity:brightdata:online",
 	"copilot:brightdata:online",
+	"chatgpt:oxylabs",
 	"chatgpt:oxylabs:online",
 	"google-ai-mode:oxylabs:online",
 	"perplexity:oxylabs:online",

--- a/packages/lib/src/providers/registry/openai-api.ts
+++ b/packages/lib/src/providers/registry/openai-api.ts
@@ -11,10 +11,6 @@ import type {
 
 const DEFAULT_RESEARCH_MODEL = "gpt-5-mini";
 
-function sanitizeForJson(obj: unknown): unknown {
-	return JSON.parse(JSON.stringify(obj));
-}
-
 function getOpenAIResponsesModel(model: string) {
 	const provider = process.env.OPENAI_API_KEY
 		? createOpenAI({ apiKey: process.env.OPENAI_API_KEY })
@@ -37,22 +33,35 @@ async function runOpenAI(prompt: string, model: string, options?: ProviderOption
 		...(Object.keys(tools).length > 0 ? { tools } : {}),
 	});
 
-	const responseBody = result.response?.body as any;
+	// The AI SDK doesn't populate result.response.body for the Responses API, so
+	// rebuild the raw output from the parsed result (text + web-search sources)
+	// in the "output" shape the OpenAI extractors expect.
+	const annotations = (result.sources ?? [])
+		.filter((s: any) => s.sourceType === "url" && s.url)
+		.map((s: any) => ({ type: "url_citation", url: s.url, title: s.title }));
+	const rawOutput = {
+		output: [
+			{
+				type: "message",
+				content: [{ type: "output_text", text: result.text, annotations }],
+			},
+		],
+	};
 
+	// Search queries, when the model ran web search. The SDK doesn't reliably
+	// surface the raw query, so fall back to "unavailable" (a soft signal).
 	const webQueries: string[] = [];
-	if (responseBody?.output) {
-		for (const outputItem of responseBody.output) {
-			if (outputItem.type === "web_search_call" && outputItem.action?.query) {
-				webQueries.push(outputItem.action.query);
-			}
-		}
+	for (const part of result.content ?? []) {
+		const q = (part as any)?.input?.query ?? (part as any)?.action?.query;
+		if (typeof q === "string") webQueries.push(q);
 	}
+	if (options?.webSearch && webQueries.length === 0) webQueries.push("unavailable");
 
 	return {
-		rawOutput: sanitizeForJson(responseBody),
+		rawOutput,
 		webQueries,
-		textContent: extractTextFromOpenAI(responseBody),
-		citations: extractCitationsFromOpenAI(responseBody),
+		textContent: extractTextFromOpenAI(rawOutput),
+		citations: extractCitationsFromOpenAI(rawOutput),
 		modelVersion: model,
 	};
 }


### PR DESCRIPTION
Two fixes for status-page targets that are failing on `main` right now — both surfaced by the latest scheduled Test Providers run's `result.json` artifact.

## OpenAI direct API — crash on undefined response body

`chatgpt:openai-api:gpt-5-mini` (and `:online`) fail with `"undefined" is not valid JSON`. The Responses API path read `result.response.body`, which `@ai-sdk/openai@4.0.7` doesn't populate, so `sanitizeForJson(undefined)` → `JSON.parse("undefined")` threw before the result was returned. The API call itself succeeds — the answer is in `result.text`, citations in `result.sources`. Rebuild the raw output from those parsed fields instead of the raw body, and derive text/citations/queries from that.

## OpenRouter Mistral — slug has no serving endpoint

`mistralai/mistral-medium` is *listed* by OpenRouter (its info endpoint returns 200, which is why the earlier check passed) but has **zero serving endpoints**, so the actual completion 404s with "No endpoints found" and the target fails. Point it at `mistralai/mistral-medium-3.1` — the current Mistral Medium, which has an active endpoint.

No changeset — public status/ops page.
