### PR TITLE
fix(www): cmd+K opening two search modals on the docs site

### DIFF
--- a/.github/contributors.txt
+++ b/.github/contributors.txt
@@ -27,3 +27,4 @@ tuliren
 melalj
 mfa-g
 rodriguescarson
+dchaudhari7177

--- a/apps/www/src/components/blog-post-layout.tsx
+++ b/apps/www/src/components/blog-post-layout.tsx
@@ -82,7 +82,10 @@ function PostFaq({ items }: { items: BlogPostFaqItem[] }) {
 
 export function BlogPostLayout({ data }: { data: BlogPostLoaderData }) {
 	return (
-		<RootProvider theme={{ defaultTheme: "light", forcedTheme: "light" }}>
+		<RootProvider
+			theme={{ defaultTheme: "light", forcedTheme: "light" }}
+			search={{ enabled: false }}
+		>
 			<div className="min-h-screen">
 				<Navbar />
 				<main className="mx-auto max-w-3xl px-4 py-12 md:px-6 lg:py-16">

--- a/apps/www/src/components/docs-page-layout.tsx
+++ b/apps/www/src/components/docs-page-layout.tsx
@@ -160,7 +160,10 @@ export function DocsPageLayout({ loaderData }: { loaderData: LoaderData }) {
 	const data = useFumadocsLoader(loaderData);
 
 	return (
-		<RootProvider theme={{ defaultTheme: "light", forcedTheme: "light" }}>
+		<RootProvider
+			theme={{ defaultTheme: "light", forcedTheme: "light" }}
+			search={{ enabled: false }}
+		>
 			<div className="min-h-screen">
 				<Navbar />
 				<div className="mx-auto max-w-6xl px-4 py-8 md:px-6 lg:px-8">


### PR DESCRIPTION
Fixes #443

## Problem

Pressing <kbd>cmd</kbd>+<kbd>K</kbd> / <kbd>ctrl</kbd>+<kbd>K</kbd> on `/docs` opens two stacked search modals.

## Cause

`RootProvider` from `fumadocs-ui` mounts its own `SearchProvider` by default, which registers a global cmd+K/ctrl+K keydown listener and lazily renders the default fumadocs search dialog. The docs layout also renders the custom `SearchDialog` (via `DocsSidebar`), whose `useSearchDialog` hook registers its own cmd+K listener — so one keystroke opens both dialogs.

## Fix

Pass `search={{ enabled: false }}` to `RootProvider` in `docs-page-layout.tsx` so the built-in fumadocs search stays unmounted and only the custom dialog handles cmd+K. Nothing in the repo consumes fumadocs' search context (`useSearchContext`/`SearchOnly`/`SearchToggle` have no usages), so disabling it has no other effect.

## Verification

Ran `apps/www` locally and dispatched ctrl+K on `/docs`, counting `[role="dialog"]` elements:

- before: **2** dialogs (placeholders `Search` — fumadocs default — and `Search docs...` — custom)
- after: **1** dialog (`Search docs...`), search/navigation still working

`tsc --noEmit` passes for `@workspace/www`.

## CLA

Added `dchaudhari7177` to `.github/contributors.txt` per CONTRIBUTING.md.