### PR TITLE
unify overdue-prompt logic so the Sentry alert matches the dashboard

### DIFF
--- a/apps/web/src/server/admin.ts
+++ b/apps/web/src/server/admin.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/postgres-read";
 import { analyzeBrand } from "@workspace/lib/onboarding";
 import { getDefaultDelayHours } from "@workspace/lib/constants";
+import { getModelOverdueStatus } from "@workspace/lib/overdue";
 import { sendImmediatePromptJob } from "@/lib/job-scheduler";
 import { Client } from "pg";
 import { parseScrapeTargets } from "@workspace/lib/providers";
@@ -604,23 +605,15 @@ export const getWorkflowDataFn = createServerFn({ method: "GET" }).handler(async
 
 			for (const model of modelList) {
 				const lastRunAt = lastRuns[model] || null;
-				let isOverdue = false;
-				let overdueByMs: number | null = null;
-
-				if (prompt.enabled) {
-					if (lastRunAt) {
-						const timeSinceRun = now - new Date(lastRunAt).getTime();
-						if (timeSinceRun > runFrequencyMs) {
-							isOverdue = true;
-							overdueByMs = timeSinceRun - runFrequencyMs;
-							anyOverdue = true;
-						}
-					} else {
-						isOverdue = true;
-						anyOverdue = true;
-					}
-				}
-
+				const { isOverdue, overdueByMs } = prompt.enabled
+					? getModelOverdueStatus({
+							lastRunAt,
+							promptCreatedAt: prompt.createdAt,
+							runFrequencyMs,
+							now,
+						})
+					: { isOverdue: false, overdueByMs: null };
+				if (isOverdue) anyOverdue = true;
 				lastRunsByModel[model] = { lastRunAt, isOverdue, overdueByMs };
 			}
 

--- a/apps/worker/src/jobs/schedule-maintenance.ts
+++ b/apps/worker/src/jobs/schedule-maintenance.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/node";
 import { getDefaultDelayHours } from "@workspace/lib/constants";
 import { db } from "@workspace/lib/db/db";
 import { brands, promptRuns, prompts } from "@workspace/lib/db/schema";
+import { isPromptOverdue } from "@workspace/lib/overdue";
 import { parseScrapeTargets } from "@workspace/lib/providers";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import type { Job } from "pg-boss";
@@ -32,8 +33,6 @@ const EXPEDITE_MIN_INTERVAL_MS = 60 * 60 * 1000;
  * Maintenance job that ensures all enabled prompts have scheduled jobs.
  * This is a self-healing mechanism that catches any prompts that fell through
  * the cracks (e.g., due to worker crashes, failed jobs, etc.).
- *
- * Runs every 6 hours via pg-boss schedule.
  */
 export async function scheduleMaintenanceJob(jobs: Job<ScheduleMaintenanceData>[]): Promise<void> {
 	for (const job of jobs) {
@@ -112,6 +111,7 @@ async function runMaintenanceCheck(): Promise<void> {
 		brandDelayHours: brandDelayMap,
 		defaultDelayHours,
 		lastRunsMap,
+		modelNames,
 		now,
 	});
 
@@ -127,20 +127,13 @@ async function runMaintenanceCheck(): Promise<void> {
 		const runFrequencyMs = cadenceHours * 60 * 60 * 1000;
 		const lastRuns = lastRunsMap[prompt.id] || {};
 
-		// Check if any model is overdue (matches dashboard logic)
-		let isOverdue = false;
-		for (const model of modelNames) {
-			const lastRunAt = lastRuns[model];
-			if (!lastRunAt) {
-				isOverdue = true;
-				break;
-			}
-			const timeSinceRun = now - new Date(lastRunAt).getTime();
-			if (timeSinceRun > runFrequencyMs) {
-				isOverdue = true;
-				break;
-			}
-		}
+		const isOverdue = isPromptOverdue({
+			models: modelNames,
+			lastRunByModel: lastRuns,
+			promptCreatedAt: prompt.createdAt,
+			runFrequencyMs,
+			now,
+		});
 
 		if (!isOverdue) continue;
 
@@ -231,29 +224,32 @@ async function runMaintenanceCheck(): Promise<void> {
 }
 
 /**
- * Report to Sentry (as an error, so it pages) when enabled prompts are overdue —
- * i.e. haven't produced a run in more than their cadence plus a grace window, or
- * have never run. Throttled in-process so a sustained outage doesn't emit a new
- * event on every maintenance tick.
+ * Report to Sentry (as an error, so it pages) when enabled prompts are overdue on
+ * any of their models — the same per-model definition the dashboard uses — past a
+ * grace window. Throttled in-process so a sustained outage doesn't emit a new event
+ * on every maintenance tick.
  */
 function reportOverduePrompts(input: {
 	prompts: { id: string; brandId: string; createdAt: Date }[];
 	brandDelayHours: Record<string, number>;
 	defaultDelayHours: number;
 	lastRunsMap: Record<string, Record<string, Date>>;
+	modelNames: string[];
 	now: number;
 }): void {
-	const { prompts: enabled, brandDelayHours, defaultDelayHours, lastRunsMap, now } = input;
+	const { prompts: enabled, brandDelayHours, defaultDelayHours, lastRunsMap, modelNames, now } = input;
 
 	let overduePrompts = 0;
 	for (const prompt of enabled) {
-		const cadenceMs = (brandDelayHours[prompt.brandId] ?? defaultDelayHours) * 60 * 60 * 1000;
-		const runs = lastRunsMap[prompt.id];
-		const runTimes = runs ? Object.values(runs).map((d) => new Date(d).getTime()) : [];
-		const overdue =
-			runTimes.length === 0
-				? now - new Date(prompt.createdAt).getTime() > OVERDUE_ALERT_GRACE_MS
-				: now - Math.max(...runTimes) > cadenceMs + OVERDUE_ALERT_GRACE_MS;
+		const runFrequencyMs = (brandDelayHours[prompt.brandId] ?? defaultDelayHours) * 60 * 60 * 1000;
+		const overdue = isPromptOverdue({
+			models: modelNames,
+			lastRunByModel: lastRunsMap[prompt.id] ?? {},
+			promptCreatedAt: prompt.createdAt,
+			runFrequencyMs,
+			now,
+			graceMs: OVERDUE_ALERT_GRACE_MS,
+		});
 		if (overdue) overduePrompts++;
 	}
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -17,6 +17,7 @@
     "./auth/client": "./src/auth/client.ts",
     "./auth/permissions": "./src/auth/permissions.ts",
     "./constants": "./src/constants.ts",
+    "./overdue": "./src/overdue.ts",
     "./text-extraction": "./src/text-extraction.ts",
     "./dataforseo": "./src/dataforseo.ts",
     "./onboarding": "./src/onboarding/index.ts",

--- a/packages/lib/src/overdue.test.ts
+++ b/packages/lib/src/overdue.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { getModelOverdueStatus, isPromptOverdue } from "./overdue";
+
+const HOUR = 60 * 60 * 1000;
+const MINUTE = 60 * 1000;
+const now = 1_000_000_000_000;
+const runFrequencyMs = 24 * HOUR;
+const createdLongAgo = new Date(now - 5 * 24 * HOUR);
+
+describe("getModelOverdueStatus", () => {
+	it("flags a never-run model once the prompt is past the grace window", () => {
+		expect(getModelOverdueStatus({ lastRunAt: null, promptCreatedAt: createdLongAgo, runFrequencyMs, now })).toEqual({
+			isOverdue: true,
+			overdueByMs: null,
+		});
+	});
+
+	it("does not flag a run within cadence", () => {
+		expect(
+			getModelOverdueStatus({
+				lastRunAt: new Date(now - HOUR),
+				promptCreatedAt: createdLongAgo,
+				runFrequencyMs,
+				now,
+			}),
+		).toEqual({ isOverdue: false, overdueByMs: null });
+	});
+
+	it("reports how far past cadence an overdue run is (dashboard view, no grace)", () => {
+		expect(
+			getModelOverdueStatus({
+				lastRunAt: new Date(now - 25 * HOUR),
+				promptCreatedAt: createdLongAgo,
+				runFrequencyMs,
+				now,
+			}),
+		).toEqual({ isOverdue: true, overdueByMs: HOUR });
+	});
+
+	it("holds off within the grace window and fires past it", () => {
+		const graceMs = 30 * MINUTE;
+		expect(
+			getModelOverdueStatus({
+				lastRunAt: new Date(now - (24 * HOUR + 10 * MINUTE)),
+				promptCreatedAt: createdLongAgo,
+				runFrequencyMs,
+				now,
+				graceMs,
+			}).isOverdue,
+		).toBe(false);
+		expect(
+			getModelOverdueStatus({
+				lastRunAt: new Date(now - (24 * HOUR + 40 * MINUTE)),
+				promptCreatedAt: createdLongAgo,
+				runFrequencyMs,
+				now,
+				graceMs,
+			}),
+		).toEqual({ isOverdue: true, overdueByMs: 40 * MINUTE });
+	});
+
+	it("gives freshly-created prompts the grace window before flagging a missing run", () => {
+		const graceMs = 30 * MINUTE;
+		expect(
+			getModelOverdueStatus({
+				lastRunAt: null,
+				promptCreatedAt: new Date(now - 20 * MINUTE),
+				runFrequencyMs,
+				now,
+				graceMs,
+			}).isOverdue,
+		).toBe(false);
+		expect(
+			getModelOverdueStatus({
+				lastRunAt: null,
+				promptCreatedAt: new Date(now - 40 * MINUTE),
+				runFrequencyMs,
+				now,
+				graceMs,
+			}).isOverdue,
+		).toBe(true);
+	});
+});
+
+describe("isPromptOverdue", () => {
+	it("is overdue when any single model is behind, even if another ran recently", () => {
+		expect(
+			isPromptOverdue({
+				models: ["openai", "perplexity"],
+				lastRunByModel: { openai: new Date(now - HOUR) },
+				promptCreatedAt: createdLongAgo,
+				runFrequencyMs,
+				now,
+			}),
+		).toBe(true);
+	});
+
+	it("is on schedule when every model ran within cadence", () => {
+		expect(
+			isPromptOverdue({
+				models: ["openai", "perplexity"],
+				lastRunByModel: { openai: new Date(now - HOUR), perplexity: new Date(now - 2 * HOUR) },
+				promptCreatedAt: createdLongAgo,
+				runFrequencyMs,
+				now,
+			}),
+		).toBe(false);
+	});
+
+	it("honors the grace window across models", () => {
+		const lastRunByModel = { openai: new Date(now - (24 * HOUR + 10 * MINUTE)) };
+		expect(
+			isPromptOverdue({ models: ["openai"], lastRunByModel, promptCreatedAt: createdLongAgo, runFrequencyMs, now }),
+		).toBe(true);
+		expect(
+			isPromptOverdue({
+				models: ["openai"],
+				lastRunByModel,
+				promptCreatedAt: createdLongAgo,
+				runFrequencyMs,
+				now,
+				graceMs: 30 * MINUTE,
+			}),
+		).toBe(false);
+	});
+
+	it("is never overdue with no configured models", () => {
+		expect(
+			isPromptOverdue({ models: [], lastRunByModel: {}, promptCreatedAt: createdLongAgo, runFrequencyMs, now }),
+		).toBe(false);
+	});
+});

--- a/packages/lib/src/overdue.ts
+++ b/packages/lib/src/overdue.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared "is this prompt overdue?" logic so the admin dashboard, the scheduler's
+ * self-healing pass, and the overdue Sentry alert all agree. Overdue is decided
+ * per (prompt, model): a model with no recorded run counts as overdue once the
+ * prompt is past the grace window — failed runs record no row, so a target broken
+ * on one provider is overdue even while its other models stay fresh — and a model
+ * whose last run predates the cadence-plus-grace window is overdue.
+ */
+
+export interface ModelOverdueStatus {
+	isOverdue: boolean;
+	/** How far past cadence the last run is, in ms; null when never run or on schedule. */
+	overdueByMs: number | null;
+}
+
+/**
+ * Overdue status for a single (prompt, model) target. `graceMs` defaults to 0 —
+ * the dashboard's immediate view — while alerting passes a non-zero grace so
+ * normal jitter and freshly-created prompts don't trip it.
+ */
+export function getModelOverdueStatus(params: {
+	lastRunAt: Date | null | undefined;
+	promptCreatedAt: Date;
+	runFrequencyMs: number;
+	now: number;
+	graceMs?: number;
+}): ModelOverdueStatus {
+	const { lastRunAt, promptCreatedAt, runFrequencyMs, now, graceMs = 0 } = params;
+
+	if (!lastRunAt) {
+		return {
+			isOverdue: now - new Date(promptCreatedAt).getTime() > graceMs,
+			overdueByMs: null,
+		};
+	}
+
+	const timeSinceRun = now - new Date(lastRunAt).getTime();
+	if (timeSinceRun > runFrequencyMs + graceMs) {
+		return { isOverdue: true, overdueByMs: timeSinceRun - runFrequencyMs };
+	}
+	return { isOverdue: false, overdueByMs: null };
+}
+
+/** Whether a prompt is overdue on any of its configured models. */
+export function isPromptOverdue(params: {
+	models: string[];
+	lastRunByModel: Record<string, Date>;
+	promptCreatedAt: Date;
+	runFrequencyMs: number;
+	now: number;
+	graceMs?: number;
+}): boolean {
+	const { models, lastRunByModel, promptCreatedAt, runFrequencyMs, now, graceMs } = params;
+	return models.some(
+		(model) =>
+			getModelOverdueStatus({
+				lastRunAt: lastRunByModel[model],
+				promptCreatedAt,
+				runFrequencyMs,
+				now,
+				graceMs,
+			}).isOverdue,
+	);
+}


### PR DESCRIPTION
## Problem

A deployment had ~300 prompts shown overdue on the admin dashboard but got **no Sentry alert**, despite #442 shipping the overdue alert.

Root cause: the alert and the dashboard disagreed on what "overdue" means.

- **Dashboard / scheduler** (`admin.ts`, `schedule-maintenance.ts`) judge **per-model**: a prompt is overdue if *any* configured model is past cadence or has never run.
- **Alert** (`reportOverduePrompts`) judged **per-prompt** off `Math.max(...runTimes)` — the single most-recent run across *all* models.

Failed runs write no `prompt_runs` row (`savePromptRun` only runs on success), so a broken model is simply absent from the last-runs map. The dashboard flags that prompt; the alert's `Math.max` picks a *healthy* model's fresh timestamp and sees nothing wrong. When every overdue prompt is the "one provider down, others fine" kind, the alert computes `0` and returns before ever calling Sentry.

## Change

Extract one per-model definition into `@workspace/lib/overdue` and route all three consumers through it:

| Consumer | Before | After |
|---|---|---|
| Dashboard (`admin.ts`) | inline per-model loop | `getModelOverdueStatus` (grace `0`) — behavior identical |
| Scheduler self-healing loop | inline per-model loop | `isPromptOverdue` (grace `0`) — behavior identical |
| Alert (`reportOverduePrompts`) | `Math.max` across all models | `isPromptOverdue` (grace `30m`) — **now matches the dashboard** |

The alert keeps its 30-minute grace window (now a `graceMs` parameter) so jitter and freshly-created prompts don't page; the dashboard passes no grace, so its numbers are unchanged. The only remaining gap is the boundary — a prompt overdue by <30 min shows on the dashboard but doesn't page.

Also removed the stale `Runs every 6 hours` doc comment; the real schedule is `*/5 * * * *` in the worker entrypoint.

## Notes

- This makes the alert *fire* for the partial-provider case, but it still only pages if `SENTRY_DSN` is set in the **worker's** environment (optional; without it the worker skips `Sentry.init()` and every capture is a no-op).
- No changeset: internal ops/monitoring, no user-facing behavior change (dashboard output is identical).

## Test plan

- [x] `apps/web` + `apps/worker` `tsc --noEmit` clean
- [x] `@workspace/lib` suite green, incl. new `overdue.test.ts` covering the fresh-on-one-model / never-run-on-another case and the dashboard-equivalence (grace `0`)