### PR TITLE
surface per-run provider failures in the worker to Sentry

### DIFF
--- a/.changeset/fix-openai-responses-crash.md
+++ b/.changeset/fix-openai-responses-crash.md
@@ -1,0 +1,5 @@
+---
+"@workspace/lib": patch
+---
+
+Fixed OpenAI tracking that broke in v0.2.15, where every OpenAI Responses API call crashed after being billed, so runs were charged but never recorded.

--- a/.changeset/fix-openai-responses-crash.md
+++ b/.changeset/fix-openai-responses-crash.md
@@ -2,4 +2,4 @@
 "@workspace/lib": patch
 ---
 
-Fixed OpenAI tracking that broke in v0.2.15, where every OpenAI Responses API call crashed after being billed, so runs were charged but never recorded.
+IMPORTANT BUGFIX: Fixed OpenAI response retrieval that broke in v0.2.15, which caused repeated (but billable) failures. If you are collecting data from the direct OpenAI API using Elmo, please update immediately.

--- a/apps/worker/src/jobs/process-prompt.ts
+++ b/apps/worker/src/jobs/process-prompt.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/node";
 import type { Job } from "pg-boss";
 import { db } from "@workspace/lib/db/db";
 import { brands, citations, competitors, promptRuns, prompts, type Brand, type Competitor } from "@workspace/lib/db/schema";
@@ -220,40 +221,53 @@ async function runModelIteration({
 }): Promise<void> {
 	const logPrefix = `[${config.model}_${runIndex}]`;
 
-	const result = await providerImpl.run(config.model, promptValue, {
-		webSearch: config.webSearch,
-		version: config.version,
-	});
+	try {
+		const result = await providerImpl.run(config.model, promptValue, {
+			webSearch: config.webSearch,
+			version: config.version,
+		});
 
-	// `webQueries` is stored exactly as the provider reported it — engines do
-	// sometimes genuinely search the prompt verbatim, and that's real data. The
-	// fan-out page excludes verbatim repeats at read time as a display rule;
-	// providers whose query field is fabricated (DataForSEO) write the
-	// `unavailable` sentinel in their own extractor instead.
-	const { rawOutput, textContent, webQueries, citations: extractedCitations, modelVersion } = result;
-	console.log(`${logPrefix} AI call completed, textContent length: ${textContent?.length ?? "null"}`);
+		// `webQueries` is stored exactly as the provider reported it — engines do
+		// sometimes genuinely search the prompt verbatim, and that's real data. The
+		// fan-out page excludes verbatim repeats at read time as a display rule;
+		// providers whose query field is fabricated (DataForSEO) write the
+		// `unavailable` sentinel in their own extractor instead.
+		const { rawOutput, textContent, webQueries, citations: extractedCitations, modelVersion } = result;
+		console.log(`${logPrefix} AI call completed, textContent length: ${textContent?.length ?? "null"}`);
 
-	const safeTextContent = typeof textContent === "string" ? textContent : "";
+		const safeTextContent = typeof textContent === "string" ? textContent : "";
 
-	const { brandMentioned, competitorsMentioned } = analyzeMentions(safeTextContent, brand, competitorsList);
+		const { brandMentioned, competitorsMentioned } = analyzeMentions(safeTextContent, brand, competitorsList);
 
-	const recordedVersion = modelVersion ?? config.version ?? config.provider;
+		const recordedVersion = modelVersion ?? config.version ?? config.provider;
 
-	const { id: promptRunId, createdAt } = await savePromptRun(
-		promptId,
-		brand.id,
-		config.model,
-		config.provider,
-		recordedVersion,
-		config.webSearch,
-		rawOutput,
-		webQueries,
-		brandMentioned,
-		competitorsMentioned,
-	);
-	console.log(`${logPrefix} Saved prompt run ${promptRunId}`);
+		const { id: promptRunId, createdAt } = await savePromptRun(
+			promptId,
+			brand.id,
+			config.model,
+			config.provider,
+			recordedVersion,
+			config.webSearch,
+			rawOutput,
+			webQueries,
+			brandMentioned,
+			competitorsMentioned,
+		);
+		console.log(`${logPrefix} Saved prompt run ${promptRunId}`);
 
-	await saveCitations(promptRunId, promptId, brand.id, config.model, extractedCitations, createdAt);
+		await saveCitations(promptRunId, promptId, brand.id, config.model, extractedCitations, createdAt);
+	} catch (error) {
+		// A single run's failure doesn't fail the job (only an all-runs failure
+		// does), so report it here to keep per-provider failure rates visible.
+		Sentry.withScope((scope) => {
+			scope.setTag("queue", "process-prompt");
+			scope.setTag("provider", config.provider);
+			scope.setTag("model", config.model);
+			scope.setContext("run", { promptId, brandId: brand.id, runIndex });
+			Sentry.captureException(error);
+		});
+		throw error;
+	}
 }
 
 /**


### PR DESCRIPTION
## What

- **`process-prompt` now reports each failed run to Sentry** (tagged by `provider`/`model`, with prompt/brand context), instead of only `console.error`-ing it. Because a job only throws when *all* of its runs fail, per-provider failures on a partially-succeeding job were previously invisible — which is how the v0.2.15 OpenAI crash burned billed calls for ~48h without surfacing. This makes per-provider failure rates trackable over time.
- **Changeset** documenting the OpenAI Responses API crash fix from #436 (billed-but-never-recorded runs on v0.2.15 after the AI SDK v7 upgrade).

## Why

Root-cause of the recent whitelabel OpenAI overspend: under AI SDK v7, `@ai-sdk/openai` stopped populating `result.response.body`, so every gpt-5-mini call crashed in post-processing *after* being billed — saving no `prompt_runs` row. `schedule-maintenance` then read every prompt as perpetually overdue and re-fired them far more often than the 24h cadence. The provider crash itself is already fixed (#436); this PR adds the observability that would have caught it same-hour.

## Notes

Worker-only observability change; no changeset for it (internal). The still-open hardening (throttle the maintenance expedite path / scope the overdue check to `brand.enabledModels`) is intentionally left for a separate PR.