### PR TITLE
Run the worker in e2e and verify a submitted job is processed

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,11 +1,12 @@
 # End-to-End Integration Tests
 #
 # Verifies the open source local deployment works end-to-end.
-# Walks through the `elmo init --dev` CLI flow in CI mode, starts services
-# (web + worker) via Docker Compose with the worker pointed at the no-network
-# `stub` provider, seeds test data, and runs Playwright tests against the
-# Dockerized web app — including one that submits a job and asserts the worker
-# processes it.
+# Walks through the `elmo init --dev` CLI flow in CI mode, then runs in two
+# phases against the Dockerized stack: with the worker down, seed data and run
+# the fixture-dependent Playwright + Bruno suites; then start the worker (pointed
+# at the no-network `stub` provider) and run one spec that submits a job and
+# asserts the worker processes it. Starting the worker only after the fixture
+# suites finish keeps its self-healing scheduler from mutating seeded data.
 #
 # This workflow is the SINGLE SOURCE OF TRUTH for E2E test orchestration.
 # Run locally via: pnpm test:e2e  (uses https://github.com/nektos/act)
@@ -108,12 +109,10 @@ jobs:
       - name: Build images
         run: docker compose -f e2e/.elmo/elmo.yaml build
 
-      # Start web and the worker (both depend on db-migrate + postgres). The
-      # worker override points SCRAPE_TARGETS at the no-network `stub` provider
-      # and disables its recurring schedules, so it processes only the jobs the
-      # tests submit and makes no paid API calls.
-      - name: Start services
-        run: docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml up -d --no-build web worker
+      # Start web only (with its deps db-migrate + postgres). The worker stays
+      # down for now — it comes up in phase 2, after the fixture suites run.
+      - name: Start web
+        run: docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml up -d --no-build web
 
       - name: Wait for web
         run: |
@@ -129,28 +128,42 @@ jobs:
           docker compose -f e2e/.elmo/elmo.yaml logs
           exit 1
 
+      - name: Seed test data
+        run: cd e2e && npx tsx seed.ts
+
+      # Phase 1 — worker still down. Run everything that reads the seeded
+      # fixtures, so no background job can mutate them mid-suite.
+      - name: Run Playwright E2E tests
+        run: pnpm -C e2e exec playwright test --grep-invert @worker
+
+      - name: Run Bruno API tests
+        run: pnpm test:api
+
+      # Phase 2 — bring the worker up and prove it processes a submitted job.
+      - name: Start worker
+        run: docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml up -d --no-build worker
+
       - name: Wait for worker
         run: |
           echo "Waiting for the worker to register its handlers..."
           for i in $(seq 1 40); do
-            if docker compose -f e2e/.elmo/elmo.yaml logs worker 2>/dev/null | grep -q "worker is ready"; then
+            if docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml logs worker 2>/dev/null | grep -q "worker is ready"; then
               echo "Worker is ready."
               exit 0
             fi
             sleep 3
           done
           echo "ERROR: Worker did not become ready in time."
-          docker compose -f e2e/.elmo/elmo.yaml logs worker
+          docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml logs worker
           exit 1
 
-      - name: Seed test data
-        run: cd e2e && npx tsx seed.ts
-
-      - name: Run Playwright E2E tests
-        run: pnpm test:e2e
-
-      - name: Run Bruno API tests
-        run: pnpm test:api
+      - name: Run worker job-processing test
+        run: |
+          pnpm -C e2e exec playwright test --grep @worker --reporter=list || {
+            echo "=== worker logs ==="
+            docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml logs worker
+            exit 1
+          }
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -36,6 +36,12 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
 
+    env:
+      # One file set for every `docker compose` invocation below, so no step
+      # can silently run against a different effective config. The override
+      # scopes the worker to the no-network stub provider.
+      COMPOSE_FILE: e2e/.elmo/elmo.yaml:e2e/worker-override.yaml
+
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -110,12 +116,12 @@ jobs:
       # builds those once — building all three costs little more than building
       # web alone. postgres is an image pull, so `build` skips it.
       - name: Build images
-        run: docker compose -f e2e/.elmo/elmo.yaml build
+        run: docker compose build
 
       # Start web only (with its deps db-migrate + postgres). The worker stays
       # down for now — it comes up in phase 2, after the fixture suites run.
       - name: Start web
-        run: docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml up -d --no-build web
+        run: docker compose up -d --no-build web
 
       - name: Wait for web
         run: |
@@ -128,7 +134,7 @@ jobs:
             sleep 3
           done
           echo "ERROR: Web did not become ready in time."
-          docker compose -f e2e/.elmo/elmo.yaml logs
+          docker compose logs
           exit 1
 
       - name: Seed test data
@@ -146,7 +152,7 @@ jobs:
       # No readiness wait: the job the spec submits is durable in pg-boss, so
       # the spec's own DB poll absorbs worker startup.
       - name: Start worker
-        run: docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml up -d --no-build worker
+        run: docker compose up -d --no-build worker
 
       # `github` keeps PR annotations on failure; omitting `html` leaves phase
       # 1's playwright-report/ untouched for the upload below.
@@ -155,7 +161,7 @@ jobs:
 
       - name: Dump worker logs
         if: failure()
-        run: docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml logs worker
+        run: docker compose logs worker
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,8 +2,10 @@
 #
 # Verifies the open source local deployment works end-to-end.
 # Walks through the `elmo init --dev` CLI flow in CI mode, starts services
-# via Docker Compose (skipping worker to avoid execution costs),
-# seeds test data, and runs Playwright tests against the Dockerized web app.
+# (web + worker) via Docker Compose with the worker pointed at the no-network
+# `stub` provider, seeds test data, and runs Playwright tests against the
+# Dockerized web app — including one that submits a job and asserts the worker
+# processes it.
 #
 # This workflow is the SINGLE SOURCE OF TRUTH for E2E test orchestration.
 # Run locally via: pnpm test:e2e  (uses https://github.com/nektos/act)
@@ -100,19 +102,18 @@ jobs:
           grep -E '^\s{2}\w' e2e/.elmo/elmo.yaml || true
 
       # Build all images so a broken worker (or db-migrate) Dockerfile fails CI
-      # here, even though we don't run the worker. web/worker/migrate share the
-      # base/deps/builder stages, so BuildKit builds those once — building all
-      # three costs little more than building web alone. postgres is an image
-      # pull, so `build` skips it.
+      # here. web/worker/migrate share the base/deps/builder stages, so BuildKit
+      # builds those once — building all three costs little more than building
+      # web alone. postgres is an image pull, so `build` skips it.
       - name: Build images
         run: docker compose -f e2e/.elmo/elmo.yaml build
 
-      # Start only web and its deps (db-migrate, postgres). The worker is
-      # intentionally not started (we skip it to avoid execution costs); it was
-      # only ever started to be immediately stopped, which gave no runtime
-      # safety, so we just don't start it.
+      # Start web and the worker (both depend on db-migrate + postgres). The
+      # worker override points SCRAPE_TARGETS at the no-network `stub` provider
+      # and disables its recurring schedules, so it processes only the jobs the
+      # tests submit and makes no paid API calls.
       - name: Start services
-        run: docker compose -f e2e/.elmo/elmo.yaml up -d --no-build web
+        run: docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml up -d --no-build web worker
 
       - name: Wait for web
         run: |
@@ -126,6 +127,20 @@ jobs:
           done
           echo "ERROR: Web did not become ready in time."
           docker compose -f e2e/.elmo/elmo.yaml logs
+          exit 1
+
+      - name: Wait for worker
+        run: |
+          echo "Waiting for the worker to register its handlers..."
+          for i in $(seq 1 40); do
+            if docker compose -f e2e/.elmo/elmo.yaml logs worker 2>/dev/null | grep -q "worker is ready"; then
+              echo "Worker is ready."
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "ERROR: Worker did not become ready in time."
+          docker compose -f e2e/.elmo/elmo.yaml logs worker
           exit 1
 
       - name: Seed test data

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,13 +3,16 @@
 # Verifies the open source local deployment works end-to-end.
 # Walks through the `elmo init --dev` CLI flow in CI mode, then runs in two
 # phases against the Dockerized stack: with the worker down, seed data and run
-# the fixture-dependent Playwright + Bruno suites; then start the worker (pointed
-# at the no-network `stub` provider) and run one spec that submits a job and
-# asserts the worker processes it. Starting the worker only after the fixture
-# suites finish keeps its self-healing scheduler from mutating seeded data.
+# the fixture-dependent Playwright + Bruno suites; then start the worker
+# (pointed at the no-network `stub` provider) and run the `worker` Playwright
+# project, which submits a job and asserts the worker processes it. Starting
+# the worker only after the fixture suites finish keeps its self-healing
+# scheduler from mutating seeded data.
 #
 # This workflow is the SINGLE SOURCE OF TRUTH for E2E test orchestration.
-# Run locally via: pnpm test:e2e  (uses https://github.com/nektos/act)
+# Run locally via: pnpm test:e2e-local  (replays this workflow with
+# https://github.com/nektos/act); `pnpm test:e2e` runs just the fixture specs
+# against an already-running stack.
 
 name: E2E Tests
 
@@ -134,36 +137,25 @@ jobs:
       # Phase 1 — worker still down. Run everything that reads the seeded
       # fixtures, so no background job can mutate them mid-suite.
       - name: Run Playwright E2E tests
-        run: pnpm -C e2e exec playwright test --grep-invert @worker
+        run: pnpm -C e2e exec playwright test --project=fixtures
 
       - name: Run Bruno API tests
         run: pnpm test:api
 
       # Phase 2 — bring the worker up and prove it processes a submitted job.
+      # No readiness wait: the job the spec submits is durable in pg-boss, so
+      # the spec's own DB poll absorbs worker startup.
       - name: Start worker
         run: docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml up -d --no-build worker
 
-      - name: Wait for worker
-        run: |
-          echo "Waiting for the worker to register its handlers..."
-          for i in $(seq 1 40); do
-            if docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml logs worker 2>/dev/null | grep -q "worker is ready"; then
-              echo "Worker is ready."
-              exit 0
-            fi
-            sleep 3
-          done
-          echo "ERROR: Worker did not become ready in time."
-          docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml logs worker
-          exit 1
-
+      # `github` keeps PR annotations on failure; omitting `html` leaves phase
+      # 1's playwright-report/ untouched for the upload below.
       - name: Run worker job-processing test
-        run: |
-          pnpm -C e2e exec playwright test --grep @worker --reporter=list || {
-            echo "=== worker logs ==="
-            docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml logs worker
-            exit 1
-          }
+        run: pnpm -C e2e exec playwright test --project=worker --reporter=list,github
+
+      - name: Dump worker logs
+        if: failure()
+        run: docker compose -f e2e/.elmo/elmo.yaml -f e2e/worker-override.yaml logs worker
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
@@ -178,5 +170,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: test-results
-          path: e2e/test-results/
+          path: |
+            e2e/test-results/
+            e2e/test-results-worker/
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ storybook-static/
 # playwright
 playwright-report/
 test-results/
+test-results-worker/
 blob-report/
 
 # e2e generated config (created by `elmo init --dev --defaults`)

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -70,24 +70,22 @@ async function main() {
 	}
 	console.log("Queues created");
 
-	// With WORKER_DISABLE_SCHEDULES set, the worker still processes jobs but
-	// installs none of the recurring cron schedules. The e2e suite relies on
-	// this so the worker only runs jobs a test explicitly submits — the
-	// self-healing maintenance pass counts any prompt with no run for the
-	// configured model as immediately overdue, so it would otherwise re-enqueue
-	// the seeded prompts and mutate fixture data the other tests assert on.
-	const schedulesDisabled = /^(1|true)$/i.test(process.env.WORKER_DISABLE_SCHEDULES ?? "");
+	await boss.schedule(
+		"schedule-maintenance",
+		"*/5 * * * *",
+		{ source: "scheduled" },
+		{ tz: "UTC" },
+	);
+	console.log("Scheduled maintenance job (every 5 minutes)");
 
-	if (schedulesDisabled) {
-		console.log("Recurring schedules disabled (WORKER_DISABLE_SCHEDULES)");
-	} else {
-		await boss.schedule("schedule-maintenance", "*/5 * * * *", { source: "scheduled" }, { tz: "UTC" });
-		console.log("Scheduled maintenance job (every 5 minutes)");
-
-		if (process.env.DEPLOYMENT_MODE === "whitelabel") {
-			await boss.schedule("sync-auth0-memberships", "*/15 * * * *", { source: "scheduled" }, { tz: "UTC" });
-			console.log("Scheduled Auth0 membership sync (every 15 minutes)");
-		}
+	if (process.env.DEPLOYMENT_MODE === "whitelabel") {
+		await boss.schedule(
+			"sync-auth0-memberships",
+			"*/15 * * * *",
+			{ source: "scheduled" },
+			{ tz: "UTC" },
+		);
+		console.log("Scheduled Auth0 membership sync (every 15 minutes)");
 	}
 
 	// Register job handlers

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -70,22 +70,24 @@ async function main() {
 	}
 	console.log("Queues created");
 
-	await boss.schedule(
-		"schedule-maintenance",
-		"*/5 * * * *",
-		{ source: "scheduled" },
-		{ tz: "UTC" },
-	);
-	console.log("Scheduled maintenance job (every 5 minutes)");
+	// With WORKER_DISABLE_SCHEDULES set, the worker still processes jobs but
+	// installs none of the recurring cron schedules. The e2e suite relies on
+	// this so the worker only runs jobs a test explicitly submits — the
+	// self-healing maintenance pass counts any prompt with no run for the
+	// configured model as immediately overdue, so it would otherwise re-enqueue
+	// the seeded prompts and mutate fixture data the other tests assert on.
+	const schedulesDisabled = /^(1|true)$/i.test(process.env.WORKER_DISABLE_SCHEDULES ?? "");
 
-	if (process.env.DEPLOYMENT_MODE === "whitelabel") {
-		await boss.schedule(
-			"sync-auth0-memberships",
-			"*/15 * * * *",
-			{ source: "scheduled" },
-			{ tz: "UTC" },
-		);
-		console.log("Scheduled Auth0 membership sync (every 15 minutes)");
+	if (schedulesDisabled) {
+		console.log("Recurring schedules disabled (WORKER_DISABLE_SCHEDULES)");
+	} else {
+		await boss.schedule("schedule-maintenance", "*/5 * * * *", { source: "scheduled" }, { tz: "UTC" });
+		console.log("Scheduled maintenance job (every 5 minutes)");
+
+		if (process.env.DEPLOYMENT_MODE === "whitelabel") {
+			await boss.schedule("sync-auth0-memberships", "*/15 * * * *", { source: "scheduled" }, { tz: "UTC" });
+			console.log("Scheduled Auth0 membership sync (every 15 minutes)");
+		}
 	}
 
 	// Register job handlers

--- a/e2e/auth-setup.ts
+++ b/e2e/auth-setup.ts
@@ -7,10 +7,9 @@
  */
 import { chromium, type FullConfig } from "@playwright/test";
 import pg from "pg";
-import { TEST_USER, TEST_BRAND_ID, TEST_BRAND_NAME } from "./seed";
+import { DATABASE_URL, TEST_USER, TEST_BRAND_ID, TEST_BRAND_NAME } from "./fixtures";
 
 const AUTH_STATE_PATH = "e2e/.auth/user.json";
-const DATABASE_URL = "postgres://postgres:postgres@localhost:5432/elmo";
 
 export default async function globalSetup(config: FullConfig) {
 	const baseURL = config.projects[0]?.use?.baseURL || "http://localhost:1515";

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared E2E fixture constants — the single place the seeder, auth setup, and
+ * Playwright specs agree on IDs and credentials. Unlike seed.ts this module
+ * has no side effects, so specs can import from it freely.
+ */
+
+// Hardcoded to localhost so the destructive seeder can never point at a
+// production database.
+export const DATABASE_URL = "postgres://postgres:postgres@localhost:5432/elmo";
+
+// Must match ADMIN_API_KEYS in the CI-patched .env (.github/workflows/e2e.yaml)
+// and bruno/environments/local.bru.
+export const TEST_API_KEY = "test-api-key-e2e";
+
+export const TEST_USER = {
+  email: "e2e@test.local",
+  password: "e2e-test-password-123",
+  name: "E2E Test User",
+} as const;
+
+export const TEST_BRAND_ID = "default";
+export const TEST_BRAND_NAME = "Test Organization";
+export const TEST_BRAND_WEBSITE = "https://example.com";
+
+export const PROMPT_IDS = {
+  branded1: "00000000-0000-0000-0000-000000000001",
+  branded2: "00000000-0000-0000-0000-000000000002",
+  unbranded1: "00000000-0000-0000-0000-000000000003",
+  branded3: "00000000-0000-0000-0000-000000000004",
+  unbranded2: "00000000-0000-0000-0000-000000000005",
+} as const;
+
+export const COMPETITOR_IDS = {
+  competitorA: "00000000-0000-0000-0000-100000000001",
+  competitorB: "00000000-0000-0000-0000-100000000002",
+} as const;
+
+export const REPORT_IDS = {
+  completed: "00000000-0000-0000-0000-300000000001",
+  pending: "00000000-0000-0000-0000-300000000002",
+  processing: "00000000-0000-0000-0000-300000000003",
+  failed: "00000000-0000-0000-0000-300000000004",
+} as const;
+
+// Second tenant — a brand in an org the E2E user is NOT a member of.
+export const NIKE_ORG_ID = "nike";
+export const NIKE_BRAND_ID = "nike";
+export const NIKE_PROMPT_IDS = {
+  training: "00000000-0000-0000-0000-400000000001",
+  lifestyle: "00000000-0000-0000-0000-400000000002",
+} as const;
+export const NIKE_COMPETITOR_IDS = {
+  adidas: "00000000-0000-0000-0000-410000000001",
+  puma: "00000000-0000-0000-0000-410000000002",
+} as const;

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "test:e2e": "playwright test",
+    "test:e2e": "playwright test --project=fixtures",
     "test:api": "mkdir -p test-results && cd bruno && bru run -r --env local --reporter-junit ../test-results/api-junit.xml --reporter-json ../test-results/api-report.json",
     "seed": "tsx seed.ts"
   },

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -30,7 +30,22 @@ export default defineConfig({
 
   projects: [
     {
-      name: "chromium",
+      name: "fixtures",
+      testIgnore: /worker\.spec\.ts/,
+      use: { ...devices["Desktop Chrome"] },
+    },
+    // Run explicitly by CI phase 2 (--project=worker) once the worker
+    // container is up; `pnpm test:e2e` stays worker-free so a bare local run
+    // doesn't hang on (or feed a paid job to) whatever worker happens to be
+    // running. Separate outputDir because Playwright wipes the output dir of
+    // every project it runs — sharing test-results/ would delete phase 1's
+    // traces and the Bruno reports before CI uploads them. The timeout leaves
+    // room for the spec's 120s poll (worker startup + one pg-boss retry).
+    {
+      name: "worker",
+      testMatch: /worker\.spec\.ts/,
+      outputDir: "test-results-worker",
+      timeout: 150_000,
       use: { ...devices["Desktop Chrome"] },
     },
   ],

--- a/e2e/seed.ts
+++ b/e2e/seed.ts
@@ -3,61 +3,26 @@
  *
  * Seeds the LOCAL test database with realistic fixture data for E2E testing.
  *
- * SAFETY: Database URL is hardcoded to localhost to prevent
- * accidentally running this against a production database (it DELETEs all data).
+ * SAFETY: the database URL (see fixtures.ts) is hardcoded to localhost to
+ * prevent accidentally running this against a production database (it DELETEs
+ * all data).
  *
  * Usage: tsx seed.ts
  */
-import { realpathSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import pg from "pg";
-
-const DATABASE_URL = "postgres://postgres:postgres@localhost:5432/elmo";
-
-// ---------------------------------------------------------------------------
-// Fixed IDs for test fixtures (so tests can reference them directly)
-// ---------------------------------------------------------------------------
-export const TEST_USER = {
-  email: "e2e@test.local",
-  password: "e2e-test-password-123",
-  name: "E2E Test User",
-} as const;
-
-export const TEST_BRAND_ID = "default";
-export const TEST_BRAND_NAME = "Test Organization";
-export const TEST_BRAND_WEBSITE = "https://example.com";
-
-export const PROMPT_IDS = {
-  branded1: "00000000-0000-0000-0000-000000000001",
-  branded2: "00000000-0000-0000-0000-000000000002",
-  unbranded1: "00000000-0000-0000-0000-000000000003",
-  branded3: "00000000-0000-0000-0000-000000000004",
-  unbranded2: "00000000-0000-0000-0000-000000000005",
-} as const;
-
-export const COMPETITOR_IDS = {
-  competitorA: "00000000-0000-0000-0000-100000000001",
-  competitorB: "00000000-0000-0000-0000-100000000002",
-} as const;
-
-export const REPORT_IDS = {
-  completed: "00000000-0000-0000-0000-300000000001",
-  pending: "00000000-0000-0000-0000-300000000002",
-  processing: "00000000-0000-0000-0000-300000000003",
-  failed: "00000000-0000-0000-0000-300000000004",
-} as const;
-
-// Second tenant — a brand in an org the E2E user is NOT a member of.
-export const NIKE_ORG_ID = "nike";
-export const NIKE_BRAND_ID = "nike";
-export const NIKE_PROMPT_IDS = {
-  training: "00000000-0000-0000-0000-400000000001",
-  lifestyle: "00000000-0000-0000-0000-400000000002",
-} as const;
-export const NIKE_COMPETITOR_IDS = {
-  adidas: "00000000-0000-0000-0000-410000000001",
-  puma: "00000000-0000-0000-0000-410000000002",
-} as const;
+import {
+  COMPETITOR_IDS,
+  DATABASE_URL,
+  NIKE_BRAND_ID,
+  NIKE_COMPETITOR_IDS,
+  NIKE_ORG_ID,
+  NIKE_PROMPT_IDS,
+  PROMPT_IDS,
+  REPORT_IDS,
+  TEST_BRAND_ID,
+  TEST_BRAND_NAME,
+  TEST_BRAND_WEBSITE,
+} from "./fixtures";
 
 // Prompt run IDs (for prompt detail page testing)
 const RUN_IDS = [
@@ -504,26 +469,7 @@ async function seed() {
   }
 }
 
-/**
- * True only when this file is the process entry (`tsx seed.ts`), not when it is
- * imported for its exported fixture constants. Guarding the seed() call on this
- * keeps `import { TEST_* } from "./seed"` side-effect free: otherwise globalSetup
- * and any spec that reads a constant would re-run this destructive seed
- * (DELETE + re-insert) on import and wipe rows out from under running tests.
- */
-function isMainModule(): boolean {
-  const entry = process.argv[1];
-  if (!entry) return false;
-  try {
-    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
-  } catch {
-    return false;
-  }
-}
-
-if (isMainModule()) {
-  seed().catch((err) => {
-    console.error("Seeding failed:", err);
-    process.exit(1);
-  });
-}
+seed().catch((err) => {
+  console.error("Seeding failed:", err);
+  process.exit(1);
+});

--- a/e2e/seed.ts
+++ b/e2e/seed.ts
@@ -8,6 +8,8 @@
  *
  * Usage: tsx seed.ts
  */
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import pg from "pg";
 
 const DATABASE_URL = "postgres://postgres:postgres@localhost:5432/elmo";
@@ -502,7 +504,26 @@ async function seed() {
   }
 }
 
-seed().catch((err) => {
-  console.error("Seeding failed:", err);
-  process.exit(1);
-});
+/**
+ * True only when this file is the process entry (`tsx seed.ts`), not when it is
+ * imported for its exported fixture constants. Guarding the seed() call on this
+ * keeps `import { TEST_* } from "./seed"` side-effect free: otherwise globalSetup
+ * and any spec that reads a constant would re-run this destructive seed
+ * (DELETE + re-insert) on import and wipe rows out from under running tests.
+ */
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
+  seed().catch((err) => {
+    console.error("Seeding failed:", err);
+    process.exit(1);
+  });
+}

--- a/e2e/tests/worker.spec.ts
+++ b/e2e/tests/worker.spec.ts
@@ -7,53 +7,52 @@
  * run. We assert on the `prompt_runs` side effect rather than the job's own
  * state so the test only passes if the handler actually did its work.
  *
- * This spec is tagged @worker and runs in its own phase, after the worker is
- * started. The fixture-dependent specs run earlier while the worker is still
- * down, so the worker's self-healing scheduler can't re-enqueue the seeded
- * prompts and mutate data they assert on (see .github/workflows/e2e.yaml).
+ * This spec is the `worker` Playwright project and runs in its own phase,
+ * after the worker is started. The fixture-dependent specs (the `fixtures`
+ * project) run earlier while the worker is still down, so the worker's
+ * self-healing scheduler can't re-enqueue the seeded prompts and mutate data
+ * they assert on (see .github/workflows/e2e.yaml).
  */
 import { test, expect } from "@playwright/test";
 import pg from "pg";
+import { DATABASE_URL, TEST_API_KEY, TEST_BRAND_ID } from "../fixtures";
 
-const API_KEY = "test-api-key-e2e";
-const BRAND_ID = "default";
-const DATABASE_URL = "postgres://postgres:postgres@localhost:5432/elmo";
-
-// The stub provider records its runs under this model version.
-const STUB_MODEL_VERSION = "stub";
-
-test.describe("Worker job processing", { tag: "@worker" }, () => {
+test.describe("Worker job processing", () => {
   test("a submitted prompt is dequeued and processed by the worker", async ({ request }) => {
     // Submit: creating a prompt enqueues an immediate process-prompt job.
     const value = "worker e2e — does a submitted job get processed?";
     const createRes = await request.post("/api/v1/prompts", {
-      headers: { Authorization: `Bearer ${API_KEY}` },
-      data: { brandId: BRAND_ID, value },
+      headers: { Authorization: `Bearer ${TEST_API_KEY}` },
+      data: { brandId: TEST_BRAND_ID, value },
     });
     expect(createRes.status(), await createRes.text()).toBe(201);
     const prompt = (await createRes.json()) as { id: string };
     expect(prompt.id).toBeTruthy();
 
-    // Assert: poll until the worker records at least one run for this prompt.
+    // Assert: poll until the worker records a run for this prompt. The stub
+    // provider is the worker's only configured target, so the run must carry
+    // its version — proof the job ran, not a stray write. The job is durable
+    // in pg-boss, so the poll budget absorbs worker startup (there is no
+    // separate readiness wait in CI) and covers one retry cycle of the
+    // process-prompt queue (retryDelay 60s).
     const client = new pg.Client({ connectionString: DATABASE_URL });
     await client.connect();
     try {
-      const deadline = Date.now() + 45_000;
-      let run: { model: string; version: string } | undefined;
-      while (Date.now() < deadline) {
-        const { rows } = await client.query<{ model: string; version: string }>(
-          `SELECT model, version FROM prompt_runs WHERE prompt_id = $1 LIMIT 1`,
-          [prompt.id],
-        );
-        run = rows[0];
-        if (run) break;
-        await new Promise((resolve) => setTimeout(resolve, 1_000));
-      }
-
-      expect(run, `worker did not record a prompt_run for ${prompt.id} within 45s`).toBeTruthy();
-      // The stub provider is the only configured target for the worker, so the
-      // recorded run must be its output — proof the job ran, not a stray write.
-      expect(run?.version).toBe(STUB_MODEL_VERSION);
+      await expect
+        .poll(
+          async () => {
+            const { rows } = await client.query<{ version: string }>(
+              `SELECT version FROM prompt_runs WHERE prompt_id = $1 LIMIT 1`,
+              [prompt.id],
+            );
+            return rows[0]?.version;
+          },
+          {
+            message: `worker did not record a prompt_run for ${prompt.id}`,
+            timeout: 120_000,
+          },
+        )
+        .toBe("stub");
     } finally {
       await client.end();
     }

--- a/e2e/tests/worker.spec.ts
+++ b/e2e/tests/worker.spec.ts
@@ -7,9 +7,10 @@
  * run. We assert on the `prompt_runs` side effect rather than the job's own
  * state so the test only passes if the handler actually did its work.
  *
- * The worker is started with WORKER_DISABLE_SCHEDULES=1 (see
- * e2e/worker-override.yaml), so nothing but this submitted job runs — the
- * seeded fixtures the other specs depend on are left untouched.
+ * This spec is tagged @worker and runs in its own phase, after the worker is
+ * started. The fixture-dependent specs run earlier while the worker is still
+ * down, so the worker's self-healing scheduler can't re-enqueue the seeded
+ * prompts and mutate data they assert on (see .github/workflows/e2e.yaml).
  */
 import { test, expect } from "@playwright/test";
 import pg from "pg";
@@ -21,7 +22,7 @@ const DATABASE_URL = "postgres://postgres:postgres@localhost:5432/elmo";
 // The stub provider records its runs under this model version.
 const STUB_MODEL_VERSION = "stub";
 
-test.describe("Worker job processing", () => {
+test.describe("Worker job processing", { tag: "@worker" }, () => {
   test("a submitted prompt is dequeued and processed by the worker", async ({ request }) => {
     // Submit: creating a prompt enqueues an immediate process-prompt job.
     const value = "worker e2e — does a submitted job get processed?";

--- a/e2e/tests/worker.spec.ts
+++ b/e2e/tests/worker.spec.ts
@@ -14,9 +14,9 @@
  */
 import { test, expect } from "@playwright/test";
 import pg from "pg";
-import { TEST_BRAND_ID } from "../seed";
 
 const API_KEY = "test-api-key-e2e";
+const BRAND_ID = "default";
 const DATABASE_URL = "postgres://postgres:postgres@localhost:5432/elmo";
 
 // The stub provider records its runs under this model version.
@@ -28,7 +28,7 @@ test.describe("Worker job processing", { tag: "@worker" }, () => {
     const value = "worker e2e — does a submitted job get processed?";
     const createRes = await request.post("/api/v1/prompts", {
       headers: { Authorization: `Bearer ${API_KEY}` },
-      data: { brandId: TEST_BRAND_ID, value },
+      data: { brandId: BRAND_ID, value },
     });
     expect(createRes.status(), await createRes.text()).toBe(201);
     const prompt = (await createRes.json()) as { id: string };

--- a/e2e/tests/worker.spec.ts
+++ b/e2e/tests/worker.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Worker Job Processing E2E Test
+ *
+ * Proves the background worker is wired up end to end: submitting a prompt
+ * through the public API enqueues a `process-prompt` pg-boss job, and the
+ * worker (running the no-network `stub` provider) dequeues it and records the
+ * run. We assert on the `prompt_runs` side effect rather than the job's own
+ * state so the test only passes if the handler actually did its work.
+ *
+ * The worker is started with WORKER_DISABLE_SCHEDULES=1 (see
+ * e2e/worker-override.yaml), so nothing but this submitted job runs — the
+ * seeded fixtures the other specs depend on are left untouched.
+ */
+import { test, expect } from "@playwright/test";
+import pg from "pg";
+import { TEST_BRAND_ID } from "../seed";
+
+const API_KEY = "test-api-key-e2e";
+const DATABASE_URL = "postgres://postgres:postgres@localhost:5432/elmo";
+
+// The stub provider records its runs under this model version.
+const STUB_MODEL_VERSION = "stub";
+
+test.describe("Worker job processing", () => {
+  test("a submitted prompt is dequeued and processed by the worker", async ({ request }) => {
+    // Submit: creating a prompt enqueues an immediate process-prompt job.
+    const value = "worker e2e — does a submitted job get processed?";
+    const createRes = await request.post("/api/v1/prompts", {
+      headers: { Authorization: `Bearer ${API_KEY}` },
+      data: { brandId: TEST_BRAND_ID, value },
+    });
+    expect(createRes.status(), await createRes.text()).toBe(201);
+    const prompt = (await createRes.json()) as { id: string };
+    expect(prompt.id).toBeTruthy();
+
+    // Assert: poll until the worker records at least one run for this prompt.
+    const client = new pg.Client({ connectionString: DATABASE_URL });
+    await client.connect();
+    try {
+      const deadline = Date.now() + 45_000;
+      let run: { model: string; version: string } | undefined;
+      while (Date.now() < deadline) {
+        const { rows } = await client.query<{ model: string; version: string }>(
+          `SELECT model, version FROM prompt_runs WHERE prompt_id = $1 LIMIT 1`,
+          [prompt.id],
+        );
+        run = rows[0];
+        if (run) break;
+        await new Promise((resolve) => setTimeout(resolve, 1_000));
+      }
+
+      expect(run, `worker did not record a prompt_run for ${prompt.id} within 45s`).toBeTruthy();
+      // The stub provider is the only configured target for the worker, so the
+      // recorded run must be its output — proof the job ran, not a stray write.
+      expect(run?.version).toBe(STUB_MODEL_VERSION);
+    } finally {
+      await client.end();
+    }
+  });
+});

--- a/e2e/worker-override.yaml
+++ b/e2e/worker-override.yaml
@@ -1,0 +1,16 @@
+# Compose override layered on top of the generated .elmo/elmo.yaml so the E2E
+# worker can process jobs without any paid API calls.
+#
+#   - SCRAPE_TARGETS=stub:stub  → process-prompt runs the no-network `stub`
+#     provider instead of the real (placeholder-keyed) targets in .env, so a
+#     submitted job records a prompt_run without reaching out to any LLM API.
+#   - WORKER_DISABLE_SCHEDULES=1 → the worker installs no recurring cron
+#     schedules, so it only runs jobs a test submits and never re-enqueues the
+#     seeded prompts.
+#
+# Worker-only: the web service keeps the real SCRAPE_TARGETS from .env.
+services:
+  worker:
+    environment:
+      SCRAPE_TARGETS: stub:stub
+      WORKER_DISABLE_SCHEDULES: "1"

--- a/e2e/worker-override.yaml
+++ b/e2e/worker-override.yaml
@@ -1,16 +1,9 @@
 # Compose override layered on top of the generated .elmo/elmo.yaml so the E2E
-# worker can process jobs without any paid API calls.
-#
-#   - SCRAPE_TARGETS=stub:stub  → process-prompt runs the no-network `stub`
-#     provider instead of the real (placeholder-keyed) targets in .env, so a
-#     submitted job records a prompt_run without reaching out to any LLM API.
-#   - WORKER_DISABLE_SCHEDULES=1 → the worker installs no recurring cron
-#     schedules, so it only runs jobs a test submits and never re-enqueues the
-#     seeded prompts.
-#
-# Worker-only: the web service keeps the real SCRAPE_TARGETS from .env.
+# worker processes jobs without any paid API calls: SCRAPE_TARGETS points at the
+# no-network `stub` provider, so a submitted job records a prompt_run without
+# reaching out to any LLM API. Worker-only — the web service keeps the real
+# SCRAPE_TARGETS from .env.
 services:
   worker:
     environment:
       SCRAPE_TARGETS: stub:stub
-      WORKER_DISABLE_SCHEDULES: "1"


### PR DESCRIPTION
## What

The e2e suite previously started only `web` and deliberately skipped the worker. Now that we have a no-network `stub` provider, this runs the worker in e2e and adds a spec that proves a submitted job is actually processed end-to-end.

## How it works

The run is split into two phases so the worker's self-healing scheduler can't mutate the seeded fixtures the other tests assert on. The phase boundary lives in the Playwright config as two projects (`fixtures` / `worker`), so every entrypoint inherits it — not just the CI YAML.

**Phase 1 — worker down.** Seed, then run every fixture-dependent suite: the `fixtures` Playwright project and the Bruno API suite. With no worker running, nothing can re-enqueue or reprocess the seeded prompts. `pnpm test:e2e` runs only this project, so a bare local run never depends on worker topology (and can't feed a paid job to a real worker).

**Phase 2 — worker up.** Start the worker and run `--project=worker`. Its one spec `POST`s to `/api/v1/prompts` (which enqueues an immediate `process-prompt` job) and `expect.poll`s Postgres until a `prompt_runs` row with the stub's version appears for the new prompt. There is no separate readiness wait: the job is durable in pg-boss, so the 120s poll budget absorbs worker startup and covers one 60s retry cycle of the queue. Asserting the DB side-effect — not just job state — means it only passes if the handler actually did its work.

The `worker` project writes to its own `outputDir` and drops the `html` reporter (keeping `github` for PR annotations), so the second Playwright invocation can't wipe phase 1's traces, report, or the Bruno JUnit/JSON reports before the artifact uploads.

The worker runs **exactly as it does in production**; only its `SCRAPE_TARGETS` is overridden to `stub:stub` via `e2e/worker-override.yaml`. The override is worker-only because the web app derives its model filter/settings UI from `SCRAPE_TARGETS`, so web keeps the real value from `.env`. The compose file set is pinned once via a job-level `COMPOSE_FILE` so every step runs against the same effective config.

Shared fixture constants (DB URL, brand/prompt IDs, the test API key) live in a side-effect-free `e2e/fixtures.ts`; specs and auth-setup import from it, and `seed.ts` stays a pure script.

## Why phased, not a flag

An earlier revision added a `WORKER_DISABLE_SCHEDULES` env branch to the production worker so its `schedule-maintenance` cron wouldn't reprocess seeded prompts (that maintenance pass counts any prompt with no run for the configured model as immediately overdue, so it would re-enqueue the run-less fixtures the moment it fired). Gating production code purely for tests is an anti-pattern — this instead orders the run so the fixture suites finish before the worker exists. No production code changes.

## Verification

- `tsc --noEmit` green on `e2e/`; workflow YAML parses.
- `playwright test --list` confirms the split: 21 tests in 5 files under `fixtures`, exactly the 1 worker spec under `worker`.
- Confirmed the fixture suites (loose Playwright content checks; Bruno's `total gte 5`, `totalPages gt 1`, `prompts[0].brandId`) are unaffected, and they run before the worker starts regardless.
- Full suite runs in CI (or locally via `pnpm test:e2e-local` / act) — not run locally since it needs the Docker + `elmo init --dev` flow.

No changeset: internal test/CI plumbing, not user-facing.
