### PR TITLE
throttle schedule-maintenance's expedite path

### DIFF
--- a/apps/worker/src/jobs/schedule-maintenance.ts
+++ b/apps/worker/src/jobs/schedule-maintenance.ts
@@ -11,6 +11,15 @@ export interface ScheduleMaintenanceData {
 }
 
 /**
+ * Minimum time since a prompt's last run before maintenance will expedite its
+ * next job again. Without it, a target that never records a run (e.g. a
+ * consistently-failing provider) keeps every prompt perpetually "overdue", so
+ * maintenance re-fires it every tick — turning one broken provider into a
+ * fleet-wide run/cost storm. Mirrors the 1h throttle on the job-creation path.
+ */
+const EXPEDITE_MIN_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
  * Maintenance job that ensures all enabled prompts have scheduled jobs.
  * This is a self-healing mechanism that catches any prompts that fell through
  * the cracks (e.g., due to worker crashes, failed jobs, etc.).
@@ -119,6 +128,14 @@ async function runMaintenanceCheck(): Promise<void> {
 		if (!isOverdue) continue;
 
 		if (pendingJob && pendingJob.state === "created") {
+			// Throttle: if the prompt ran within the window it isn't really stalled,
+			// so don't drag its next job forward again. A never-recording target
+			// would otherwise keep it perpetually "overdue" and re-fire it every tick.
+			const lastRunTimes = Object.values(lastRuns).map((d) => new Date(d).getTime());
+			const mostRecentRunMs = lastRunTimes.length > 0 ? Math.max(...lastRunTimes) : null;
+			if (mostRecentRunMs !== null && now - mostRecentRunMs < Math.min(runFrequencyMs, EXPEDITE_MIN_INTERVAL_MS)) {
+				continue;
+			}
 			// There's a future job scheduled - expedite it to run now
 			jobsToExpedite.push(pendingJob.jobId);
 		} else {


### PR DESCRIPTION
## What

Throttles the expedite path in `schedule-maintenance`: a prompt that ran within `min(cadence, 1h)` is no longer dragged forward again. The expedite path (raw `UPDATE pgboss.job SET start_after = now()`) previously had **no throttle** — unlike the job-creation path's 1h singleton — so a target that never records a run (e.g. a failing provider) kept every prompt perpetually "overdue" and re-fired it on every 5-min maintenance tick.

## Why

Blast-radius cap for the failure mode behind the recent whitelabel OpenAI overspend: one silently-failing provider → fleet-wide re-firing (~10x runs + spend, flat prompts/brands). This caps re-firing to ~hourly, matching the existing create-path throttle. Genuinely-overdue prompts (all models stale / never run) are unaffected — the guard only skips prompts that already ran recently, which is exactly the spurious-overdue storm case.

## Scope

Throttle only, as requested. The other options in #439 — scoping the overdue check to `brand.enabledModels`, and basing "overdue" on scheduling state rather than data recency — are deferred. No changeset (internal worker behavior).

Addresses #439.