### PR TITLE
Add Google AI Overview support to the BrightData and DataForSEO providers

### DIFF
--- a/.changeset/google-ai-overview-brightdata-dataforseo.md
+++ b/.changeset/google-ai-overview-brightdata-dataforseo.md
@@ -1,0 +1,5 @@
+---
+"@elmohq/cli": patch
+---
+
+Added Google AI Overview tracking via the BrightData and DataForSEO providers; `SCRAPE_TARGETS` now accepts `google-ai-overview:brightdata:online` and `google-ai-overview:dataforseo:online`.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -397,7 +397,15 @@ const OXYLABS_AFFILIATE = "https://oxylabs.go2cloud.org/aff_c?offer_id=7&aff_id=
 const PROVIDERS_DOC_URL = "https://docs.elmohq.com/docs/user-guide/providers";
 
 // Surfaces each scraper can track — the first two are the "recommended starter" set.
-const BRIGHTDATA_MODELS = ["chatgpt", "google-ai-mode", "perplexity", "copilot", "gemini", "grok"] as const;
+const BRIGHTDATA_MODELS = [
+	"chatgpt",
+	"google-ai-mode",
+	"google-ai-overview",
+	"perplexity",
+	"copilot",
+	"gemini",
+	"grok",
+] as const;
 
 const OLOSTEP_MODELS = [
 	"chatgpt",
@@ -412,7 +420,7 @@ const OLOSTEP_MODELS = [
 const OXYLABS_MODELS = ["chatgpt", "google-ai-mode", "perplexity"] as const;
 
 const DEFAULT_SCRAPER_MODELS = ["chatgpt", "google-ai-mode"] as const;
-const DATAFORSEO_MODELS = ["google-ai-mode", "chatgpt", "perplexity", "gemini"] as const;
+const DATAFORSEO_MODELS = ["google-ai-mode", "google-ai-overview", "chatgpt", "perplexity", "gemini"] as const;
 
 const DEFAULT_OPENAI_MODEL = "gpt-5-mini";
 const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";

--- a/packages/docs/content/docs/user-guide/providers.mdx
+++ b/packages/docs/content/docs/user-guide/providers.mdx
@@ -30,6 +30,7 @@ Supported scrape targets out of the box:
 ```
 chatgpt:brightdata:online
 google-ai-mode:brightdata:online
+google-ai-overview:brightdata:online
 perplexity:brightdata:online
 copilot:brightdata:online
 gemini:brightdata:online
@@ -37,6 +38,8 @@ grok:brightdata:online
 ```
 
 You can also pass a custom dataset id as the version slug: `chatgpt:brightdata:gd_abc123`.
+
+`google-ai-overview` is the one exception: it's the AI summary block on a normal Google results page, so it's fetched through BrightData's SERP API rather than a dataset collector — no dataset id, and the SERP zone is provisioned automatically from your `BRIGHTDATA_API_TOKEN`.
 
 ### Oxylabs
 
@@ -106,15 +109,17 @@ OpenAI/Anthropic/Mistral/OpenRouter entries all require a version slug as the th
 
 ```bash
 google-ai-mode:dataforseo:online
+google-ai-overview:dataforseo:online
 chatgpt:dataforseo:online
 perplexity:dataforseo:online
 gemini:dataforseo:online
 ```
 
 - `google-ai-mode` uses DataForSEO's SERP Google AI Mode endpoint (unchanged).
+- `google-ai-overview` uses DataForSEO's Google Organic SERP endpoint with `load_async_ai_overview` on, returning the AI Overview block and its cited sources.
 - `chatgpt`, `perplexity`, and `gemini` use DataForSEO's [AI Optimization "LLM Responses"](https://docs.dataforseo.com/v3/ai_optimization-llm_responses-overview/) API with web search enabled, returning the answer text and cited source URLs.
 
-Each LLM surface defaults to a sensible model (`gpt-5.5`, `sonar`, `gemini-2.5-flash`). Override the underlying DataForSEO `model_name` via the version slug, e.g. `chatgpt:dataforseo:gpt-5-mini:online`. All four require `:online`.
+Each LLM surface defaults to a sensible model (`gpt-5.5`, `sonar`, `gemini-2.5-flash`). Override the underlying DataForSEO `model_name` via the version slug, e.g. `chatgpt:dataforseo:gpt-5-mini:online`. All require `:online`.
 
 DataForSEO prompt text is limited to 500 characters. Country localization is intentionally not exposed in `SCRAPE_TARGETS` yet because support differs by DataForSEO surface and underlying model.
 
@@ -156,7 +161,7 @@ SCRAPE_TARGETS=chatgpt:openai-api:gpt-5-mini:online,claude:anthropic-api:claude-
 model:provider[:version][:online]
 ```
 
-- `model` — the AI surface being tracked (`chatgpt`, `claude`, `google-ai-mode`, `gemini`, `perplexity`, `copilot`, `grok`).
+- `model` — the AI surface being tracked (`chatgpt`, `claude`, `google-ai-mode`, `google-ai-overview`, `gemini`, `perplexity`, `copilot`, `grok`).
 - `provider` — how to reach it (`brightdata`, `oxylabs`, `olostep`, `openai-api`, `anthropic-api`, `mistral-api`, `openrouter`, `dataforseo`).
 - `version` — required for `openai-api`, `anthropic-api`, `mistral-api`, `openrouter`. Optional for scrapers (pass a BrightData dataset id here).
 - `:online` — append to enable web search. Required for most scraped models since the live UIs always search.

--- a/packages/docs/content/docs/user-guide/providers.mdx
+++ b/packages/docs/content/docs/user-guide/providers.mdx
@@ -39,7 +39,7 @@ grok:brightdata:online
 
 You can also pass a custom dataset id as the version slug: `chatgpt:brightdata:gd_abc123`.
 
-`google-ai-overview` is the one exception: it's the AI summary block on a normal Google results page, so it's fetched through BrightData's SERP API rather than a dataset collector — no dataset id, and the SERP zone is provisioned automatically from your `BRIGHTDATA_API_TOKEN`.
+`google-ai-overview` is the one exception: it's the AI summary block on a normal Google results page, so it's fetched through BrightData's SERP API rather than a dataset collector — no dataset id needed. It runs through a serp zone (default `sdk_serp`, the zone the BrightData SDK auto-provisions; override with `BRIGHTDATA_SERP_ZONE`) billed to the same `BRIGHTDATA_API_TOKEN`.
 
 ### Oxylabs
 

--- a/packages/lib/src/providers/registry/brightdata.ts
+++ b/packages/lib/src/providers/registry/brightdata.ts
@@ -1,7 +1,12 @@
 import { bdclient } from "@brightdata/sdk";
 import type { Provider, ScrapeResult, ProviderOptions, ModelConfig } from "../types";
-import type { Citation } from "../../text-extraction";
+import { extractCitationsFromBrightdata, extractTextFromBrightdata, type Citation } from "../../text-extraction";
 import { WEB_QUERIES_UNAVAILABLE } from "../../constants";
+
+// Google AI Overview isn't a Web Scraper dataset — it's the AI summary block on
+// a normal Google results page, fetched through BrightData's SERP API instead of
+// the datasets/v3 collectors below.
+const AI_OVERVIEW_MODEL = "google-ai-overview";
 
 const BD_DATASET_IDS: Record<string, string> = {
 	chatgpt: "gd_m7aof0k82r803d5bjm",
@@ -15,7 +20,6 @@ const BD_DATASET_IDS: Record<string, string> = {
 const BD_BASE_URL: Record<string, string> = {
 	chatgpt: "https://chatgpt.com/",
 	"google-ai-mode": "https://google.com/aimode",
-	"google-ai-overview": "https://www.google.com/",
 	gemini: "https://gemini.google.com/",
 	copilot: "https://copilot.microsoft.com/chats",
 	perplexity: "https://www.perplexity.ai/",
@@ -24,6 +28,38 @@ const BD_BASE_URL: Record<string, string> = {
 
 function createClient(): bdclient {
 	return new bdclient({ apiKey: process.env.BRIGHTDATA_API_TOKEN });
+}
+
+/**
+ * Fetch Google's AI Overview through BrightData's SERP API (client.search.google
+ * → google.com/search?brd_json=1). This routes through a serp zone that the SDK
+ * auto-provisions from BRIGHTDATA_API_TOKEN, so it needs no dataset id and no
+ * extra credential. The parsed SERP carries an `ai_overview` field when Google
+ * shows one; the shared BrightData extractors read it (defensively, since the
+ * brd_json AI Overview shape isn't formally documented).
+ */
+async function runGoogleAiOverview(prompt: string): Promise<ScrapeResult> {
+	const client = createClient();
+	try {
+		const res = await client.search.google(prompt, { format: "json" });
+		if (typeof res.status_code === "number" && res.status_code >= 400) {
+			throw new Error(`BrightData SERP failed (${res.status_code})`);
+		}
+		const parsed = typeof res.body === "string" ? JSON.parse(res.body) : res.body;
+
+		const citations = extractCitationsFromBrightdata(parsed);
+		return {
+			rawOutput: parsed,
+			textContent: extractTextFromBrightdata(parsed),
+			// The SERP API doesn't expose the query expansion behind the overview;
+			// mark it unavailable when sources prove a live result, else empty.
+			webQueries: citations.length > 0 ? [WEB_QUERIES_UNAVAILABLE] : [],
+			citations,
+			modelVersion: "brightdata-serp",
+		};
+	} finally {
+		await client.close();
+	}
 }
 
 function normalizeAnswer(record: Record<string, any>): string {
@@ -87,9 +123,16 @@ export const brightdata: Provider = {
 	},
 
 	validateTarget(config: ModelConfig) {
+		// Google AI Overview goes through the SERP API, not a dataset collector.
+		if (config.model === AI_OVERVIEW_MODEL) {
+			if (!config.webSearch) {
+				return `${config.model}:brightdata requires :online — AI Overview always uses web search`;
+			}
+			return null;
+		}
 		// Allow custom dataset IDs via version slug (e.g. chatgpt:brightdata:gd_abc123)
 		if (!config.version && !BD_DATASET_IDS[config.model]) {
-			return `BrightData does not support model "${config.model}". Supported: ${Object.keys(BD_DATASET_IDS).join(", ")}`;
+			return `BrightData does not support model "${config.model}". Supported: ${[...Object.keys(BD_DATASET_IDS), AI_OVERVIEW_MODEL].join(", ")}`;
 		}
 		// ChatGPT has a web search toggle; all other chatbots always search
 		if (!config.webSearch && config.model !== "chatgpt") {
@@ -99,12 +142,16 @@ export const brightdata: Provider = {
 	},
 
 	async run(model: string, prompt: string, options?: ProviderOptions): Promise<ScrapeResult> {
+		if (model === AI_OVERVIEW_MODEL) {
+			return runGoogleAiOverview(prompt);
+		}
+
 		const datasetId = options?.version ?? BD_DATASET_IDS[model];
 		if (!datasetId) {
 			throw new Error(
 				`BrightData: no dataset ID for model "${model}". ` +
-				`Either use a known model (${Object.keys(BD_DATASET_IDS).join(", ")}) ` +
-				`or pass a dataset ID as the version slug: ${model}:brightdata:gd_abc123`,
+					`Either use a known model (${Object.keys(BD_DATASET_IDS).join(", ")}) ` +
+					`or pass a dataset ID as the version slug: ${model}:brightdata:gd_abc123`,
 			);
 		}
 
@@ -120,12 +167,14 @@ export const brightdata: Provider = {
 						Authorization: `Bearer ${process.env.BRIGHTDATA_API_TOKEN}`,
 						"Content-Type": "application/json",
 					},
-					body: JSON.stringify([{
-						url: BD_BASE_URL[model] ?? "",
-						prompt,
-						index: 1,
-						...(model === "chatgpt" ? { web_search: options?.webSearch ?? false } : {}),
-					}]),
+					body: JSON.stringify([
+						{
+							url: BD_BASE_URL[model] ?? "",
+							prompt,
+							index: 1,
+							...(model === "chatgpt" ? { web_search: options?.webSearch ?? false } : {}),
+						},
+					]),
 				},
 			);
 
@@ -156,7 +205,11 @@ export const brightdata: Provider = {
 				// and citations exist but no query strings were exposed.
 				// When web search is disabled, webQueries is always empty.
 				webQueries: options?.webSearch
-					? (webQueries.length > 0 ? webQueries : citations.length > 0 ? [WEB_QUERIES_UNAVAILABLE] : [])
+					? webQueries.length > 0
+						? webQueries
+						: citations.length > 0
+							? [WEB_QUERIES_UNAVAILABLE]
+							: []
 					: [],
 				citations,
 				modelVersion: record?.model ?? undefined,

--- a/packages/lib/src/providers/registry/brightdata.ts
+++ b/packages/lib/src/providers/registry/brightdata.ts
@@ -30,36 +30,63 @@ function createClient(): bdclient {
 	return new bdclient({ apiKey: process.env.BRIGHTDATA_API_TOKEN });
 }
 
+const BRIGHTDATA_REQUEST_URL = "https://api.brightdata.com/request";
+
 /**
- * Fetch Google's AI Overview through BrightData's SERP API (client.search.google
- * → google.com/search?brd_json=1). This routes through a serp zone that the SDK
- * auto-provisions from BRIGHTDATA_API_TOKEN, so it needs no dataset id and no
- * extra credential. The parsed SERP carries an `ai_overview` field when Google
- * shows one; the shared BrightData extractors read it (defensively, since the
- * brd_json AI Overview shape isn't formally documented).
+ * Fetch Google's AI Overview through BrightData's SERP API. AI Overview is the
+ * AI summary block on a normal results page, so we request a US-English Google
+ * SERP as parsed JSON (`brd_json=1`) with `brd_ai_overview=2` — the flag that
+ * makes BrightData surface the overview; without it AIO shows up in only a
+ * fraction of SERPs. This runs through a serp zone (default `sdk_serp`, the zone
+ * the BrightData SDK auto-provisions; override with BRIGHTDATA_SERP_ZONE), billed
+ * to the same BRIGHTDATA_API_TOKEN — no dataset id or extra credential. The
+ * parsed SERP carries an `ai_overview` object when Google shows one.
  */
 async function runGoogleAiOverview(prompt: string): Promise<ScrapeResult> {
-	const client = createClient();
-	try {
-		const res = await client.search.google(prompt, { format: "json" });
-		if (typeof res.status_code === "number" && res.status_code >= 400) {
-			throw new Error(`BrightData SERP failed (${res.status_code})`);
-		}
-		const parsed = typeof res.body === "string" ? JSON.parse(res.body) : res.body;
+	const zone = process.env.BRIGHTDATA_SERP_ZONE ?? "sdk_serp";
+	const url = `https://www.google.com/search?q=${encodeURIComponent(prompt)}&brd_json=1&brd_ai_overview=2&gl=us&hl=en`;
 
-		const citations = extractCitationsFromBrightdata(parsed);
-		return {
-			rawOutput: parsed,
-			textContent: extractTextFromBrightdata(parsed),
-			// The SERP API doesn't expose the query expansion behind the overview;
-			// mark it unavailable when sources prove a live result, else empty.
-			webQueries: citations.length > 0 ? [WEB_QUERIES_UNAVAILABLE] : [],
-			citations,
-			modelVersion: "brightdata-serp",
-		};
-	} finally {
-		await client.close();
+	let lastError = "";
+	for (let attempt = 0; attempt < 3; attempt++) {
+		const res = await fetch(BRIGHTDATA_REQUEST_URL, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${process.env.BRIGHTDATA_API_TOKEN}`,
+				"Content-Type": "application/json",
+			},
+			// `method: "GET"` tells BrightData how to fetch the target URL — without
+			// it the response comes back empty. `format: "raw"` returns the brd_json
+			// SERP directly as the body.
+			body: JSON.stringify({ zone, url, method: "GET", format: "raw" }),
+		});
+		const text = await res.text();
+
+		let parsed: unknown;
+		if (res.ok && text.trim()) {
+			try {
+				parsed = JSON.parse(text);
+			} catch {
+				// fall through to retry — a non-JSON body is a transient edge/error page
+			}
+		}
+
+		if (parsed !== undefined) {
+			const citations = extractCitationsFromBrightdata(parsed);
+			return {
+				rawOutput: parsed,
+				textContent: extractTextFromBrightdata(parsed),
+				// The SERP API doesn't expose the query expansion behind the overview;
+				// mark it unavailable when sources prove a live result, else empty.
+				webQueries: citations.length > 0 ? [WEB_QUERIES_UNAVAILABLE] : [],
+				citations,
+				modelVersion: "brightdata-serp",
+			};
+		}
+
+		lastError = `${res.status} ${text.slice(0, 200)}`.trim();
+		await new Promise((resolve) => setTimeout(resolve, 1500 * (attempt + 1)));
 	}
+	throw new Error(`BrightData SERP request failed after 3 attempts — ${lastError}`);
 }
 
 function normalizeAnswer(record: Record<string, any>): string {

--- a/packages/lib/src/providers/registry/dataforseo.test.ts
+++ b/packages/lib/src/providers/registry/dataforseo.test.ts
@@ -5,6 +5,7 @@ const dataforseoClient = vi.hoisted(() => ({
 	perplexityLlmResponsesLive: vi.fn(),
 	geminiLlmResponsesLive: vi.fn(),
 	googleAiModeLiveAdvanced: vi.fn(),
+	googleOrganicLiveAdvanced: vi.fn(),
 }));
 
 vi.mock("dataforseo-client", () => ({
@@ -15,8 +16,14 @@ vi.mock("dataforseo-client", () => ({
 	},
 	SerpApi: class {
 		googleAiModeLiveAdvanced = dataforseoClient.googleAiModeLiveAdvanced;
+		googleOrganicLiveAdvanced = dataforseoClient.googleOrganicLiveAdvanced;
 	},
 	SerpGoogleAiModeLiveAdvancedRequestInfo: class {
+		constructor(args: Record<string, unknown>) {
+			Object.assign(this, args);
+		}
+	},
+	SerpGoogleOrganicLiveAdvancedRequestInfo: class {
 		constructor(args: Record<string, unknown>) {
 			Object.assign(this, args);
 		}
@@ -94,6 +101,47 @@ describe("dataforseo provider", () => {
 			model_name: "gpt-5.5",
 			web_search: true,
 		});
+	});
+
+	it("fetches Google AI Overview from the organic SERP endpoint with async loading on", async () => {
+		dataforseoClient.googleOrganicLiveAdvanced.mockResolvedValueOnce({
+			tasks: [
+				{
+					status_code: 20000,
+					status_message: "Ok.",
+					result: [
+						{
+							items: [
+								{ type: "organic", title: "some result" },
+								{
+									type: "ai_overview",
+									markdown: "The Sonos Era 300 is a well-reviewed speaker released recently.",
+									references: [
+										{ url: "https://www.whathifi.com/reviews/sonos-era-300", title: "Sonos Era 300 review" },
+									],
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+
+		const result = await dataforseo.run("google-ai-overview", "What is a well-reviewed speaker released last month?", {
+			webSearch: true,
+		});
+
+		const [payload] = dataforseoClient.googleOrganicLiveAdvanced.mock.calls[0];
+		expect(payload[0]).toMatchObject({
+			keyword: "What is a well-reviewed speaker released last month?",
+			location_code: 2840,
+			load_async_ai_overview: true,
+		});
+
+		expect(result.textContent).toContain("Sonos Era 300");
+		expect(result.citations).toHaveLength(1);
+		expect(result.citations[0].domain).toBe("whathifi.com");
+		expect(result.webQueries).toEqual(["unavailable"]);
 	});
 
 	it("resolves Gemini Vertex grounding-redirect citation URLs to the real source", async () => {

--- a/packages/lib/src/providers/registry/dataforseo.ts
+++ b/packages/lib/src/providers/registry/dataforseo.ts
@@ -30,7 +30,11 @@ const LLM_MODELS: Record<string, { defaultModelName: string; call: keyof typeof 
 	gemini: { defaultModelName: "gemini-2.5-flash", call: "gemini" },
 };
 
-const SUPPORTED_MODELS = new Set([...SERP_MODELS, ...Object.keys(LLM_MODELS)]);
+// Google AI Overview is the AI summary block on a standard Google results page.
+// It comes from the Organic SERP endpoint (not AI Mode's dedicated SERP), so it
+// gets its own runner rather than joining SERP_MODELS.
+const AI_OVERVIEW_MODEL = "google-ai-overview";
+const SUPPORTED_MODELS = new Set([...SERP_MODELS, AI_OVERVIEW_MODEL, ...Object.keys(LLM_MODELS)]);
 const MAX_PROMPT_CHARS = 500;
 
 interface DataForSeoLlmRequest {
@@ -107,6 +111,42 @@ async function runGoogleAiMode(prompt: string): Promise<ScrapeResult> {
 	// strings anywhere in its response. Mark "unavailable" when citations
 	// prove a search, like the other providers; never echo the prompt (runs
 	// before this change did).
+	return {
+		rawOutput: sanitizeForJson(response),
+		webQueries: citations.length > 0 ? [WEB_QUERIES_UNAVAILABLE] : [],
+		textContent: extractTextFromGoogle(response),
+		citations,
+		modelVersion: "dataforseo",
+	};
+}
+
+async function runGoogleAiOverview(prompt: string): Promise<ScrapeResult> {
+	assertPromptLength(prompt);
+	const api = createDfsSerpApi();
+	const requestInfo = new client.SerpGoogleOrganicLiveAdvancedRequestInfo({
+		keyword: prompt,
+		location_code: 2840,
+		language_code: "en",
+		depth: 10,
+		// AI Overviews are generated on demand; without this DataForSEO only
+		// returns whatever it had cached, so most runs would come back empty.
+		load_async_ai_overview: true,
+	});
+
+	const response = await api.googleOrganicLiveAdvanced([requestInfo]);
+
+	if (!response?.tasks?.length) {
+		throw new Error(`DataForSEO API Error: No response or tasks.`);
+	}
+
+	const task = response.tasks[0];
+	if (task.status_code !== 20000 || !task.result?.length) {
+		throw new Error(`DataForSEO API Error: ${task.status_message}`);
+	}
+
+	// The SERP response carries the AI Overview as an items[].type "ai_overview"
+	// element, which the shared Google extractors already understand.
+	const citations = extractCitationsFromGoogle(response);
 	return {
 		rawOutput: sanitizeForJson(response),
 		webQueries: citations.length > 0 ? [WEB_QUERIES_UNAVAILABLE] : [],
@@ -240,6 +280,9 @@ export const dataforseo: Provider = {
 		assertPromptLength(prompt);
 		if (SERP_MODELS.has(model)) {
 			return runGoogleAiMode(prompt);
+		}
+		if (model === AI_OVERVIEW_MODEL) {
+			return runGoogleAiOverview(prompt);
 		}
 		if (LLM_MODELS[model]) {
 			return runLlmResponse(model, prompt, options);

--- a/packages/lib/src/text-extraction.test.ts
+++ b/packages/lib/src/text-extraction.test.ts
@@ -603,20 +603,6 @@ describe("text-extraction", () => {
 			expect(citations[0].title).toBe("What Hi-Fi");
 		});
 
-		it("keeps titles without the marker intact, even with heavy whitespace", () => {
-			const rawOutput = {
-				ai_overview: {
-					references: [
-						{ href: "https://example.com/a", title: "Best Speakers 2026." },
-						{ href: "https://example.com/b", title: `${" ".repeat(50000)}no marker here` },
-					],
-				},
-			};
-			const citations = extractCitationsFromBrightdata(rawOutput);
-			expect(citations[0].title).toBe("Best Speakers 2026.");
-			expect(citations[1].title).toBe("no marker here");
-		});
-
 		it("still extracts chatbot dataset citations", () => {
 			const rawOutput = { citations: [{ url: "https://example.com/a", title: "A" }] };
 			expect(extractCitationsFromBrightdata(rawOutput)).toHaveLength(1);

--- a/packages/lib/src/text-extraction.test.ts
+++ b/packages/lib/src/text-extraction.test.ts
@@ -603,6 +603,20 @@ describe("text-extraction", () => {
 			expect(citations[0].title).toBe("What Hi-Fi");
 		});
 
+		it("keeps titles without the marker intact, even with heavy whitespace", () => {
+			const rawOutput = {
+				ai_overview: {
+					references: [
+						{ href: "https://example.com/a", title: "Best Speakers 2026." },
+						{ href: "https://example.com/b", title: `${" ".repeat(50000)}no marker here` },
+					],
+				},
+			};
+			const citations = extractCitationsFromBrightdata(rawOutput);
+			expect(citations[0].title).toBe("Best Speakers 2026.");
+			expect(citations[1].title).toBe("no marker here");
+		});
+
 		it("still extracts chatbot dataset citations", () => {
 			const rawOutput = { citations: [{ url: "https://example.com/a", title: "A" }] };
 			expect(extractCitationsFromBrightdata(rawOutput)).toHaveLength(1);

--- a/packages/lib/src/text-extraction.test.ts
+++ b/packages/lib/src/text-extraction.test.ts
@@ -541,48 +541,69 @@ describe("text-extraction", () => {
 	});
 
 	describe("extractTextFromBrightdata", () => {
-		it("should read the SERP AI Overview from the ai_overview field", () => {
+		it("reads the SERP AI Overview from ai_overview.texts, including nested list blocks", () => {
 			const rawOutput = {
 				ai_overview: {
-					markdown: "The Sonos Era 300 is a well-reviewed speaker with spatial audio support.",
-					source_links: [{ url: "https://www.whathifi.com/reviews/sonos-era-300", title: "Sonos Era 300" }],
+					texts: [
+						{ type: "paragraph", snippet: "The Sonos Era 300 is a well-reviewed speaker with spatial audio." },
+						{
+							type: "list",
+							snippet: "",
+							list: [
+								{ type: "paragraph", snippet: "Battery Life: 6 hours" },
+								{ type: "paragraph", snippet: "Water resistance: IP55" },
+							],
+						},
+					],
+					references: [
+						{
+							href: "https://www.whathifi.com/reviews/sonos-era-300",
+							title: "What Hi-Fi. Opens in new tab.",
+							index: 0,
+						},
+					],
 				},
 			};
-			expect(extractTextFromBrightdata(rawOutput)).toContain("Sonos Era 300");
+			expect(extractTextFromBrightdata(rawOutput)).toBe(
+				"The Sonos Era 300 is a well-reviewed speaker with spatial audio.\nBattery Life: 6 hours\nWater resistance: IP55",
+			);
 		});
 
-		it("should join an AI Overview split into text blocks", () => {
-			const rawOutput = {
-				ai_overview: {
-					items: [{ text: "First paragraph." }, "Second paragraph.", { snippet: "Third." }],
-				},
-			};
-			expect(extractTextFromBrightdata(rawOutput)).toBe("First paragraph.\nSecond paragraph.\nThird.");
+		it("falls back to other ai_overview text fields", () => {
+			expect(extractTextFromBrightdata({ ai_overview: { markdown: "Overview markdown." } })).toBe("Overview markdown.");
 		});
 
-		it("should still read chatbot dataset answers and report missing content", () => {
+		it("still reads chatbot dataset answers and reports missing content", () => {
 			expect(extractTextFromBrightdata({ answer_text_markdown: "Dataset answer." })).toBe("Dataset answer.");
 			expect(extractTextFromBrightdata({})).toBe("No text content found in BrightData output.");
 		});
 	});
 
 	describe("extractCitationsFromBrightdata", () => {
-		it("should extract AI Overview sources and de-dupe across fields", () => {
+		it("extracts AI Overview references by href, trims title noise, and de-dupes", () => {
 			const rawOutput = {
 				ai_overview: {
-					source_links: [
-						{ url: "https://www.whathifi.com/reviews/sonos-era-300", title: "What Hi-Fi" },
-						{ link: "https://www.rtings.com/speaker/reviews/sonos/era-300", name: "RTINGS" },
+					references: [
+						{
+							href: "https://www.whathifi.com/reviews/sonos-era-300",
+							title: "What Hi-Fi. Opens in new tab.",
+							index: 0,
+						},
+						{
+							href: "https://www.rtings.com/speaker/reviews/sonos/era-300",
+							title: "RTINGS. Opens in new tab.",
+							index: 1,
+						},
+						{ href: "https://www.whathifi.com/reviews/sonos-era-300", title: "dupe", index: 2 },
 					],
-					references: [{ url: "https://www.whathifi.com/reviews/sonos-era-300" }],
 				},
 			};
 			const citations = extractCitationsFromBrightdata(rawOutput);
 			expect(citations.map((c) => c.domain)).toEqual(["whathifi.com", "rtings.com"]);
-			expect(citations[1].title).toBe("RTINGS");
+			expect(citations[0].title).toBe("What Hi-Fi");
 		});
 
-		it("should still extract chatbot dataset citations", () => {
+		it("still extracts chatbot dataset citations", () => {
 			const rawOutput = { citations: [{ url: "https://example.com/a", title: "A" }] };
 			expect(extractCitationsFromBrightdata(rawOutput)).toHaveLength(1);
 		});

--- a/packages/lib/src/text-extraction.test.ts
+++ b/packages/lib/src/text-extraction.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
 	extractCitations,
+	extractCitationsFromBrightdata,
 	extractCitationsFromDataforseoLlm,
 	extractCitationsFromGoogle,
 	extractCitationsFromOpenAI,
 	extractCitationsFromOxylabs,
 	extractTextContent,
 	extractTextFromAnthropic,
+	extractTextFromBrightdata,
 	extractTextFromDataforseoLlm,
 	extractTextFromGoogle,
 	extractTextFromOpenAI,
@@ -453,9 +455,7 @@ describe("text-extraction", () => {
 				results: [
 					{
 						content: {
-							citations: [
-								{ url: "https://www.forbes.com/article", title: "Best Speakers" },
-							],
+							citations: [{ url: "https://www.forbes.com/article", title: "Best Speakers" }],
 						},
 					},
 				],
@@ -479,10 +479,7 @@ describe("text-extraction", () => {
 							citations: [
 								{
 									text: "The JBL Xtreme 5 is a newly released option.",
-									urls: [
-										"https://www.bgr.com/best-speakers",
-										"https://www.soundguys.com/jbl-xtreme-5",
-									],
+									urls: ["https://www.bgr.com/best-speakers", "https://www.soundguys.com/jbl-xtreme-5"],
 								},
 								{ text: "Other mentions.", urls: ["https://www.rtings.com/speaker"] },
 							],
@@ -492,11 +489,7 @@ describe("text-extraction", () => {
 			};
 
 			const citations = extractCitationsFromOxylabs(rawOutput);
-			expect(citations.map((c) => c.domain)).toEqual([
-				"bgr.com",
-				"soundguys.com",
-				"rtings.com",
-			]);
+			expect(citations.map((c) => c.domain)).toEqual(["bgr.com", "soundguys.com", "rtings.com"]);
 			expect(citations[0].citationIndex).toBe(0);
 			expect(citations[2].citationIndex).toBe(2);
 		});
@@ -507,9 +500,7 @@ describe("text-extraction", () => {
 					{
 						content: {
 							additional_results: {
-								sources_results: [
-									{ url: "https://www.rtings.com/best", title: "Best Bluetooth Speakers" },
-								],
+								sources_results: [{ url: "https://www.rtings.com/best", title: "Best Bluetooth Speakers" }],
 							},
 						},
 					},
@@ -536,10 +527,7 @@ describe("text-extraction", () => {
 			};
 
 			const citations = extractCitationsFromOxylabs(rawOutput);
-			expect(citations.map((c) => c.url)).toEqual([
-				"https://example.com/x",
-				"https://other.com/y",
-			]);
+			expect(citations.map((c) => c.url)).toEqual(["https://example.com/x", "https://other.com/y"]);
 		});
 
 		it("should skip invalid URLs and handle empty output gracefully", () => {
@@ -549,6 +537,54 @@ describe("text-extraction", () => {
 				results: [{ content: { citations: [{ urls: ["not-a-url", "https://valid.com"] }] } }],
 			};
 			expect(extractCitationsFromOxylabs(rawOutput).map((c) => c.domain)).toEqual(["valid.com"]);
+		});
+	});
+
+	describe("extractTextFromBrightdata", () => {
+		it("should read the SERP AI Overview from the ai_overview field", () => {
+			const rawOutput = {
+				ai_overview: {
+					markdown: "The Sonos Era 300 is a well-reviewed speaker with spatial audio support.",
+					source_links: [{ url: "https://www.whathifi.com/reviews/sonos-era-300", title: "Sonos Era 300" }],
+				},
+			};
+			expect(extractTextFromBrightdata(rawOutput)).toContain("Sonos Era 300");
+		});
+
+		it("should join an AI Overview split into text blocks", () => {
+			const rawOutput = {
+				ai_overview: {
+					items: [{ text: "First paragraph." }, "Second paragraph.", { snippet: "Third." }],
+				},
+			};
+			expect(extractTextFromBrightdata(rawOutput)).toBe("First paragraph.\nSecond paragraph.\nThird.");
+		});
+
+		it("should still read chatbot dataset answers and report missing content", () => {
+			expect(extractTextFromBrightdata({ answer_text_markdown: "Dataset answer." })).toBe("Dataset answer.");
+			expect(extractTextFromBrightdata({})).toBe("No text content found in BrightData output.");
+		});
+	});
+
+	describe("extractCitationsFromBrightdata", () => {
+		it("should extract AI Overview sources and de-dupe across fields", () => {
+			const rawOutput = {
+				ai_overview: {
+					source_links: [
+						{ url: "https://www.whathifi.com/reviews/sonos-era-300", title: "What Hi-Fi" },
+						{ link: "https://www.rtings.com/speaker/reviews/sonos/era-300", name: "RTINGS" },
+					],
+					references: [{ url: "https://www.whathifi.com/reviews/sonos-era-300" }],
+				},
+			};
+			const citations = extractCitationsFromBrightdata(rawOutput);
+			expect(citations.map((c) => c.domain)).toEqual(["whathifi.com", "rtings.com"]);
+			expect(citations[1].title).toBe("RTINGS");
+		});
+
+		it("should still extract chatbot dataset citations", () => {
+			const rawOutput = { citations: [{ url: "https://example.com/a", title: "A" }] };
+			expect(extractCitationsFromBrightdata(rawOutput)).toHaveLength(1);
 		});
 	});
 

--- a/packages/lib/src/text-extraction.ts
+++ b/packages/lib/src/text-extraction.ts
@@ -509,6 +509,18 @@ export function extractCitationsFromAnthropic(rawOutput: any): Citation[] {
 	}
 }
 
+// BrightData suffixes AI Overview reference titles with UI noise like
+// ". Opens in new tab." Cut it at a plain indexOf and trim the trailing
+// punctuation — no backtracking regex over the (uncontrolled) title.
+function stripAioTitleNoise(title: string): string {
+	const marker = title.toLowerCase().indexOf("opens in new tab");
+	if (marker === -1) return title.trim();
+	return title
+		.slice(0, marker)
+		.replace(/[.\s]+$/, "")
+		.trim();
+}
+
 export function extractCitationsFromBrightdata(rawOutput: any): Citation[] {
 	try {
 		const record = Array.isArray(rawOutput) ? rawOutput[0] : rawOutput;
@@ -534,10 +546,7 @@ export function extractCitationsFromBrightdata(rawOutput: any): Citation[] {
 				if (!Array.isArray(aio[field])) continue;
 				for (const item of aio[field]) {
 					const url = typeof item === "string" ? item : (item?.href ?? item?.url ?? item?.link);
-					const title =
-						typeof item?.title === "string"
-							? item.title.replace(/\.?\s*Opens in new tab\.?\s*$/i, "").trim()
-							: item?.name;
+					const title = typeof item?.title === "string" ? stripAioTitleNoise(item.title) : item?.name;
 					push(url, title);
 				}
 			}

--- a/packages/lib/src/text-extraction.ts
+++ b/packages/lib/src/text-extraction.ts
@@ -157,22 +157,41 @@ export function extractTextFromOlostep(rawOutput: any): string {
 	}
 }
 
+// BrightData's SERP `ai_overview.texts` is a tree: paragraph blocks carry a
+// `snippet`, list blocks nest their items under `list` (which can themselves
+// nest), so walk it depth-first and collect snippets in reading order.
+function collectAioSnippets(node: any, out: string[], depth = 0): void {
+	if (node == null || depth > 8) return;
+	if (Array.isArray(node)) {
+		for (const child of node) collectAioSnippets(child, out, depth + 1);
+		return;
+	}
+	if (typeof node === "string") {
+		if (node.trim()) out.push(node.trim());
+		return;
+	}
+	if (typeof node === "object") {
+		if (typeof node.snippet === "string" && node.snippet.trim()) out.push(node.snippet.trim());
+		else if (typeof node.text === "string" && node.text.trim()) out.push(node.text.trim());
+		for (const key of ["list", "texts", "items", "blocks", "paragraphs"]) {
+			if (Array.isArray(node[key])) collectAioSnippets(node[key], out, depth + 1);
+		}
+	}
+}
+
 // Google AI Overview arrives through BrightData's SERP API (brd_json), where the
-// overview sits under `ai_overview` rather than the chatbot answer fields. The
-// parsed shape isn't formally documented, so read defensively across the fields
-// BrightData's SERP output is known to use.
+// overview sits under `ai_overview` rather than the chatbot answer fields.
 function extractBrightdataAiOverviewText(record: any): string | null {
 	const aio = record?.ai_overview;
 	if (!aio || typeof aio !== "object") return null;
 	for (const key of ["markdown", "text", "aio_text", "content", "answer"]) {
 		if (typeof aio[key] === "string" && aio[key].trim()) return aio[key].trim();
 	}
-	for (const listKey of ["items", "text_blocks", "blocks", "paragraphs"]) {
+	for (const listKey of ["texts", "items", "text_blocks", "blocks", "paragraphs"]) {
 		if (!Array.isArray(aio[listKey])) continue;
-		const parts = aio[listKey]
-			.map((b: any) => (typeof b === "string" ? b : (b?.text ?? b?.snippet ?? b?.markdown)))
-			.filter((s: any): s is string => typeof s === "string" && s.trim().length > 0);
-		if (parts.length) return parts.join("\n").trim();
+		const snippets: string[] = [];
+		collectAioSnippets(aio[listKey], snippets);
+		if (snippets.length) return snippets.join("\n");
 	}
 	return null;
 }
@@ -506,13 +525,20 @@ export function extractCitationsFromBrightdata(rawOutput: any): Citation[] {
 				idx++;
 			}
 		};
-		// SERP API (Google AI Overview) exposes its sources under `ai_overview`.
+		// SERP API (Google AI Overview) lists its sources under `ai_overview`,
+		// where each reference carries the URL as `href` and a title suffixed with
+		// UI noise (". Opens in new tab.") that we trim off.
 		const aio = record.ai_overview;
 		if (aio && typeof aio === "object") {
-			for (const field of ["source_links", "references", "sources", "links"]) {
+			for (const field of ["references", "source_links", "sources", "links"]) {
 				if (!Array.isArray(aio[field])) continue;
 				for (const item of aio[field]) {
-					push(typeof item === "string" ? item : (item?.url ?? item?.link), item?.title ?? item?.name);
+					const url = typeof item === "string" ? item : (item?.href ?? item?.url ?? item?.link);
+					const title =
+						typeof item?.title === "string"
+							? item.title.replace(/\.?\s*Opens in new tab\.?\s*$/i, "").trim()
+							: item?.name;
+					push(url, title);
 				}
 			}
 		}

--- a/packages/lib/src/text-extraction.ts
+++ b/packages/lib/src/text-extraction.ts
@@ -157,10 +157,32 @@ export function extractTextFromOlostep(rawOutput: any): string {
 	}
 }
 
+// Google AI Overview arrives through BrightData's SERP API (brd_json), where the
+// overview sits under `ai_overview` rather than the chatbot answer fields. The
+// parsed shape isn't formally documented, so read defensively across the fields
+// BrightData's SERP output is known to use.
+function extractBrightdataAiOverviewText(record: any): string | null {
+	const aio = record?.ai_overview;
+	if (!aio || typeof aio !== "object") return null;
+	for (const key of ["markdown", "text", "aio_text", "content", "answer"]) {
+		if (typeof aio[key] === "string" && aio[key].trim()) return aio[key].trim();
+	}
+	for (const listKey of ["items", "text_blocks", "blocks", "paragraphs"]) {
+		if (!Array.isArray(aio[listKey])) continue;
+		const parts = aio[listKey]
+			.map((b: any) => (typeof b === "string" ? b : (b?.text ?? b?.snippet ?? b?.markdown)))
+			.filter((s: any): s is string => typeof s === "string" && s.trim().length > 0);
+		if (parts.length) return parts.join("\n").trim();
+	}
+	return null;
+}
+
 export function extractTextFromBrightdata(rawOutput: any): string {
 	try {
 		const record = Array.isArray(rawOutput) ? rawOutput[0] : rawOutput;
 		if (!record) return "No content in BrightData output.";
+		const aiOverview = extractBrightdataAiOverviewText(record);
+		if (aiOverview) return aiOverview;
 		for (const key of [
 			"answer_text_markdown",
 			"answer_text",
@@ -183,9 +205,9 @@ export function extractTextFromOxylabs(rawOutput: any): string {
 		const content = rawOutput?.results?.[0]?.content;
 		if (!content) return "No content in Oxylabs output.";
 		for (const key of [
-			"markdown_text",       // ChatGPT parsed
-			"answer_results_md",   // Perplexity parsed
-			"response_text",       // ChatGPT / Google AI Mode fallback
+			"markdown_text", // ChatGPT parsed
+			"answer_results_md", // Perplexity parsed
+			"response_text", // ChatGPT / Google AI Mode fallback
 			"answer_text",
 			"answer",
 		]) {
@@ -475,17 +497,30 @@ export function extractCitationsFromBrightdata(rawOutput: any): Citation[] {
 		const citations: Citation[] = [];
 		const seen = new Set<string>();
 		let idx = 0;
+		const push = (url: any, title: any) => {
+			if (typeof url !== "string" || !url.startsWith("http") || seen.has(url)) return;
+			seen.add(url);
+			const c = parseCitationUrl(url, typeof title === "string" ? title : undefined, idx);
+			if (c) {
+				citations.push(c);
+				idx++;
+			}
+		};
+		// SERP API (Google AI Overview) exposes its sources under `ai_overview`.
+		const aio = record.ai_overview;
+		if (aio && typeof aio === "object") {
+			for (const field of ["source_links", "references", "sources", "links"]) {
+				if (!Array.isArray(aio[field])) continue;
+				for (const item of aio[field]) {
+					push(typeof item === "string" ? item : (item?.url ?? item?.link), item?.title ?? item?.name);
+				}
+			}
+		}
+		// Chatbot dataset citation fields.
 		for (const field of ["citations", "links_attached", "sources"]) {
 			if (!Array.isArray(record[field])) continue;
 			for (const item of record[field]) {
-				const url = typeof item === "string" ? item : item?.url;
-				if (!url || typeof url !== "string" || !url.startsWith("http") || seen.has(url)) continue;
-				seen.add(url);
-				const c = parseCitationUrl(url, item?.title, idx);
-				if (c) {
-					citations.push(c);
-					idx++;
-				}
+				push(typeof item === "string" ? item : item?.url, item?.title);
 			}
 		}
 		return citations;
@@ -506,7 +541,10 @@ export function extractCitationsFromOxylabs(rawOutput: any): Citation[] {
 			if (typeof url !== "string" || !url.startsWith("http") || seen.has(url)) return;
 			seen.add(url);
 			const c = parseCitationUrl(url, typeof title === "string" ? title : undefined, idx);
-			if (c) { citations.push(c); idx++; }
+			if (c) {
+				citations.push(c);
+				idx++;
+			}
 		};
 
 		// Common citation fields across Oxylabs parsed AI sources.


### PR DESCRIPTION
Adds `google-ai-overview` as a runnable target for two more providers, so AI Overview isn't a single-source (Olostep-only) surface.

## What each provider does

- **DataForSEO** — new `runGoogleAiOverview` calls the Google **Organic Advanced** SERP endpoint with `load_async_ai_overview: true` (the flag that forces on-demand AI Overviews instead of cache-only). The response carries the overview as an `items[].type: "ai_overview"` element, which the existing `extractTextFromGoogle`/`extractCitationsFromGoogle` already parse — no extractor changes needed.
- **BrightData** — AI Overview is **not** a Web Scraper dataset; it's the AI summary block on a normal Google results page. So it goes through BrightData's **SERP API** (`client.search.google` → `google.com/search?brd_json=1`), which routes through a `serp` zone the SDK auto-provisions from the existing `BRIGHTDATA_API_TOKEN`. **No `gd_` dataset id and no new credential.** The parsed SERP's `ai_overview` field is read by the BrightData extractors, which now understand that shape.

## Surface

- `elmo init` offers `google-ai-overview` when you enable BrightData or DataForSEO.
- `SCRAPE_TARGETS` accepts `google-ai-overview:brightdata:online` and `google-ai-overview:dataforseo:online`.
- User-guide docs updated for both.

## Tests

- DataForSEO AIO path (organic endpoint + `load_async_ai_overview` + extraction) in `dataforseo.test.ts`.
- BrightData SERP `ai_overview` text + citation extraction in `text-extraction.test.ts`.
- `packages/lib` typechecks; worker + cli `check-types` pass; 48 lib tests green.

## ⚠️ One thing to validate

BrightData's `brd_json` AI Overview sub-shape isn't formally documented, so the extractor reads **defensively** across the likely fields (`ai_overview.markdown`/`text`/`items[]`, sources under `source_links`/`references`/`sources`/`links`). Worth a one-off `pnpm tsx apps/worker/scripts/test-provider.ts --target google-ai-overview:brightdata:online` against the live (billed) API to confirm the field names — I didn't run it since it hits your account. If the shape differs, it's a small tweak to the two extractor helpers.

Stacked below this: a follow-up PR adds these (plus grok/gemini/deepseek changes) to the `/status` matrix.