### PR TITLE
Include DataForSEO status code in AI Overview errors

### DIFF
--- a/packages/lib/src/providers/registry/dataforseo.test.ts
+++ b/packages/lib/src/providers/registry/dataforseo.test.ts
@@ -173,7 +173,7 @@ describe("dataforseo provider", () => {
 		const promise = dataforseo.run("google-ai-overview", "What is a well-reviewed speaker released last month?", {
 			webSearch: true,
 		});
-		const assertion = expect(promise).rejects.toThrow("DataForSEO API Error: Internal SE Server Error.");
+		const assertion = expect(promise).rejects.toThrow("DataForSEO API Error: 40602 Internal SE Server Error.");
 		await vi.runAllTimersAsync();
 		await assertion;
 

--- a/packages/lib/src/providers/registry/dataforseo.ts
+++ b/packages/lib/src/providers/registry/dataforseo.ts
@@ -154,7 +154,7 @@ async function runGoogleAiOverview(prompt: string): Promise<ScrapeResult> {
 					modelVersion: "dataforseo",
 				};
 			}
-			lastError = task?.status_message ?? "No response or tasks.";
+			lastError = task ? `${task.status_code} ${task.status_message}` : "No response or tasks.";
 		} catch (error) {
 			lastError = error instanceof Error ? error.message : String(error);
 		}


### PR DESCRIPTION
## Why

The `/status` page shows 0% for Google AI Overview on DataForSEO. Diagnosis so far: in a single CI run, every DataForSEO surface passes (AI Mode + ChatGPT/Perplexity/Gemini LLM Responses) **except** Google AI Overview — the only one using `googleOrganicLiveAdvanced` + `load_async_ai_overview` — which fails 100% with `Internal SE Server Error`. The same request succeeds 10/10 against a different (demo) DataForSEO account. That points at an account-level difference on DataForSEO's side (async-AI-Overview feature enablement, balance, or a cost cap on the extra async charge), not a code bug.

The blocker to confirming this is that the failure path threw only DataForSEO's `status_message` ("Internal SE Server Error."), swallowing the numeric `status_code`. The code distinguishes a billing/limit rejection from a genuinely transient server error.

## Change

Prefix the DataForSEO `status_code` to the AI Overview error, matching what the LLM Responses path already does. The next failing scheduled run then logs e.g. `DataForSEO API Error: 40202 ...` instead of an opaque message — self-diagnosing the real cause.

Follows #472 (the retry). Internal error-detail only — no changeset.
