### PR TITLE
Show last evaluation on Opportunities

### DIFF
--- a/.changeset/show-opportunities-evaluation-date.md
+++ b/.changeset/show-opportunities-evaluation-date.md
@@ -2,4 +2,4 @@
 "@workspace/web": patch
 ---
 
-Show when an Opportunities report was last evaluated.
+Show when an opportunities report was last evaluated.

--- a/.changeset/show-opportunities-evaluation-date.md
+++ b/.changeset/show-opportunities-evaluation-date.md
@@ -2,4 +2,4 @@
 "@workspace/web": patch
 ---
 
-Show when the tracked prompts for an Opportunities report were last evaluated.
+Show when an Opportunities report was last evaluated.

--- a/.changeset/show-opportunities-evaluation-date.md
+++ b/.changeset/show-opportunities-evaluation-date.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Show when the tracked prompts for an Opportunities report were last evaluated.

--- a/apps/web/src/routes/_authed/app/$brand/opportunities.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/opportunities.tsx
@@ -9,7 +9,7 @@
  * server-side and regenerated only when stale — see server/opportunities.ts.
  */
 
-import { IconLoader2 } from "@tabler/icons-react";
+import { IconClock, IconLoader2 } from "@tabler/icons-react";
 import { createFileRoute } from "@tanstack/react-router";
 import { Skeleton } from "@workspace/ui/components/skeleton";
 import { OpportunitiesReport } from "@/components/opportunities-report";
@@ -59,8 +59,23 @@ function OpportunitiesPage() {
 			subtitle="What to create, pitch, and seed to earn more AI citations — generated from your tracked answer data."
 			infoContent={infoContent}
 		>
-			<div className="space-y-6">{content}</div>
+			<div className="space-y-6">
+				{data?.report && data.lastEvaluatedAt && <LastEvaluatedAt date={data.lastEvaluatedAt} />}
+				{content}
+			</div>
 		</PageHeader>
+	);
+}
+
+function LastEvaluatedAt({ date }: { date: string }) {
+	return (
+		<p className="flex items-center gap-1.5 text-sm text-muted-foreground">
+			<IconClock className="size-4" aria-hidden />
+			Last evaluated{" "}
+			<time dateTime={date}>
+				{new Date(date).toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" })}
+			</time>
+		</p>
 	);
 }
 

--- a/apps/web/src/server/opportunities.ts
+++ b/apps/web/src/server/opportunities.ts
@@ -18,9 +18,9 @@
  */
 import { createServerFn } from "@tanstack/react-start";
 import { db } from "@workspace/lib/db/db";
-import { brandOpportunities, brands, competitors, prompts, promptRuns } from "@workspace/lib/db/schema";
+import { brandOpportunities, brands, competitors } from "@workspace/lib/db/schema";
 import { runStructuredCompletionPrompt } from "@workspace/lib/onboarding";
-import { and, desc, eq, sql } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
 import { extractDomain } from "@/lib/domain-categories";
@@ -478,24 +478,13 @@ export const getOpportunitiesFn = createServerFn({ method: "GET" })
 
 		// Serve the most recent stored report while it's fresh. Every generation is
 		// kept (append-only); we regenerate only when the latest is stale.
-		const [[latest], [evaluation]] = await Promise.all([
-			db
-				.select()
-				.from(brandOpportunities)
-				.where(eq(brandOpportunities.brandId, data.brandId))
-				.orderBy(desc(brandOpportunities.createdAt))
-				.limit(1),
-			db
-				.select({
-					lastEvaluatedAt: sql<string | null>`
-						to_char(max(${promptRuns.createdAt}) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS') || '.000Z'
-					`,
-				})
-				.from(promptRuns)
-				.innerJoin(prompts, eq(promptRuns.promptId, prompts.id))
-				.where(and(eq(promptRuns.brandId, data.brandId), eq(prompts.enabled, true))),
-		]);
-		const lastEvaluatedAt = evaluation?.lastEvaluatedAt ?? null;
+		const [latest] = await db
+			.select()
+			.from(brandOpportunities)
+			.where(eq(brandOpportunities.brandId, data.brandId))
+			.orderBy(desc(brandOpportunities.createdAt))
+			.limit(1);
+		const lastEvaluatedAt = latest?.createdAt.toISOString() ?? null;
 		const isFresh = latest && Date.now() - new Date(latest.createdAt).getTime() < REFRESH_AFTER_DAYS * 86_400_000;
 		if (latest && isFresh) {
 			return { report: latest.report as OpportunitiesReport, reason: null, generatedFor: null, lastEvaluatedAt };
@@ -518,7 +507,15 @@ export const getOpportunitiesFn = createServerFn({ method: "GET" })
 		}
 
 		const report = enrichReport(generated.report, digest);
-		await db.insert(brandOpportunities).values({ brandId: data.brandId, report, model: generated.model });
+		const [savedReport] = await db
+			.insert(brandOpportunities)
+			.values({ brandId: data.brandId, report, model: generated.model })
+			.returning({ createdAt: brandOpportunities.createdAt });
 
-		return { report, reason: null, generatedFor: { brandName: digest.brandName }, lastEvaluatedAt };
+		return {
+			report,
+			reason: null,
+			generatedFor: { brandName: digest.brandName },
+			lastEvaluatedAt: savedReport?.createdAt.toISOString() ?? null,
+		};
 	});

--- a/apps/web/src/server/opportunities.ts
+++ b/apps/web/src/server/opportunities.ts
@@ -18,9 +18,9 @@
  */
 import { createServerFn } from "@tanstack/react-start";
 import { db } from "@workspace/lib/db/db";
-import { brandOpportunities, brands, competitors } from "@workspace/lib/db/schema";
+import { brandOpportunities, brands, competitors, prompts, promptRuns } from "@workspace/lib/db/schema";
 import { runStructuredCompletionPrompt } from "@workspace/lib/onboarding";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
 import { extractDomain } from "@/lib/domain-categories";
@@ -109,6 +109,7 @@ export interface OpportunitiesResponse {
 	report: OpportunitiesReport | null;
 	reason: OpportunitiesReason;
 	generatedFor: { brandName: string } | null;
+	lastEvaluatedAt: string | null;
 }
 
 // ============================================================================
@@ -477,33 +478,47 @@ export const getOpportunitiesFn = createServerFn({ method: "GET" })
 
 		// Serve the most recent stored report while it's fresh. Every generation is
 		// kept (append-only); we regenerate only when the latest is stale.
-		const [latest] = await db
-			.select()
-			.from(brandOpportunities)
-			.where(eq(brandOpportunities.brandId, data.brandId))
-			.orderBy(desc(brandOpportunities.createdAt))
-			.limit(1);
+		const [[latest], [evaluation]] = await Promise.all([
+			db
+				.select()
+				.from(brandOpportunities)
+				.where(eq(brandOpportunities.brandId, data.brandId))
+				.orderBy(desc(brandOpportunities.createdAt))
+				.limit(1),
+			db
+				.select({
+					lastEvaluatedAt: sql<string | null>`
+						to_char(max(${promptRuns.createdAt}) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS') || '.000Z'
+					`,
+				})
+				.from(promptRuns)
+				.innerJoin(prompts, eq(promptRuns.promptId, prompts.id))
+				.where(and(eq(promptRuns.brandId, data.brandId), eq(prompts.enabled, true))),
+		]);
+		const lastEvaluatedAt = evaluation?.lastEvaluatedAt ?? null;
 		const isFresh = latest && Date.now() - new Date(latest.createdAt).getTime() < REFRESH_AFTER_DAYS * 86_400_000;
 		if (latest && isFresh) {
-			return { report: latest.report as OpportunitiesReport, reason: null, generatedFor: null };
+			return { report: latest.report as OpportunitiesReport, reason: null, generatedFor: null, lastEvaluatedAt };
 		}
 
 		const digest = await buildDigest(data.brandId, data.timezone);
 		if (!digest) {
-			if (latest) return { report: latest.report as OpportunitiesReport, reason: null, generatedFor: null };
-			return { report: null, reason: "insufficient-data", generatedFor: null };
+			if (latest)
+				return { report: latest.report as OpportunitiesReport, reason: null, generatedFor: null, lastEvaluatedAt };
+			return { report: null, reason: "insufficient-data", generatedFor: null, lastEvaluatedAt };
 		}
 
 		const prompt = `${GUIDANCE}\n\n=== BRAND DATA ===\n${digest.text}\n\n=== TASK ===\n${TASK}`;
 		const generated = await generateValidReport(prompt);
 		if (!generated) {
 			// Couldn't get a schema-valid report — serve the last good one if we have it.
-			if (latest) return { report: latest.report as OpportunitiesReport, reason: null, generatedFor: null };
+			if (latest)
+				return { report: latest.report as OpportunitiesReport, reason: null, generatedFor: null, lastEvaluatedAt };
 			throw new Error("Failed to generate a valid opportunities report");
 		}
 
 		const report = enrichReport(generated.report, digest);
 		await db.insert(brandOpportunities).values({ brandId: data.brandId, report, model: generated.model });
 
-		return { report, reason: null, generatedFor: { brandName: digest.brandName } };
+		return { report, reason: null, generatedFor: { brandName: digest.brandName }, lastEvaluatedAt };
 	});

--- a/apps/web/src/stories/analytics-fixtures.ts
+++ b/apps/web/src/stories/analytics-fixtures.ts
@@ -68,6 +68,7 @@ export const mockShareOfVoice = {
 export const mockOpportunities = {
 	reason: null,
 	generatedFor: { brandName: "Acme" },
+	lastEvaluatedAt: "2026-06-04T09:12:00.000Z",
 	report: {
 		summary: [
 			"Acme is out-cited by Globex and Initech on nearly every unbranded category question.",


### PR DESCRIPTION
## Summary
- Show the most recent Opportunities report evaluation date.
- Return the stored report's `createdAt` with report data and update the Storybook fixture.
- Add a patch changeset.

## Testing
- `pnpm --filter @workspace/web check-types`
- `pnpm --filter @workspace/web test`