### PR TITLE
Per-target replication/cadence for SCRAPE_TARGETS and hard API spend caps

### DIFF
--- a/.changeset/per-target-run-policy.md
+++ b/.changeset/per-target-run-policy.md
@@ -1,0 +1,9 @@
+---
+"@workspace/lib": patch
+"@workspace/config": patch
+"@workspace/worker": patch
+"@workspace/web": patch
+"@workspace/docs": patch
+---
+
+SCRAPE_TARGETS entries accept per-target replication (`:xN`) and cadence (`:Ch`) suffixes, and API-provider runs now enforce output-token and web-search budget caps.

--- a/apps/web/src/lib/job-scheduler.ts
+++ b/apps/web/src/lib/job-scheduler.ts
@@ -1,7 +1,16 @@
 import { db } from "@workspace/lib/db/db";
-import { prompts, brands } from "@workspace/lib/db/schema";
+import { prompts, brands, organization } from "@workspace/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { getDefaultDelayHours } from "@workspace/lib/constants";
+import {
+	minCadenceHours,
+	parseOrgRunPolicyOverrides,
+	parseScrapeTargets,
+	resolveTargetRunPolicy,
+	selectTargetsForBrand,
+	type ModelConfig,
+	type OrgRunPolicyOverrides,
+} from "@workspace/lib/providers";
 import { getBoss } from "@/lib/boss-client";
 
 /**
@@ -12,7 +21,22 @@ export function hoursToMs(hours: number): number {
 }
 
 /**
- * Gets the cadence (delay between runs) for a prompt based on its brand's delay override or the default
+ * Read a cloud org's per-target run-policy overrides from its better-auth
+ * metadata. Only called in cloud mode.
+ */
+async function getOrgRunPolicyOverrides(organizationId: string): Promise<OrgRunPolicyOverrides | null> {
+	const [org] = await db
+		.select({ metadata: organization.metadata })
+		.from(organization)
+		.where(eq(organization.id, organizationId))
+		.limit(1);
+	return parseOrgRunPolicyOverrides(org?.metadata);
+}
+
+/**
+ * Gets the effective cadence (delay before the first scheduled run) for a
+ * prompt: the fastest of its resolved per-target cadences, falling back to the
+ * brand's delay override or the deployment default.
  */
 export async function getPromptCadenceHours(promptId: string): Promise<number> {
 	const defaultDelayHours = getDefaultDelayHours();
@@ -37,13 +61,24 @@ export async function getPromptCadenceHours(promptId: string): Promise<number> {
 			return defaultDelayHours;
 		}
 
-		// Use override if set, otherwise use default
-		if (brand.delayOverrideHours !== null) {
-			console.log(`Using custom cadence for brand ${brand.name}: ${brand.delayOverrideHours}h`);
-			return brand.delayOverrideHours;
+		const brandCadenceHours = brand.delayOverrideHours ?? defaultDelayHours;
+
+		let selectedConfigs: ModelConfig[];
+		try {
+			selectedConfigs = selectTargetsForBrand(parseScrapeTargets(process.env.SCRAPE_TARGETS), brand.enabledModels);
+		} catch (error) {
+			// Stale enabledModels or misconfigured SCRAPE_TARGETS — fall back to the
+			// brand/default cadence rather than blocking scheduling.
+			console.warn(`Cannot resolve targets for prompt ${promptId}, using brand cadence:`, error);
+			return brandCadenceHours;
 		}
 
-		return defaultDelayHours;
+		const deploymentMode = process.env.DEPLOYMENT_MODE ?? "";
+		const orgOverrides = deploymentMode === "cloud" ? await getOrgRunPolicyOverrides(brand.organizationId) : null;
+		const policies = selectedConfigs.map((config) =>
+			resolveTargetRunPolicy(config, { deploymentMode, brandCadenceHours, orgOverrides }),
+		);
+		return minCadenceHours(policies, brandCadenceHours);
 	} catch (error) {
 		console.error(`Error fetching cadence for prompt ${promptId}:`, error);
 		return defaultDelayHours;
@@ -59,10 +94,7 @@ type SchedulerOptions = {
 	sendImmediate?: boolean;
 };
 
-export async function createPromptJobScheduler(
-	promptId: string,
-	options: SchedulerOptions = {},
-): Promise<boolean> {
+export async function createPromptJobScheduler(promptId: string, options: SchedulerOptions = {}): Promise<boolean> {
 	try {
 		const boss = await getBoss();
 		const cadenceHours = await getPromptCadenceHours(promptId);
@@ -130,7 +162,7 @@ export async function removePromptJobScheduler(promptId: string): Promise<boolea
 		}
 
 		// Cancel any pending jobs for this prompt
-		// Note: pg-boss doesn't have a direct way to cancel by data, 
+		// Note: pg-boss doesn't have a direct way to cancel by data,
 		// but the singletonKey prevents duplicates
 		console.log(`Removed schedule for prompt ${promptId}`);
 		return true;
@@ -148,9 +180,7 @@ export async function createMultiplePromptJobSchedulers(
 	promptIds: string[],
 	options: SchedulerOptions = {},
 ): Promise<boolean[]> {
-	const results = await Promise.allSettled(
-		promptIds.map((promptId) => createPromptJobScheduler(promptId, options)),
-	);
+	const results = await Promise.allSettled(promptIds.map((promptId) => createPromptJobScheduler(promptId, options)));
 
 	return results.map((result) => (result.status === "fulfilled" ? result.value : false));
 }
@@ -169,10 +199,7 @@ export async function removeMultiplePromptJobSchedulers(promptIds: string[]): Pr
  * Recreates a schedule for a prompt (removes and creates).
  * Useful when cadence has changed or job needs to be reset.
  */
-export async function recreatePromptJobScheduler(
-	promptId: string,
-	options: SchedulerOptions = {},
-): Promise<boolean> {
+export async function recreatePromptJobScheduler(promptId: string, options: SchedulerOptions = {}): Promise<boolean> {
 	try {
 		// Remove existing schedule if any (ignore errors if it doesn't exist)
 		await removePromptJobScheduler(promptId);
@@ -193,9 +220,11 @@ export async function sendImmediatePromptJob(promptId: string): Promise<boolean>
 		const boss = await getBoss();
 		const cadenceHours = await getPromptCadenceHours(promptId);
 
+		// force: bypass per-target due checks so a manual retry right after a
+		// scheduled run isn't silently skipped under mixed cadences.
 		await boss.send(
 			"process-prompt",
-			{ promptId, cadenceHours },
+			{ promptId, cadenceHours, force: true },
 			{
 				retryLimit: 3,
 				retryDelay: 60,

--- a/apps/worker/src/jobs/process-prompt.ts
+++ b/apps/worker/src/jobs/process-prompt.ts
@@ -1,14 +1,30 @@
 import type { Job } from "pg-boss";
 import { db } from "@workspace/lib/db/db";
-import { brands, citations, competitors, promptRuns, prompts, type Brand, type Competitor } from "@workspace/lib/db/schema";
-import { eq } from "drizzle-orm";
-import { RUNS_PER_PROMPT, getDefaultDelayHours } from "@workspace/lib/constants";
+import {
+	brands,
+	citations,
+	competitors,
+	organization,
+	promptRuns,
+	prompts,
+	type Brand,
+	type Competitor,
+} from "@workspace/lib/db/schema";
+import { eq, sql } from "drizzle-orm";
+import { getDefaultDelayHours } from "@workspace/lib/constants";
 import {
 	getProvider,
+	lastRunKey,
+	minCadenceHours,
+	parseOrgRunPolicyOverrides,
 	parseScrapeTargets,
+	resolveTargetRunPolicy,
+	selectDueTargets,
 	selectTargetsForBrand,
 	type ModelConfig,
+	type OrgRunPolicyOverrides,
 	type Provider,
+	type TargetRunPolicy,
 } from "@workspace/lib/providers";
 import type { Citation } from "@workspace/lib/text-extraction";
 import boss from "../boss";
@@ -16,7 +32,8 @@ import { trackWorkerEvent } from "../telemetry";
 
 export interface ProcessPromptData {
 	promptId: string;
-	cadenceHours?: number; // Hours until next run (for self-rescheduling)
+	cadenceHours?: number; // advisory/back-compat; the job recomputes cadence each firing
+	force?: boolean; // admin "run now": bypass per-target due checks
 }
 
 interface PromptContext {
@@ -53,23 +70,16 @@ async function scheduleNextRun(promptId: string, cadenceHours: number): Promise<
 }
 
 /**
- * Get the cadence hours for a prompt based on its brand's delay override.
+ * Read a cloud org's per-target run-policy overrides from its better-auth
+ * metadata. Only called in cloud mode.
  */
-async function getCadenceHours(promptId: string): Promise<number> {
-	const defaultDelayHours = getDefaultDelayHours();
-	const prompt = await db.query.prompts.findFirst({
-		where: eq(prompts.id, promptId),
-	});
-
-	if (!prompt) return defaultDelayHours;
-
-	const brand = await db.query.brands.findFirst({
-		where: eq(brands.id, prompt.brandId),
-	});
-
-	if (!brand) return defaultDelayHours;
-
-	return brand.delayOverrideHours ?? defaultDelayHours;
+async function getOrgRunPolicyOverrides(organizationId: string): Promise<OrgRunPolicyOverrides | null> {
+	const [org] = await db
+		.select({ metadata: organization.metadata })
+		.from(organization)
+		.where(eq(organization.id, organizationId))
+		.limit(1);
+	return parseOrgRunPolicyOverrides(org?.metadata);
 }
 
 async function getPromptContext(promptId: string): Promise<PromptContext | null> {
@@ -127,16 +137,13 @@ function analyzeMentions(
 		...(brand.additionalDomains || []).map(extractDomainFromUrl),
 	];
 	const brandMentioned =
-		brandNames.some((n) => contentLower.includes(n)) ||
-		brandDomains.some((d) => contentLower.includes(d));
+		brandNames.some((n) => contentLower.includes(n)) || brandDomains.some((d) => contentLower.includes(d));
 
 	const competitorsMentioned = competitorsList
 		.filter((competitor) => {
 			const names = [competitor.name, ...(competitor.aliases || [])].map((n) => n.toLowerCase());
 			const nameMatch = names.some((n) => contentLower.includes(n));
-			const domainMatch = (competitor.domains || []).some((d) =>
-				contentLower.includes(extractDomainFromUrl(d)),
-			);
+			const domainMatch = (competitor.domains || []).some((d) => contentLower.includes(extractDomainFromUrl(d)));
 			return nameMatch || domainMatch;
 		})
 		.map((competitor) => competitor.name);
@@ -200,7 +207,6 @@ async function saveCitations(
 	);
 }
 
-
 async function runModelIteration({
 	promptId,
 	promptValue,
@@ -263,14 +269,12 @@ async function runModelIteration({
  */
 export async function processPromptJob(jobs: Job<ProcessPromptData>[]): Promise<void> {
 	const scrapeConfigs = parseScrapeTargets(process.env.SCRAPE_TARGETS);
+	const deploymentMode = process.env.DEPLOYMENT_MODE ?? "";
 
 	// pg-boss v12 passes an array of jobs - process each one
 	for (const job of jobs) {
-		const { promptId, cadenceHours: providedCadence } = job.data;
+		const { promptId, force } = job.data;
 		console.log(`Processing prompt ${promptId}`);
-
-		// Get cadence hours - use provided value or look it up
-		const cadenceHours = providedCadence ?? (await getCadenceHours(promptId));
 
 		// Get prompt context
 		const context = await getPromptContext(promptId);
@@ -280,12 +284,14 @@ export async function processPromptJob(jobs: Job<ProcessPromptData>[]): Promise<
 		}
 
 		const { prompt, brand, competitors: competitorsList } = context;
+		const brandCadenceHours = brand.delayOverrideHours ?? getDefaultDelayHours();
 
 		// Check if prompt and brand are enabled
 		if (!prompt.enabled || !brand.enabled) {
 			console.log(`Prompt ${promptId} or brand ${brand.id} is disabled, skipping but rescheduling`);
-			// Still reschedule - the prompt might be enabled later
-			await scheduleNextRun(promptId, cadenceHours);
+			// Still reschedule - the prompt might be enabled later; targets are
+			// recomputed on the firing after re-enable.
+			await scheduleNextRun(promptId, brandCadenceHours);
 			continue;
 		}
 
@@ -294,21 +300,50 @@ export async function processPromptJob(jobs: Job<ProcessPromptData>[]): Promise<
 			console.log(`Prompt ${promptId} for brand ${brand.id} has no targets (brand.enabledModels=[])`);
 		}
 
+		const orgOverrides = deploymentMode === "cloud" ? await getOrgRunPolicyOverrides(brand.organizationId) : null;
+		const policies = selectedConfigs.map((config) =>
+			resolveTargetRunPolicy(config, { deploymentMode, brandCadenceHours, orgOverrides }),
+		);
+
+		// Uniform-cadence (the default and cloud shapes) and forced admin runs skip
+		// the due query and run every target — this is what keeps unchanged
+		// deployments at identical volume with no extra DB reads.
+		const uniformCadence = new Set(policies.map((p) => p.cadenceHours)).size <= 1;
+		let duePolicies: TargetRunPolicy[];
+		if (force || uniformCadence) {
+			duePolicies = policies;
+		} else {
+			const lastRuns = await db
+				.select({
+					model: promptRuns.model,
+					provider: promptRuns.provider,
+					lastRunAt: sql<Date>`MAX(${promptRuns.createdAt})`.as("last_run_at"),
+				})
+				.from(promptRuns)
+				.where(eq(promptRuns.promptId, promptId))
+				.groupBy(promptRuns.model, promptRuns.provider);
+			const lastRunMap = new Map<string, Date>();
+			for (const row of lastRuns) {
+				lastRunMap.set(lastRunKey(row.model, row.provider), new Date(row.lastRunAt));
+			}
+			duePolicies = selectDueTargets(policies, lastRunMap, new Date());
+		}
+
 		console.log(`Processing prompt "${prompt.value}" for brand "${brand.name}"`);
 
-		// Run all model iterations in parallel
+		// Run all due model iterations in parallel
 		const runPromises: Promise<void>[] = [];
 
-		for (const config of selectedConfigs) {
-			const providerImpl = getProvider(config.provider);
-			for (let i = 0; i < RUNS_PER_PROMPT; i++) {
+		for (const policy of duePolicies) {
+			const providerImpl = getProvider(policy.config.provider);
+			for (let i = 0; i < policy.replication; i++) {
 				runPromises.push(
 					runModelIteration({
 						promptId,
 						promptValue: prompt.value,
 						brand,
 						competitorsList,
-						config,
+						config: policy.config,
 						providerImpl,
 						runIndex: i + 1,
 					}),
@@ -338,14 +373,16 @@ export async function processPromptJob(jobs: Job<ProcessPromptData>[]): Promise<
 
 		trackWorkerEvent("prompt_processed", {
 			brand_id: brand.id,
-			models: [...new Set(selectedConfigs.map((c) => c.model))],
-			providers: [...new Set(selectedConfigs.map((c) => c.provider))],
+			models: [...new Set(duePolicies.map((p) => p.config.model))],
+			providers: [...new Set(duePolicies.map((p) => p.config.provider))],
 			total_runs: runPromises.length,
 			successful_runs: successCount,
 			failed_runs: failures.length,
 		});
 
-		// Schedule the next run
-		await scheduleNextRun(promptId, cadenceHours);
+		// Reschedule against the fastest selected target so mixed-cadence prompts
+		// fire often enough for their tightest cadence; the due check gates which
+		// targets actually run on each firing.
+		await scheduleNextRun(promptId, minCadenceHours(policies, brandCadenceHours));
 	}
 }

--- a/apps/worker/src/jobs/schedule-maintenance.ts
+++ b/apps/worker/src/jobs/schedule-maintenance.ts
@@ -1,7 +1,16 @@
 import { getDefaultDelayHours } from "@workspace/lib/constants";
 import { db } from "@workspace/lib/db/db";
-import { brands, promptRuns, prompts } from "@workspace/lib/db/schema";
-import { parseScrapeTargets } from "@workspace/lib/providers";
+import { brands, organization, promptRuns, prompts } from "@workspace/lib/db/schema";
+import {
+	lastRunKey,
+	minCadenceHours,
+	parseOrgRunPolicyOverrides,
+	parseScrapeTargets,
+	resolveTargetRunPolicy,
+	selectDueTargets,
+	selectTargetsForBrand,
+	type OrgRunPolicyOverrides,
+} from "@workspace/lib/providers";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import type { Job } from "pg-boss";
 import boss from "../boss";
@@ -44,10 +53,8 @@ async function runMaintenanceCheck(): Promise<void> {
 
 	const brandIds = enabledBrands.map((b) => b.id);
 	const defaultDelayHours = getDefaultDelayHours();
-	const brandDelayMap: Record<string, number> = {};
-	for (const brand of enabledBrands) {
-		brandDelayMap[brand.id] = brand.delayOverrideHours ?? defaultDelayHours;
-	}
+	const deploymentMode = process.env.DEPLOYMENT_MODE ?? "";
+	const brandMap = new Map(enabledBrands.map((b) => [b.id, b]));
 
 	// Get all enabled prompts for enabled brands
 	const enabledPrompts = await db.query.prompts.findMany({
@@ -61,31 +68,46 @@ async function runMaintenanceCheck(): Promise<void> {
 
 	console.log(`[schedule-maintenance] Checking ${enabledPrompts.length} enabled prompts`);
 
-	const allModels = parseScrapeTargets(process.env.SCRAPE_TARGETS);
-	const modelNames = allModels.map((cfg) => cfg.model);
+	const allTargets = parseScrapeTargets(process.env.SCRAPE_TARGETS);
 
-	// Get last runs per prompt per model (matches dashboard overdue logic)
+	// Batch the cloud org-override lookups into one query over the distinct org ids.
+	const orgOverridesMap = new Map<string, OrgRunPolicyOverrides | null>();
+	if (deploymentMode === "cloud") {
+		const orgIds = [...new Set(enabledBrands.map((b) => b.organizationId))];
+		const orgs = await db
+			.select({ id: organization.id, metadata: organization.metadata })
+			.from(organization)
+			.where(inArray(organization.id, orgIds));
+		for (const org of orgs) {
+			orgOverridesMap.set(org.id, parseOrgRunPolicyOverrides(org.metadata));
+		}
+	}
+
+	// Get last runs per prompt per (model, provider).
 	const lastRunsQuery = await db
 		.select({
 			promptId: promptRuns.promptId,
 			model: promptRuns.model,
+			provider: promptRuns.provider,
 			lastRunAt: sql<Date>`MAX(${promptRuns.createdAt})`.as("last_run_at"),
 		})
 		.from(promptRuns)
-		.groupBy(promptRuns.promptId, promptRuns.model);
+		.groupBy(promptRuns.promptId, promptRuns.model, promptRuns.provider);
 
-	const lastRunsMap: Record<string, Record<string, Date>> = {};
+	const lastRunsMap = new Map<string, Map<string, Date>>();
 	for (const run of lastRunsQuery) {
-		if (!lastRunsMap[run.promptId]) {
-			lastRunsMap[run.promptId] = {};
+		let perPrompt = lastRunsMap.get(run.promptId);
+		if (!perPrompt) {
+			perPrompt = new Map();
+			lastRunsMap.set(run.promptId, perPrompt);
 		}
-		lastRunsMap[run.promptId][run.model] = run.lastRunAt;
+		perPrompt.set(lastRunKey(run.model, run.provider), new Date(run.lastRunAt));
 	}
 
 	// Get all pending jobs with their state info
 	const pendingJobMap = await getPendingJobMap();
 
-	const now = Date.now();
+	const now = new Date();
 	const promptsToSchedule: { promptId: string; cadenceHours: number }[] = [];
 	const jobsToExpedite: string[] = []; // Job IDs to expedite (move start_after to now)
 
@@ -97,27 +119,31 @@ async function runMaintenanceCheck(): Promise<void> {
 			continue;
 		}
 
-		const cadenceHours = brandDelayMap[prompt.brandId] ?? defaultDelayHours;
-		const runFrequencyMs = cadenceHours * 60 * 60 * 1000;
-		const lastRuns = lastRunsMap[prompt.id] || {};
+		const brand = brandMap.get(prompt.brandId);
+		if (!brand) continue;
 
-		// Check if any model is overdue (matches dashboard logic)
-		let isOverdue = false;
-		for (const model of modelNames) {
-			const lastRunAt = lastRuns[model];
-			if (!lastRunAt) {
-				isOverdue = true;
-				break;
-			}
-			const timeSinceRun = now - new Date(lastRunAt).getTime();
-			if (timeSinceRun > runFrequencyMs) {
-				isOverdue = true;
-				break;
-			}
+		const brandCadenceHours = brand.delayOverrideHours ?? defaultDelayHours;
+
+		// Only the brand's selected targets count toward overdue — checking all
+		// configured models would forever mark subset brands overdue and expedite
+		// them every pass, bypassing cadence.
+		let selectedConfigs: ReturnType<typeof selectTargetsForBrand>;
+		try {
+			selectedConfigs = selectTargetsForBrand(allTargets, brand.enabledModels);
+		} catch (error) {
+			console.warn(`[schedule-maintenance] Cannot resolve targets for prompt ${prompt.id}, skipping:`, error);
+			continue;
 		}
 
-		if (!isOverdue) continue;
+		const orgOverrides = deploymentMode === "cloud" ? (orgOverridesMap.get(brand.organizationId) ?? null) : null;
+		const policies = selectedConfigs.map((config) =>
+			resolveTargetRunPolicy(config, { deploymentMode, brandCadenceHours, orgOverrides }),
+		);
 
+		const lastRuns = lastRunsMap.get(prompt.id) ?? new Map<string, Date>();
+		if (selectDueTargets(policies, lastRuns, now).length === 0) continue;
+
+		const cadenceHours = minCadenceHours(policies, brandCadenceHours);
 		if (pendingJob && pendingJob.state === "created") {
 			// There's a future job scheduled - expedite it to run now
 			jobsToExpedite.push(pendingJob.jobId);

--- a/packages/config/src/scrape-targets.test.ts
+++ b/packages/config/src/scrape-targets.test.ts
@@ -30,6 +30,86 @@ describe("formatScrapeTarget", () => {
 			}),
 		).toBe("claude:openrouter:anthropic/claude-sonnet-4.6:online");
 	});
+
+	it("formats replication and cadence in canonical order", () => {
+		expect(
+			formatScrapeTarget({
+				model: "claude",
+				provider: "anthropic-api",
+				version: "claude-sonnet-4-6",
+				webSearch: true,
+				replication: 1,
+				cadenceHours: 24,
+			}),
+		).toBe("claude:anthropic-api:claude-sonnet-4-6:online:x1:24h");
+	});
+});
+
+describe("parseScrapeTargets replication and cadence options", () => {
+	it("parses :xN after :online", () => {
+		expect(parseScrapeTargets("chatgpt:olostep:online:x4")).toEqual([
+			{ model: "chatgpt", provider: "olostep", version: undefined, webSearch: true, replication: 4 },
+		]);
+	});
+
+	it("parses :xN and :Nh with a version and no web search", () => {
+		expect(parseScrapeTargets("claude:anthropic-api:claude-sonnet-4-6:x1:24h")).toEqual([
+			{
+				model: "claude",
+				provider: "anthropic-api",
+				version: "claude-sonnet-4-6",
+				webSearch: false,
+				replication: 1,
+				cadenceHours: 24,
+			},
+		]);
+	});
+
+	it("parses all three tail options with a version", () => {
+		expect(parseScrapeTargets("claude:anthropic-api:claude-sonnet-4-6:online:x1:24h")).toEqual([
+			{
+				model: "claude",
+				provider: "anthropic-api",
+				version: "claude-sonnet-4-6",
+				webSearch: true,
+				replication: 1,
+				cadenceHours: 24,
+			},
+		]);
+	});
+
+	it("accepts tail options in any order", () => {
+		expect(parseScrapeTargets("claude:anthropic-api:claude-sonnet-4-6:24h:x1:online")).toEqual(
+			parseScrapeTargets("claude:anthropic-api:claude-sonnet-4-6:online:x1:24h"),
+		);
+	});
+
+	it("keeps the colon in OpenRouter variant slugs", () => {
+		expect(parseScrapeTargets("chatgpt:openrouter:openai/gpt-5-mini:free:online:x2:12h")).toEqual([
+			{
+				model: "chatgpt",
+				provider: "openrouter",
+				version: "openai/gpt-5-mini:free",
+				webSearch: true,
+				replication: 2,
+				cadenceHours: 12,
+			},
+		]);
+	});
+
+	it("rejects x0", () => {
+		expect(() => parseScrapeTargets("chatgpt:olostep:x0")).toThrow(/replication must be >= 1/);
+	});
+
+	it("rejects 0h", () => {
+		expect(() => parseScrapeTargets("chatgpt:olostep:0h")).toThrow(/cadence must be >= 1 hour/);
+	});
+
+	it("rejects duplicate options of the same kind", () => {
+		expect(() => parseScrapeTargets("chatgpt:olostep:x2:x3")).toThrow(/duplicate replication option/);
+		expect(() => parseScrapeTargets("chatgpt:olostep:12h:24h")).toThrow(/duplicate cadence option/);
+		expect(() => parseScrapeTargets("chatgpt:olostep:online:online")).toThrow(/duplicate online option/);
+	});
 });
 
 describe("round-trip", () => {
@@ -41,6 +121,16 @@ describe("round-trip", () => {
 			{ model: "chatgpt", provider: "openai-api", version: "gpt-5-mini", webSearch: false },
 			{ model: "chatgpt", provider: "openrouter", version: "openai/gpt-5-mini:free", webSearch: true },
 			{ model: "google-ai-mode", provider: "dataforseo", version: undefined, webSearch: true },
+			{ model: "chatgpt", provider: "olostep", version: undefined, webSearch: true, replication: 4 },
+			{ model: "claude", provider: "anthropic-api", version: "claude-sonnet-4-6", webSearch: false, cadenceHours: 24 },
+			{
+				model: "chatgpt",
+				provider: "openrouter",
+				version: "openai/gpt-5-mini:free",
+				webSearch: true,
+				replication: 2,
+				cadenceHours: 12,
+			},
 		];
 		for (const config of configs) {
 			expect(parseScrapeTargets(formatScrapeTarget(config))).toEqual([config]);
@@ -49,7 +139,7 @@ describe("round-trip", () => {
 
 	it("format(parse(s)) returns s", () => {
 		const value =
-			"chatgpt:olostep:online,claude:openrouter:anthropic/claude-sonnet-4.6,mistral:mistral-api:mistral-medium-latest:online,chatgpt:brightdata";
+			"chatgpt:olostep:online,claude:openrouter:anthropic/claude-sonnet-4.6,mistral:mistral-api:mistral-medium-latest:online,chatgpt:brightdata,claude:anthropic-api:claude-sonnet-4-6:online:x1:24h";
 		expect(parseScrapeTargets(value).map(formatScrapeTarget).join(",")).toBe(value);
 	});
 });

--- a/packages/config/src/scrape-targets.ts
+++ b/packages/config/src/scrape-targets.ts
@@ -1,11 +1,15 @@
 /**
  * The single module that parses and formats the SCRAPE_TARGETS env var.
  *
- * Format: model:provider[:version][:online]
+ * Format: model:provider[:version][:online][:xN][:Nh]
  * - model: AI model to track (chatgpt, google-ai-mode, copilot, etc.)
- * - provider: How to reach it (olostep, brightdata, direct, openrouter, dataforseo)
- * - version: Specific version slug, required for direct/openrouter (may contain colons for OpenRouter variants)
+ * - provider: How to reach it (olostep, brightdata, oxylabs, dataforseo, openrouter, openai-api, anthropic-api, mistral-api)
+ * - version: Specific version slug, required for openrouter and the *-api providers (may contain colons for OpenRouter variants)
  * - :online: Append to enable web search. Omit = no web search.
+ * - :xN: Runs per firing for this target (e.g. x4). Omit = deployment default.
+ * - :Nh: Hours between firings for this target (e.g. 24h). Omit = brand/env default.
+ *
+ * The three tail options may appear in any order after the version.
  */
 
 export interface ModelConfig {
@@ -13,14 +17,19 @@ export interface ModelConfig {
 	provider: string;
 	version?: string;
 	webSearch: boolean;
+	/** Runs per firing. Unset = deployment default (RUNS_PER_PROMPT). */
+	replication?: number;
+	/** Hours between firings for this target. Unset = brand/env default. */
+	cadenceHours?: number;
 }
 
 /**
  * Parse the SCRAPE_TARGETS env var into structured ModelConfig objects.
  *
- * Parsing: split on ":". First = model, second = provider. If last segment is "online",
- * pop it (websearch = true). Remaining middle segments rejoined with ":" = version slug.
- * This naturally handles OpenRouter variant suffixes like ":free".
+ * Parsing: split on ":". First = model, second = provider. Tail options
+ * ("online", "xN", "Nh") are popped from the end in any order; the remaining
+ * middle segments rejoined with ":" = version slug. This naturally handles
+ * OpenRouter variant suffixes like ":free".
  */
 export function parseScrapeTargets(envValue?: string): ModelConfig[] {
 	if (!envValue || !envValue.trim()) {
@@ -38,20 +47,46 @@ export function parseScrapeTargets(envValue?: string): ModelConfig[] {
 		if (parts.length < 2) throw new Error(`Invalid SCRAPE_TARGETS entry: "${trimmed}" (need at least model:provider)`);
 		const model = parts[0];
 		const provider = parts[1];
-		const webSearch = parts[parts.length - 1] === "online";
-		const versionParts = parts.slice(2, webSearch ? -1 : undefined);
-		const version = versionParts.length > 0 ? versionParts.join(":") : undefined;
-		return { model, provider, version, webSearch };
+		let webSearch = false;
+		let replication: number | undefined;
+		let cadenceHours: number | undefined;
+		const rest = parts.slice(2);
+		while (rest.length > 0) {
+			const last = rest[rest.length - 1];
+			const replicationMatch = /^x(\d+)$/.exec(last);
+			const cadenceMatch = /^(\d+)h$/.exec(last);
+			if (last === "online") {
+				if (webSearch) throw new Error(`Invalid SCRAPE_TARGETS entry "${trimmed}": duplicate online option`);
+				webSearch = true;
+			} else if (replicationMatch) {
+				if (replication !== undefined)
+					throw new Error(`Invalid SCRAPE_TARGETS entry "${trimmed}": duplicate replication option`);
+				replication = Number(replicationMatch[1]);
+				if (replication < 1) throw new Error(`Invalid SCRAPE_TARGETS entry "${trimmed}": replication must be >= 1`);
+			} else if (cadenceMatch) {
+				if (cadenceHours !== undefined)
+					throw new Error(`Invalid SCRAPE_TARGETS entry "${trimmed}": duplicate cadence option`);
+				cadenceHours = Number(cadenceMatch[1]);
+				if (cadenceHours < 1) throw new Error(`Invalid SCRAPE_TARGETS entry "${trimmed}": cadence must be >= 1 hour`);
+			} else {
+				break;
+			}
+			rest.pop();
+		}
+		const version = rest.length > 0 ? rest.join(":") : undefined;
+		return { model, provider, version, webSearch, replication, cadenceHours };
 	});
 }
 
 /**
- * Inverse of parseScrapeTargets for a single entry: build the
- * model:provider[:version][:online] string from a ModelConfig.
+ * Inverse of parseScrapeTargets for a single entry: build the canonical
+ * model:provider[:version][:online][:xN][:Nh] string from a ModelConfig.
  */
 export function formatScrapeTarget(config: ModelConfig): string {
 	const parts = [config.model, config.provider];
 	if (config.version) parts.push(config.version);
 	if (config.webSearch) parts.push("online");
+	if (config.replication !== undefined) parts.push(`x${config.replication}`);
+	if (config.cadenceHours !== undefined) parts.push(`${config.cadenceHours}h`);
 	return parts.join(":");
 }

--- a/packages/docs/content/docs/user-guide/providers.mdx
+++ b/packages/docs/content/docs/user-guide/providers.mdx
@@ -153,12 +153,16 @@ SCRAPE_TARGETS=chatgpt:openai-api:gpt-5-mini:online,claude:anthropic-api:claude-
 ## SCRAPE_TARGETS format
 
 ```
-model:provider[:version][:online]
+model:provider[:version][:online][:xN][:Ch]
 ```
 
 - `model` — the AI surface being tracked (`chatgpt`, `claude`, `google-ai-mode`, `gemini`, `perplexity`, `copilot`, `grok`).
 - `provider` — how to reach it (`brightdata`, `oxylabs`, `olostep`, `openai-api`, `anthropic-api`, `mistral-api`, `openrouter`, `dataforseo`).
 - `version` — required for `openai-api`, `anthropic-api`, `mistral-api`, `openrouter`. Optional for scrapers (pass a BrightData dataset id here).
 - `:online` — append to enable web search. Required for most scraped models since the live UIs always search.
+- `:xN` — runs per firing for this target (default 5).
+- `:Ch` — hours between firings for this target, e.g. `24h` (default: the brand's cadence / `DEFAULT_DELAY_HOURS`).
 
-Entries are comma-separated.
+The trailing options may appear in any order. Entries are comma-separated.
+
+For example, `claude:anthropic-api:claude-sonnet-4-6:online:x1:24h` runs Claude with web search once per firing, at most once a day.

--- a/packages/lib/src/constants.ts
+++ b/packages/lib/src/constants.ts
@@ -1,4 +1,5 @@
-// Constants for prompt processing
+// Default runs per target per firing when a SCRAPE_TARGETS entry carries no
+// `xN` option (see providers/run-policy.ts); also the report sampling count.
 export const RUNS_PER_PROMPT = 5;
 
 // Fallback cadence (hours) when the DEFAULT_DELAY_HOURS env var is unset or invalid.

--- a/packages/lib/src/providers/config.ts
+++ b/packages/lib/src/providers/config.ts
@@ -21,8 +21,12 @@ export const API_PROVIDER_MAX_OUTPUT_TOKENS: Record<string, number> = {
 export const ANTHROPIC_WEB_SEARCH_MAX_USES = 1;
 /** Caps built-in tool invocations on the OpenAI Responses API per run. */
 export const OPENAI_WEB_SEARCH_MAX_TOOL_CALLS = 2;
-/** Exa web-plugin results per OpenRouter run (fixed per-request pricing). */
+/** Result cap for the OpenRouter Exa fallback branch (ignored by native). */
 export const OPENROUTER_WEB_MAX_RESULTS = 5;
+/** Native web-search context tier for OpenRouter tracked runs; bounds native
+ *  passthrough cost. "low" | "medium" | "high" — "medium" is the provider
+ *  default, chosen to preserve parity with the real consumer surface. */
+export const OPENROUTER_WEB_SEARCH_CONTEXT_SIZE = "medium" as const;
 
 export function validateScrapeTargets(
 	configs: ModelConfig[],

--- a/packages/lib/src/providers/config.ts
+++ b/packages/lib/src/providers/config.ts
@@ -4,18 +4,44 @@ import type { ModelConfig } from "./types";
 // of truth, shared with the CLI); re-exported here for compatibility.
 export { parseScrapeTargets } from "@workspace/config/scrape-targets";
 
+/**
+ * Hard per-call output-token caps for the direct API providers. Server-side
+ * safety net so a single tracked run has bounded spend — not tunable per
+ * plan or env on purpose. OpenAI/OpenRouter get headroom because
+ * max_output_tokens counts reasoning tokens on gpt-5-family models.
+ */
+export const API_PROVIDER_MAX_OUTPUT_TOKENS: Record<string, number> = {
+	"anthropic-api": 4000,
+	"openai-api": 8000,
+	openrouter: 8000,
+	"mistral-api": 4000,
+};
+
+/** Web-search budget per tracked run. Anthropic bills per search. */
+export const ANTHROPIC_WEB_SEARCH_MAX_USES = 1;
+/** Caps built-in tool invocations on the OpenAI Responses API per run. */
+export const OPENAI_WEB_SEARCH_MAX_TOOL_CALLS = 2;
+/** Exa web-plugin results per OpenRouter run (fixed per-request pricing). */
+export const OPENROUTER_WEB_MAX_RESULTS = 5;
+
 export function validateScrapeTargets(
 	configs: ModelConfig[],
-	getProvider: (id: string) => { isConfigured(): boolean; validateTarget?(config: ModelConfig): string | null } | undefined,
+	getProvider: (
+		id: string,
+	) => { isConfigured(): boolean; validateTarget?(config: ModelConfig): string | null } | undefined,
 ): void {
 	for (const config of configs) {
 		const provider = getProvider(config.provider);
 		if (!provider) throw new Error(`SCRAPE_TARGETS: unknown provider "${config.provider}"`);
 		if (!provider.isConfigured())
-			throw new Error(
-				`SCRAPE_TARGETS: provider "${config.provider}" requires API key(s) to be configured (see docs)`,
-			);
-		if ((config.provider === "openai-api" || config.provider === "anthropic-api" || config.provider === "mistral-api" || config.provider === "openrouter") && !config.version)
+			throw new Error(`SCRAPE_TARGETS: provider "${config.provider}" requires API key(s) to be configured (see docs)`);
+		if (
+			(config.provider === "openai-api" ||
+				config.provider === "anthropic-api" ||
+				config.provider === "mistral-api" ||
+				config.provider === "openrouter") &&
+			!config.version
+		)
 			throw new Error(`SCRAPE_TARGETS: "${config.model}:${config.provider}" requires a version slug (third segment)`);
 		const targetError = provider.validateTarget?.(config);
 		if (targetError)

--- a/packages/lib/src/providers/index.ts
+++ b/packages/lib/src/providers/index.ts
@@ -19,8 +19,27 @@ export type {
 } from "./types";
 export { KNOWN_MODELS, getModelMeta } from "./models";
 export type { ModelMeta } from "./models";
-export { parseScrapeTargets, validateScrapeTargets } from "./config";
+export {
+	parseScrapeTargets,
+	validateScrapeTargets,
+	API_PROVIDER_MAX_OUTPUT_TOKENS,
+	ANTHROPIC_WEB_SEARCH_MAX_USES,
+	OPENAI_WEB_SEARCH_MAX_TOOL_CALLS,
+	OPENROUTER_WEB_MAX_RESULTS,
+} from "./config";
 export { selectTargetsForBrand } from "./runner";
+export {
+	CLOUD_STANDARD_RUNS_PER_DAY,
+	CLOUD_ANTHROPIC_RUNS_PER_DAY,
+	CLOUD_MAX_RUNS_PER_DAY,
+	CLOUD_CADENCE_FLOOR_HOURS,
+	lastRunKey,
+	minCadenceHours,
+	parseOrgRunPolicyOverrides,
+	resolveTargetRunPolicy,
+	selectDueTargets,
+} from "./run-policy";
+export type { OrgRunPolicyOverrides, TargetRunPolicy } from "./run-policy";
 
 const providerMap: Record<string, Provider> = {
 	olostep,

--- a/packages/lib/src/providers/registry/anthropic-api.ts
+++ b/packages/lib/src/providers/registry/anthropic-api.ts
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { anthropic, createAnthropic } from "@ai-sdk/anthropic";
 import { generateText, Output } from "ai";
 import { extractTextFromAnthropic } from "../../text-extraction";
+import { ANTHROPIC_WEB_SEARCH_MAX_USES, API_PROVIDER_MAX_OUTPUT_TOKENS } from "../config";
 import type {
 	Provider,
 	ScrapeResult,
@@ -34,16 +35,17 @@ async function runAnthropic(prompt: string, model: string, options?: ProviderOpt
 		tools.push({
 			type: "web_search_20250305",
 			name: "web_search",
-			max_uses: 1,
+			max_uses: ANTHROPIC_WEB_SEARCH_MAX_USES,
 		});
 	}
 
-	const makeRequest = () => client.messages.create({
-		model,
-		max_tokens: 4000,
-		messages: [{ role: "user", content: prompt }],
-		...(tools.length > 0 ? { tools } : {}),
-	});
+	const makeRequest = () =>
+		client.messages.create({
+			model,
+			max_tokens: API_PROVIDER_MAX_OUTPUT_TOKENS["anthropic-api"],
+			messages: [{ role: "user", content: prompt }],
+			...(tools.length > 0 ? { tools } : {}),
+		});
 
 	let response = await makeRequest();
 
@@ -74,9 +76,7 @@ async function runAnthropic(prompt: string, model: string, options?: ProviderOpt
 		return {
 			...block,
 			content: block.content.map((r: any) =>
-				r.type === "web_search_result"
-					? { type: r.type, url: r.url, title: r.title }
-					: r,
+				r.type === "web_search_result" ? { type: r.type, url: r.url, title: r.title } : r,
 			),
 		};
 	});
@@ -110,7 +110,9 @@ function extractAnthropicCitations(content: Anthropic.Messages.ContentBlock[]): 
 							domain: parsed.hostname.replace(/^www\./, ""),
 							citationIndex: idx++,
 						});
-					} catch (e) { console.warn(`Anthropic: skipping invalid citation URL: ${cit.url}`, e); }
+					} catch (e) {
+						console.warn(`Anthropic: skipping invalid citation URL: ${cit.url}`, e);
+					}
 				}
 			}
 		}
@@ -128,7 +130,9 @@ function extractAnthropicCitations(content: Anthropic.Messages.ContentBlock[]): 
 							domain: parsed.hostname.replace(/^www\./, ""),
 							citationIndex: idx++,
 						});
-					} catch (e) { console.warn(`Anthropic: skipping invalid search result URL: ${result.url}`, e); }
+					} catch (e) {
+						console.warn(`Anthropic: skipping invalid search result URL: ${result.url}`, e);
+					}
 				}
 			}
 		}
@@ -167,4 +171,3 @@ export const anthropicApi: Provider = {
 		};
 	},
 };
-

--- a/packages/lib/src/providers/registry/mistral-api.test.ts
+++ b/packages/lib/src/providers/registry/mistral-api.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { API_PROVIDER_MAX_OUTPUT_TOKENS } from "../config";
+import { mistralApi } from "./mistral-api";
+
+const CAP = API_PROVIDER_MAX_OUTPUT_TOKENS["mistral-api"];
+
+function stubFetch(json: unknown) {
+	const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => json });
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+function sentBody(fetchMock: ReturnType<typeof vi.fn>): Record<string, unknown> {
+	const [, init] = fetchMock.mock.calls[0];
+	return JSON.parse((init as RequestInit).body as string);
+}
+
+function calledUrl(fetchMock: ReturnType<typeof vi.fn>): string {
+	return fetchMock.mock.calls[0][0] as string;
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("mistral-api run", () => {
+	it("caps output tokens and keeps the web_search tool on the web path", async () => {
+		const fetchMock = stubFetch({ model: "mistral-medium-latest", outputs: [] });
+
+		await mistralApi.run("mistral", "prompt", { webSearch: true, version: "mistral-medium-latest" });
+
+		expect(calledUrl(fetchMock)).toContain("/v1/conversations");
+		const body = sentBody(fetchMock);
+		expect(body.tools).toEqual([{ type: "web_search" }]);
+		expect(body.completion_args).toEqual({ max_tokens: CAP });
+	});
+
+	it("caps output tokens on the non-web chat-completions path", async () => {
+		const fetchMock = stubFetch({ model: "mistral-medium-latest", choices: [{ message: { content: "answer" } }] });
+
+		await mistralApi.run("mistral", "prompt", { webSearch: false, version: "mistral-medium-latest" });
+
+		expect(calledUrl(fetchMock)).toContain("/v1/chat/completions");
+		expect(sentBody(fetchMock).max_tokens).toBe(CAP);
+	});
+});

--- a/packages/lib/src/providers/registry/mistral-api.ts
+++ b/packages/lib/src/providers/registry/mistral-api.ts
@@ -7,6 +7,7 @@ import type {
 	StructuredResearchResult,
 } from "../types";
 import type { Citation } from "../../text-extraction";
+import { API_PROVIDER_MAX_OUTPUT_TOKENS } from "../config";
 
 const MISTRAL_BASE_URL = "https://api.mistral.ai";
 const DEFAULT_MODEL = "mistral-medium-latest";
@@ -90,10 +91,14 @@ export const mistralApi: Provider = {
 		const version = options?.version ?? DEFAULT_MODEL;
 
 		if (options?.webSearch) {
+			// Mistral's web_search connector has no per-call search-count knob, so the
+			// token cap is the only budget bound (cloud does not offer Mistral on
+			// standard plans).
 			const data = await mistralPost("/v1/conversations", {
 				model: version,
 				inputs: prompt,
 				tools: [{ type: "web_search" }],
+				completion_args: { max_tokens: API_PROVIDER_MAX_OUTPUT_TOKENS["mistral-api"] },
 			});
 			const parsed = parseConversationsResponse(data);
 			return { ...parsed, rawOutput: data, modelVersion: data?.model ?? version };
@@ -102,6 +107,7 @@ export const mistralApi: Provider = {
 		const data = await mistralPost("/v1/chat/completions", {
 			model: version,
 			messages: [{ role: "user", content: prompt }],
+			max_tokens: API_PROVIDER_MAX_OUTPUT_TOKENS["mistral-api"],
 		});
 		return {
 			rawOutput: data,

--- a/packages/lib/src/providers/registry/openai-api.ts
+++ b/packages/lib/src/providers/registry/openai-api.ts
@@ -1,6 +1,7 @@
 import { openai, createOpenAI } from "@ai-sdk/openai";
 import { generateText, Output } from "ai";
 import { extractTextFromOpenAI, extractCitationsFromOpenAI } from "../../text-extraction";
+import { API_PROVIDER_MAX_OUTPUT_TOKENS, OPENAI_WEB_SEARCH_MAX_TOOL_CALLS } from "../config";
 import type {
 	Provider,
 	ScrapeResult,
@@ -16,9 +17,7 @@ function sanitizeForJson(obj: unknown): unknown {
 }
 
 function getOpenAIResponsesModel(model: string) {
-	const provider = process.env.OPENAI_API_KEY
-		? createOpenAI({ apiKey: process.env.OPENAI_API_KEY })
-		: openai;
+	const provider = process.env.OPENAI_API_KEY ? createOpenAI({ apiKey: process.env.OPENAI_API_KEY }) : openai;
 	return provider.responses(model);
 }
 
@@ -33,8 +32,12 @@ async function runOpenAI(prompt: string, model: string, options?: ProviderOption
 	const result = await generateText({
 		model: openai.responses(model),
 		prompt,
+		maxOutputTokens: API_PROVIDER_MAX_OUTPUT_TOKENS["openai-api"],
 		toolChoice: Object.keys(tools).length > 0 ? "auto" : "none",
 		...(Object.keys(tools).length > 0 ? { tools } : {}),
+		...(Object.keys(tools).length > 0
+			? { providerOptions: { openai: { maxToolCalls: OPENAI_WEB_SEARCH_MAX_TOOL_CALLS } } }
+			: {}),
 	});
 
 	const responseBody = result.response?.body as any;
@@ -78,6 +81,7 @@ export const openaiApi: Provider = {
 		const result = await generateText({
 			model: getOpenAIResponsesModel(DEFAULT_RESEARCH_MODEL),
 			...(webSearch ? { tools: { web_search: openai.tools.webSearch({ searchContextSize: "medium" }) as any } } : {}),
+			...(webSearch ? { providerOptions: { openai: { maxToolCalls: 5 } } } : {}),
 			output: Output.object({ schema }),
 			prompt,
 		});

--- a/packages/lib/src/providers/registry/openrouter.test.ts
+++ b/packages/lib/src/providers/registry/openrouter.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { API_PROVIDER_MAX_OUTPUT_TOKENS, OPENROUTER_WEB_MAX_RESULTS } from "../config";
+import {
+	API_PROVIDER_MAX_OUTPUT_TOKENS,
+	OPENROUTER_WEB_MAX_RESULTS,
+	OPENROUTER_WEB_SEARCH_CONTEXT_SIZE,
+} from "../config";
 import { openrouter } from "./openrouter";
 
 function stubFetch() {
@@ -24,18 +28,19 @@ afterEach(() => {
 });
 
 describe("openrouter run", () => {
-	it("caps output tokens and requests the capped exa web plugin when webSearch is on", async () => {
+	it("caps output tokens and requests the web plugin (native-first, Exa capped as fallback) when webSearch is on", async () => {
 		const fetchMock = stubFetch();
 
 		await openrouter.run("chatgpt", "prompt", { webSearch: true, version: "openai/gpt-5-mini" });
 
 		const body = sentBody(fetchMock);
 		expect(body.max_tokens).toBe(API_PROVIDER_MAX_OUTPUT_TOKENS.openrouter);
-		expect(body.plugins).toEqual([{ id: "web", engine: "exa", max_results: OPENROUTER_WEB_MAX_RESULTS }]);
+		expect(body.plugins).toEqual([{ id: "web", max_results: OPENROUTER_WEB_MAX_RESULTS }]);
+		expect(body.web_search_options).toEqual({ search_context_size: OPENROUTER_WEB_SEARCH_CONTEXT_SIZE });
 		expect(body.messages).toEqual([{ role: "user", content: "prompt" }]);
 	});
 
-	it("sends no plugins when webSearch is off", async () => {
+	it("sends no plugins or web_search_options when webSearch is off", async () => {
 		const fetchMock = stubFetch();
 
 		await openrouter.run("chatgpt", "prompt", { webSearch: false, version: "openai/gpt-5-mini" });
@@ -43,6 +48,7 @@ describe("openrouter run", () => {
 		const body = sentBody(fetchMock);
 		expect(body.max_tokens).toBe(API_PROVIDER_MAX_OUTPUT_TOKENS.openrouter);
 		expect(body).not.toHaveProperty("plugins");
+		expect(body).not.toHaveProperty("web_search_options");
 	});
 
 	it("strips a trailing :online from the version slug instead of forwarding it", async () => {
@@ -52,7 +58,7 @@ describe("openrouter run", () => {
 
 		const body = sentBody(fetchMock);
 		expect(body.model).toBe("openai/gpt-5-mini");
-		expect(body.plugins).toEqual([{ id: "web", engine: "exa", max_results: OPENROUTER_WEB_MAX_RESULTS }]);
+		expect(body.plugins).toEqual([{ id: "web", max_results: OPENROUTER_WEB_MAX_RESULTS }]);
 	});
 
 	it("never appends :online for web-search runs", async () => {

--- a/packages/lib/src/providers/registry/openrouter.test.ts
+++ b/packages/lib/src/providers/registry/openrouter.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { API_PROVIDER_MAX_OUTPUT_TOKENS, OPENROUTER_WEB_MAX_RESULTS } from "../config";
+import { openrouter } from "./openrouter";
+
+function stubFetch() {
+	const fetchMock = vi.fn().mockResolvedValue({
+		ok: true,
+		json: async () => ({
+			model: "openai/gpt-5-mini-2025-08-07",
+			choices: [{ message: { content: "answer" } }],
+		}),
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+function sentBody(fetchMock: ReturnType<typeof vi.fn>): Record<string, unknown> {
+	const [, init] = fetchMock.mock.calls[0];
+	return JSON.parse((init as RequestInit).body as string);
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("openrouter run", () => {
+	it("caps output tokens and requests the capped exa web plugin when webSearch is on", async () => {
+		const fetchMock = stubFetch();
+
+		await openrouter.run("chatgpt", "prompt", { webSearch: true, version: "openai/gpt-5-mini" });
+
+		const body = sentBody(fetchMock);
+		expect(body.max_tokens).toBe(API_PROVIDER_MAX_OUTPUT_TOKENS.openrouter);
+		expect(body.plugins).toEqual([{ id: "web", engine: "exa", max_results: OPENROUTER_WEB_MAX_RESULTS }]);
+		expect(body.messages).toEqual([{ role: "user", content: "prompt" }]);
+	});
+
+	it("sends no plugins when webSearch is off", async () => {
+		const fetchMock = stubFetch();
+
+		await openrouter.run("chatgpt", "prompt", { webSearch: false, version: "openai/gpt-5-mini" });
+
+		const body = sentBody(fetchMock);
+		expect(body.max_tokens).toBe(API_PROVIDER_MAX_OUTPUT_TOKENS.openrouter);
+		expect(body).not.toHaveProperty("plugins");
+	});
+
+	it("strips a trailing :online from the version slug instead of forwarding it", async () => {
+		const fetchMock = stubFetch();
+
+		await openrouter.run("chatgpt", "prompt", { webSearch: true, version: "openai/gpt-5-mini:online" });
+
+		const body = sentBody(fetchMock);
+		expect(body.model).toBe("openai/gpt-5-mini");
+		expect(body.plugins).toEqual([{ id: "web", engine: "exa", max_results: OPENROUTER_WEB_MAX_RESULTS }]);
+	});
+
+	it("never appends :online for web-search runs", async () => {
+		const fetchMock = stubFetch();
+
+		await openrouter.run("chatgpt", "prompt", { webSearch: true, version: "openai/gpt-5-mini:free" });
+
+		expect(sentBody(fetchMock).model).toBe("openai/gpt-5-mini:free");
+	});
+});

--- a/packages/lib/src/providers/registry/openrouter.ts
+++ b/packages/lib/src/providers/registry/openrouter.ts
@@ -8,6 +8,7 @@ import type {
 } from "../types";
 import type { Citation } from "../../text-extraction";
 import { WEB_QUERIES_UNAVAILABLE } from "../../constants";
+import { API_PROVIDER_MAX_OUTPUT_TOKENS, OPENROUTER_WEB_MAX_RESULTS } from "../config";
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 const OPENROUTER_API_URL = `${OPENROUTER_BASE_URL}/chat/completions`;
@@ -95,6 +96,8 @@ export const openrouter: Provider = {
 		};
 		// `engine: "native"` runs the underlying provider's real web-search tool
 		// (e.g. Anthropic's web_search_20250305) instead of the Exa fallback.
+		// Tracked runs (`run()` below) deliberately use the capped Exa plugin
+		// instead: recall matters more here, deterministic spend matters there.
 		if (webSearch) body.plugins = [{ id: "web", engine: "native" }];
 		const res = await fetch(OPENROUTER_API_URL, {
 			method: "POST",
@@ -124,12 +127,23 @@ export const openrouter: Provider = {
 		if (!modelSlug) {
 			throw new Error(
 				`OpenRouter requires a version slug in SCRAPE_TARGETS. ` +
-				`Example: ${model}:openrouter:openai/gpt-5-mini:online`,
+					`Example: ${model}:openrouter:openai/gpt-5-mini:online`,
 			);
 		}
 
-		if (options?.webSearch && !modelSlug.includes(":online")) {
-			modelSlug = `${modelSlug}:online`;
+		// Web search is requested through the explicit plugin config below, never
+		// the ":online" slug alias (strip one if the configured version carries it).
+		modelSlug = modelSlug.replace(/:online$/, "");
+
+		const body: Record<string, unknown> = {
+			model: modelSlug,
+			messages: [{ role: "user", content: prompt }],
+			max_tokens: API_PROVIDER_MAX_OUTPUT_TOKENS.openrouter,
+		};
+		// Exa engine, not the native passthrough: fixed per-request result pricing
+		// and an explicit result cap, so per-call web spend is deterministic.
+		if (options?.webSearch) {
+			body.plugins = [{ id: "web", engine: "exa", max_results: OPENROUTER_WEB_MAX_RESULTS }];
 		}
 
 		// Use raw fetch instead of SDK — the SDK's ChatAssistantMessage Zod schema
@@ -145,10 +159,7 @@ export const openrouter: Provider = {
 				"HTTP-Referer": process.env.APP_URL ?? "https://github.com/elmohq/elmo",
 				"X-Title": "Elmo AEO",
 			},
-			body: JSON.stringify({
-				model: modelSlug,
-				messages: [{ role: "user", content: prompt }],
-			}),
+			body: JSON.stringify(body),
 		});
 
 		if (!res.ok) {
@@ -167,7 +178,7 @@ export const openrouter: Provider = {
 			textContent: extractTextFromOpenRouterResponse(data),
 			webQueries,
 			citations,
-			modelVersion: data?.model ?? modelSlug.replace(":online", ""),
+			modelVersion: data?.model ?? modelSlug,
 		};
 	},
 };

--- a/packages/lib/src/providers/registry/openrouter.ts
+++ b/packages/lib/src/providers/registry/openrouter.ts
@@ -8,7 +8,11 @@ import type {
 } from "../types";
 import type { Citation } from "../../text-extraction";
 import { WEB_QUERIES_UNAVAILABLE } from "../../constants";
-import { API_PROVIDER_MAX_OUTPUT_TOKENS, OPENROUTER_WEB_MAX_RESULTS } from "../config";
+import {
+	API_PROVIDER_MAX_OUTPUT_TOKENS,
+	OPENROUTER_WEB_MAX_RESULTS,
+	OPENROUTER_WEB_SEARCH_CONTEXT_SIZE,
+} from "../config";
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 const OPENROUTER_API_URL = `${OPENROUTER_BASE_URL}/chat/completions`;
@@ -140,10 +144,14 @@ export const openrouter: Provider = {
 			messages: [{ role: "user", content: prompt }],
 			max_tokens: API_PROVIDER_MAX_OUTPUT_TOKENS.openrouter,
 		};
-		// Exa engine, not the native passthrough: fixed per-request result pricing
-		// and an explicit result cap, so per-call web spend is deterministic.
 		if (options?.webSearch) {
-			body.plugins = [{ id: "web", engine: "exa", max_results: OPENROUTER_WEB_MAX_RESULTS }];
+			// Engine omitted on purpose: OpenRouter uses the provider's NATIVE web
+			// search when available (the real consumer surface) and only falls back
+			// to Exa otherwise. Every path stays budget-bounded — search_context_size
+			// caps native cost, max_results caps the Exa fallback, max_tokens caps
+			// output either way — so no call is unbounded.
+			body.plugins = [{ id: "web", max_results: OPENROUTER_WEB_MAX_RESULTS }];
+			body.web_search_options = { search_context_size: OPENROUTER_WEB_SEARCH_CONTEXT_SIZE };
 		}
 
 		// Use raw fetch instead of SDK — the SDK's ChatAssistantMessage Zod schema

--- a/packages/lib/src/providers/run-policy.test.ts
+++ b/packages/lib/src/providers/run-policy.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import { RUNS_PER_PROMPT } from "../constants";
+import {
+	lastRunKey,
+	minCadenceHours,
+	parseOrgRunPolicyOverrides,
+	resolveTargetRunPolicy,
+	selectDueTargets,
+	type TargetRunPolicy,
+} from "./run-policy";
+import type { ModelConfig } from "./types";
+
+function target(overrides: Partial<ModelConfig> = {}): ModelConfig {
+	return { model: "chatgpt", provider: "olostep", webSearch: true, ...overrides };
+}
+
+const anthropicTarget = target({ model: "claude", provider: "anthropic-api", version: "claude-sonnet-4-6" });
+
+describe("resolveTargetRunPolicy (non-cloud)", () => {
+	it("defaults to RUNS_PER_PROMPT at the brand cadence", () => {
+		expect(resolveTargetRunPolicy(target(), { deploymentMode: "local", brandCadenceHours: 24 })).toEqual({
+			config: target(),
+			replication: RUNS_PER_PROMPT,
+			cadenceHours: 24,
+		});
+	});
+
+	it("respects explicit replication and cadence", () => {
+		const config = target({ replication: 2, cadenceHours: 6 });
+		expect(resolveTargetRunPolicy(config, { deploymentMode: "local", brandCadenceHours: 24 })).toEqual({
+			config,
+			replication: 2,
+			cadenceHours: 6,
+		});
+	});
+
+	it("lets the target cadence beat the brand override", () => {
+		const config = target({ cadenceHours: 48 });
+		expect(resolveTargetRunPolicy(config, { deploymentMode: "whitelabel", brandCadenceHours: 6 }).cadenceHours).toBe(
+			48,
+		);
+	});
+
+	it("does not clamp non-cloud replication", () => {
+		const config = target({ replication: 9 });
+		expect(resolveTargetRunPolicy(config, { deploymentMode: "local", brandCadenceHours: 24 }).replication).toBe(9);
+	});
+});
+
+describe("resolveTargetRunPolicy (cloud)", () => {
+	const cloud = { deploymentMode: "cloud", brandCadenceHours: 24 };
+
+	it("bases anthropic-api targets at 1/day and others at 4/day", () => {
+		expect(resolveTargetRunPolicy(anthropicTarget, cloud).replication).toBe(1);
+		expect(resolveTargetRunPolicy(target(), cloud).replication).toBe(4);
+	});
+
+	it("floors the cadence at 24h even when the brand override is faster", () => {
+		expect(
+			resolveTargetRunPolicy(target({ cadenceHours: 6 }), { deploymentMode: "cloud", brandCadenceHours: 6 })
+				.cadenceHours,
+		).toBe(24);
+		expect(resolveTargetRunPolicy(target(), { deploymentMode: "cloud", brandCadenceHours: 6 }).cadenceHours).toBe(24);
+	});
+
+	it("keeps cadences slower than the floor", () => {
+		expect(resolveTargetRunPolicy(target({ cadenceHours: 48 }), cloud).cadenceHours).toBe(48);
+	});
+
+	it("clamps env replication to the cloud maximum", () => {
+		expect(resolveTargetRunPolicy(target({ replication: 9 }), cloud).replication).toBe(7);
+	});
+
+	it("applies standardRunsPerDay only to non-anthropic targets", () => {
+		const ctx = { ...cloud, orgOverrides: { standardRunsPerDay: 7 } };
+		expect(resolveTargetRunPolicy(target(), ctx).replication).toBe(7);
+		expect(resolveTargetRunPolicy(anthropicTarget, ctx).replication).toBe(1);
+	});
+
+	it("applies claudeRunsPerDay only to anthropic-api targets", () => {
+		const ctx = { ...cloud, orgOverrides: { claudeRunsPerDay: 2 } };
+		expect(resolveTargetRunPolicy(anthropicTarget, ctx).replication).toBe(2);
+		expect(resolveTargetRunPolicy(target(), ctx).replication).toBe(4);
+	});
+
+	it("clamps org overrides to the cloud maximum", () => {
+		const ctx = { ...cloud, orgOverrides: { standardRunsPerDay: 12 } };
+		expect(resolveTargetRunPolicy(target(), ctx).replication).toBe(7);
+	});
+
+	it("prefers the org override over an explicit env replication", () => {
+		const ctx = { ...cloud, orgOverrides: { standardRunsPerDay: 6 } };
+		expect(resolveTargetRunPolicy(target({ replication: 2 }), ctx).replication).toBe(6);
+	});
+});
+
+describe("parseOrgRunPolicyOverrides", () => {
+	it("returns null for null, empty, invalid JSON, and missing runPolicy", () => {
+		expect(parseOrgRunPolicyOverrides(null)).toBeNull();
+		expect(parseOrgRunPolicyOverrides(undefined)).toBeNull();
+		expect(parseOrgRunPolicyOverrides("")).toBeNull();
+		expect(parseOrgRunPolicyOverrides("{not json")).toBeNull();
+		expect(parseOrgRunPolicyOverrides("{}")).toBeNull();
+		expect(parseOrgRunPolicyOverrides('"string"')).toBeNull();
+	});
+
+	it("returns null when runPolicy is not an object", () => {
+		expect(parseOrgRunPolicyOverrides('{"runPolicy": 4}')).toBeNull();
+		expect(parseOrgRunPolicyOverrides('{"runPolicy": [4]}')).toBeNull();
+	});
+
+	it("keeps only finite integer fields >= 1", () => {
+		expect(parseOrgRunPolicyOverrides('{"runPolicy": {"standardRunsPerDay": 7, "claudeRunsPerDay": 2}}')).toEqual({
+			standardRunsPerDay: 7,
+			claudeRunsPerDay: 2,
+		});
+		expect(parseOrgRunPolicyOverrides('{"runPolicy": {"standardRunsPerDay": 0}}')).toEqual({});
+		expect(parseOrgRunPolicyOverrides('{"runPolicy": {"standardRunsPerDay": 1.5}}')).toEqual({});
+		expect(parseOrgRunPolicyOverrides('{"runPolicy": {"standardRunsPerDay": "three"}}')).toEqual({});
+	});
+});
+
+describe("selectDueTargets", () => {
+	const now = new Date("2026-07-15T12:00:00Z");
+	const hoursAgo = (h: number) => new Date(now.getTime() - h * 60 * 60 * 1000);
+	const policy = (config: ModelConfig, cadenceHours: number): TargetRunPolicy => ({
+		config,
+		replication: 1,
+		cadenceHours,
+	});
+
+	it("marks never-run targets due", () => {
+		expect(selectDueTargets([policy(target(), 24)], new Map(), now)).toHaveLength(1);
+	});
+
+	it("marks a target due exactly at its cadence", () => {
+		const lastRuns = new Map([[lastRunKey("chatgpt", "olostep"), hoursAgo(24)]]);
+		expect(selectDueTargets([policy(target(), 24)], lastRuns, now)).toHaveLength(1);
+	});
+
+	it("does not mark a target due just under its cadence", () => {
+		const lastRuns = new Map([[lastRunKey("chatgpt", "olostep"), hoursAgo(23.9)]]);
+		expect(selectDueTargets([policy(target(), 24)], lastRuns, now)).toHaveLength(0);
+	});
+
+	it("lets a legacy null-provider row satisfy a (model, provider) target", () => {
+		const lastRuns = new Map([[lastRunKey("chatgpt", null), hoursAgo(1)]]);
+		expect(selectDueTargets([policy(target(), 24)], lastRuns, now)).toHaveLength(0);
+	});
+
+	it("uses the later of the keyed and legacy timestamps", () => {
+		const lastRuns = new Map([
+			[lastRunKey("chatgpt", "olostep"), hoursAgo(30)],
+			[lastRunKey("chatgpt", null), hoursAgo(1)],
+		]);
+		expect(selectDueTargets([policy(target(), 24)], lastRuns, now)).toHaveLength(0);
+	});
+
+	it("filters per target under mixed cadences", () => {
+		const daily = policy(target(), 24);
+		const claude = policy(anthropicTarget, 48);
+		const lastRuns = new Map([
+			[lastRunKey("chatgpt", "olostep"), hoursAgo(25)],
+			[lastRunKey("claude", "anthropic-api"), hoursAgo(25)],
+		]);
+		expect(selectDueTargets([daily, claude], lastRuns, now)).toEqual([daily]);
+	});
+});
+
+describe("minCadenceHours", () => {
+	it("picks the minimum cadence", () => {
+		const policies = [
+			{ config: target(), replication: 1, cadenceHours: 24 },
+			{ config: anthropicTarget, replication: 1, cadenceHours: 12 },
+		];
+		expect(minCadenceHours(policies, 48)).toBe(12);
+	});
+
+	it("falls back when empty", () => {
+		expect(minCadenceHours([], 48)).toBe(48);
+	});
+});

--- a/packages/lib/src/providers/run-policy.ts
+++ b/packages/lib/src/providers/run-policy.ts
@@ -1,0 +1,119 @@
+import { RUNS_PER_PROMPT } from "../constants";
+import type { ModelConfig } from "./types";
+
+export interface TargetRunPolicy {
+	config: ModelConfig;
+	replication: number;
+	cadenceHours: number;
+}
+
+/** Org-level overrides for cloud custom plans, stored under the `runPolicy`
+ *  key of better-auth `organization.metadata` (a JSON string column). The
+ *  entitlement system will supersede this reader — keep the shape. */
+export interface OrgRunPolicyOverrides {
+	standardRunsPerDay?: number;
+	claudeRunsPerDay?: number;
+}
+
+export const CLOUD_STANDARD_RUNS_PER_DAY = 4;
+export const CLOUD_ANTHROPIC_RUNS_PER_DAY = 1;
+export const CLOUD_MAX_RUNS_PER_DAY = 7;
+export const CLOUD_CADENCE_FLOOR_HOURS = 24;
+
+export function parseOrgRunPolicyOverrides(metadataJson: string | null | undefined): OrgRunPolicyOverrides | null {
+	if (!metadataJson) return null;
+	let metadata: unknown;
+	try {
+		metadata = JSON.parse(metadataJson);
+	} catch {
+		return null;
+	}
+	if (typeof metadata !== "object" || metadata === null) return null;
+	const runPolicy = (metadata as Record<string, unknown>).runPolicy;
+	if (typeof runPolicy !== "object" || runPolicy === null || Array.isArray(runPolicy)) return null;
+	const raw = runPolicy as Record<string, unknown>;
+	const overrides: OrgRunPolicyOverrides = {};
+	if (
+		typeof raw.standardRunsPerDay === "number" &&
+		Number.isInteger(raw.standardRunsPerDay) &&
+		raw.standardRunsPerDay >= 1
+	) {
+		overrides.standardRunsPerDay = raw.standardRunsPerDay;
+	}
+	if (typeof raw.claudeRunsPerDay === "number" && Number.isInteger(raw.claudeRunsPerDay) && raw.claudeRunsPerDay >= 1) {
+		overrides.claudeRunsPerDay = raw.claudeRunsPerDay;
+	}
+	return overrides;
+}
+
+/**
+ * Resolve the effective runs-per-firing and cadence for one target.
+ *
+ * Non-cloud: SCRAPE_TARGETS options win, then the deployment defaults — an
+ * explicit per-target cadence beats the brand override because both are
+ * operator-level knobs and the target one is scoped tighter.
+ *
+ * Cloud: org overrides beat SCRAPE_TARGETS beat the per-provider base, but the
+ * result is always clamped to [1, CLOUD_MAX_RUNS_PER_DAY] and the cadence
+ * floored at CLOUD_CADENCE_FLOOR_HOURS — plan config is not trusted to exceed
+ * the platform bounds.
+ */
+export function resolveTargetRunPolicy(
+	config: ModelConfig,
+	ctx: {
+		/** process.env.DEPLOYMENT_MODE convention; anything !== "cloud" is non-cloud. */
+		deploymentMode: string;
+		/** brand.delayOverrideHours ?? getDefaultDelayHours() */
+		brandCadenceHours: number;
+		orgOverrides?: OrgRunPolicyOverrides | null;
+	},
+): TargetRunPolicy {
+	if (ctx.deploymentMode !== "cloud") {
+		return {
+			config,
+			replication: config.replication ?? RUNS_PER_PROMPT,
+			cadenceHours: config.cadenceHours ?? ctx.brandCadenceHours,
+		};
+	}
+	const isAnthropic = config.provider === "anthropic-api";
+	const base = isAnthropic ? CLOUD_ANTHROPIC_RUNS_PER_DAY : CLOUD_STANDARD_RUNS_PER_DAY;
+	const orgOverride = isAnthropic ? ctx.orgOverrides?.claudeRunsPerDay : ctx.orgOverrides?.standardRunsPerDay;
+	const requested = orgOverride ?? config.replication ?? base;
+	return {
+		config,
+		replication: Math.min(CLOUD_MAX_RUNS_PER_DAY, Math.max(1, requested)),
+		cadenceHours: Math.max(CLOUD_CADENCE_FLOOR_HOURS, config.cadenceHours ?? ctx.brandCadenceHours),
+	};
+}
+
+/** Key for last-run lookups; provider may be null on legacy prompt_runs rows. */
+export function lastRunKey(model: string, provider: string | null): string {
+	return `${model}::${provider ?? ""}`;
+}
+
+/**
+ * A target is due when it has never run or its cadence has fully elapsed.
+ * Strict (no tolerance): the schedule is completion-anchored, so elapsed time
+ * at the next firing is always >= the period — a strict check can
+ * under-deliver by at most one firing under mixed cadences but never
+ * over-deliver (never overspend).
+ */
+export function selectDueTargets(
+	policies: TargetRunPolicy[],
+	lastRunAtByKey: Map<string, Date>,
+	now: Date,
+): TargetRunPolicy[] {
+	return policies.filter((policy) => {
+		const keyed = lastRunAtByKey.get(lastRunKey(policy.config.model, policy.config.provider));
+		// Legacy prompt_runs rows have a null provider; use the later timestamp.
+		const legacy = lastRunAtByKey.get(lastRunKey(policy.config.model, null));
+		const lastRunAt = keyed && legacy ? (keyed.getTime() >= legacy.getTime() ? keyed : legacy) : (keyed ?? legacy);
+		if (!lastRunAt) return true;
+		return now.getTime() - lastRunAt.getTime() >= policy.cadenceHours * 60 * 60 * 1000;
+	});
+}
+
+export function minCadenceHours(policies: TargetRunPolicy[], fallback: number): number {
+	if (policies.length === 0) return fallback;
+	return Math.min(...policies.map((policy) => policy.cadenceHours));
+}


### PR DESCRIPTION
Closes #340.

## What

Adds the provider-layer knobs the cloud offering needs: per-target run **replication** and **cadence**, plus hard **output-token and web-search spend caps** on the direct API providers. No behavior change for existing self-hosted / whitelabel deployments.

## Why

Every tracked prompt ran a hardcoded 5 iterations per target at one brand-level cadence, and API-provider calls had no output-token cap (except Anthropic) and, for OpenRouter and Mistral, no bound on web-search spend. Cloud requires per-target cadence/replication (standard platforms 4×/day, Claude 1×/day, custom up to 7×/day) and a guarantee that no web-grounded call can spend unboundedly. This PR delivers those knobs; the entitlement/enforcement layer that consumes them lands separately (#344 / #347).

## Changes

- **`SCRAPE_TARGETS` syntax** gains optional tail options: `model:provider[:version][:online][:xN][:Ch]`, where `:xN` is runs-per-firing and `:Ch` is per-target cadence hours. Order-independent; fully backward compatible (entries without them parse exactly as before).
- **Run-policy resolver** (`packages/lib/src/providers/run-policy.ts`) resolves each target to `{replication, cadenceHours}`. Non-cloud defaults reproduce today's behavior (5× at the brand cadence). Cloud mode bases replication per provider (Claude 1/day, standard 4/day), lets `SCRAPE_TARGETS` and per-org overrides raise it, and **clamps server-side to ≤7/day with a 24h cadence floor** — the platform bound is enforced below plan config, not trusted to it.
- **Hard API spend caps** (`packages/lib/src/providers/config.ts`): output-token caps for anthropic-api / openai-api / openrouter / mistral-api; `max_uses` on Anthropic web search; `maxToolCalls` on the OpenAI Responses web-search tool. **OpenRouter web search stays native-first** — the plugin is sent with the engine omitted, so OpenRouter uses the model provider's own web search when the model supports it (OpenAI/Anthropic/Google/Perplexity/xAI) and only falls back to Exa otherwise. Spend is still bounded on every path: `search_context_size` caps native cost, `max_results` caps the Exa fallback, `max_tokens` caps output.
- **Worker scheduling** now runs each target for its own replication and reschedules at the fastest resolved cadence. Uniform-cadence prompts (every existing deployment) take a fast path that skips the due-check query entirely — identical run volume, no extra DB reads. Admin "run now" carries a `force` flag so a manual retry isn't swallowed by the due check.
- **Folded-in bug fix**: the 6-hourly maintenance watchdog checked overdue-ness against *all* configured models rather than the brand's selected ones, so any brand with an `enabledModels` subset was judged overdue every pass and had its job expedited — sampling ~4× more often than configured. It now checks only the selected targets' resolved policies.

## Acceptance criteria (#340)

- Existing deployments with unchanged env → identical run volume ✓ (non-cloud resolver + uniform-cadence fast path)
- A target configured with replication N and cadence C → exactly N runs per C ✓
- A web-grounded call can never exceed the configured search/token budget ✓ (output-token cap always; native web search bounded by `search_context_size`, Exa fallback by `max_results`)

## Web-search fidelity

OpenRouter `:online` tracks the model provider's **native** web search (the real consumer surface), not a forced third-party engine — Exa is only a fallback for models without native search. Citation source is unchanged from before this PR; the PR adds the spend bounds around it.

## Tests

New/extended unit tests (all pure, no DB): `SCRAPE_TARGETS` parse/format round-trips incl. the new suffixes and reject cases; the full run-policy matrix (cloud clamp/floor, org-override targeting, strict due boundary, legacy null-provider rows); and request-body assertions for the OpenRouter (native-first plugin + context-size + token cap) and Mistral (both paths) providers.

## Notes

- No schema or migration changes; no dependency bumps.
- Org-scoped overrides join through `brands.organizationId` (the #370 FK).
- Reports keep `RUNS_PER_PROMPT` — reports don't exist in cloud mode.
