### PR TITLE
Allow competitor URL pastes

### DIFF
--- a/.changeset/paste-competitor-urls.md
+++ b/.changeset/paste-competitor-urls.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Competitor domains can now be added by pasting a full URL.

--- a/apps/web/src/components/competitors-editor.tsx
+++ b/apps/web/src/components/competitors-editor.tsx
@@ -138,8 +138,10 @@ export function CompetitorsEditor({ competitors, onChange, disabled }: Competito
 									value={competitor.domains.filter(Boolean)}
 									onValueChange={(values) => update(competitor._key, { domains: values })}
 									placeholder="Add domain..."
+									searchPlaceholder="Paste a URL or add a domain..."
 									maxItems={10}
 									normalizeValue={(raw) => cleanAndValidateDomain(raw) ?? raw.trim()}
+									pasteSplitter={/[\n,\t]+/}
 									onValidate={validateDomain}
 								/>
 							</div>

--- a/apps/web/src/stories/tags-input.stories.tsx
+++ b/apps/web/src/stories/tags-input.stories.tsx
@@ -1,7 +1,9 @@
-import type { Meta } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 import { useState, useMemo } from "react";
+import { expect, userEvent, within } from "storybook/test";
 import { Label } from "@workspace/ui/components/label";
 import { TagsInput } from "@workspace/ui/components/tags-input";
+import { cleanAndValidateDomain } from "@/lib/domain-categories";
 
 export default {
   title: "Components/TagsInput",
@@ -59,6 +61,43 @@ export const WithValidation = () => {
       </div>
     </div>
   );
+};
+
+/** A full URL is normalized to its domain when pasted into a domain field. */
+export const UrlPaste: StoryObj = {
+  render: () => {
+    const [values, setValues] = useState<string[]>([]);
+
+    return (
+      <div className="p-8 max-w-xl space-y-6">
+        <div className="space-y-2">
+          <Label>Domains</Label>
+          <TagsInput
+            value={values}
+            onValueChange={setValues}
+            placeholder="Add domain..."
+            searchPlaceholder="Paste a URL or add a domain..."
+            normalizeValue={(raw) => cleanAndValidateDomain(raw) ?? raw.trim()}
+            pasteSplitter={/[\n,\t]+/}
+            onValidate={(value) =>
+              cleanAndValidateDomain(value) ? true : `"${value}" is not a valid domain`
+            }
+          />
+        </div>
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const documentBody = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(canvas.getByRole("combobox"));
+    const input = await documentBody.findByPlaceholderText("Paste a URL or add a domain...");
+    await userEvent.type(input, "https://www.example.com/pricing?utm_source=ad");
+    await userEvent.keyboard("{Enter}");
+
+    await expect(canvas.findByText("example.com")).resolves.toBeVisible();
+  },
 };
 
 /**

--- a/packages/ui/src/components/tags-input.tsx
+++ b/packages/ui/src/components/tags-input.tsx
@@ -28,6 +28,8 @@ export interface TagsInputProps {
   emptyText?: string;
   allowCustomValues?: boolean;
   normalizeValue?: (raw: string) => string;
+  /** Splits clipboard text into values. Providing this also handles single-value pastes. */
+  pasteSplitter?: RegExp;
   /** Return `true` to accept the value, or an error string to reject it and show inline. */
   onValidate?: (value: string) => true | string;
   maxItems?: number;
@@ -47,6 +49,7 @@ export function TagsInput({
   emptyText = "No results.",
   allowCustomValues = true,
   normalizeValue,
+  pasteSplitter,
   onValidate,
   maxItems,
   minItems = 0,
@@ -217,9 +220,9 @@ export function TagsInput({
               onPaste={(e) => {
                 if (disabled || atMax) return;
                 const text = e.clipboardData.getData("text");
-                if (!PASTE_SPLITTER.test(text)) return;
+                if (!pasteSplitter && !PASTE_SPLITTER.test(text)) return;
                 e.preventDefault();
-                addMany(text.split(PASTE_SPLITTER));
+                addMany(text.split(pasteSplitter ?? PASTE_SPLITTER));
                 setQuery("");
               }}
             />


### PR DESCRIPTION
Accept full competitor URLs, normalize them to domains, and support comma- or newline-separated URL lists.