### PR TITLE
Fix keyboard tag selection in prompt editor

### DIFF
--- a/.changeset/prompt-tag-keyboard-selection.md
+++ b/.changeset/prompt-tag-keyboard-selection.md
@@ -3,4 +3,4 @@
 "@workspace/ui": patch
 ---
 
-Prompt tag matches can now be selected with the keyboard.
+You can now use the keyboard to select tags for filtering.

--- a/.changeset/prompt-tag-keyboard-selection.md
+++ b/.changeset/prompt-tag-keyboard-selection.md
@@ -1,0 +1,6 @@
+---
+"@workspace/web": patch
+"@workspace/ui": patch
+---
+
+Prompt tag matches can now be selected with the keyboard.

--- a/apps/web/src/stories/tags-input.stories.tsx
+++ b/apps/web/src/stories/tags-input.stories.tsx
@@ -1,11 +1,16 @@
-import type { Meta } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 import { useState, useMemo } from "react";
+import { expect, userEvent, within } from "storybook/test";
 import { Label } from "@workspace/ui/components/label";
 import { TagsInput } from "@workspace/ui/components/tags-input";
 
-export default {
+const meta = {
   title: "Components/TagsInput",
 } satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
 
 /** Standalone freeform input — each field manages its own values. */
 export const Freeform = () => {
@@ -121,4 +126,34 @@ export const SharedOptions = () => {
       </div>
     </div>
   );
+};
+
+export const KeyboardSelection: Story = {
+  render: () => {
+    const [values, setValues] = useState<string[]>([]);
+
+    return (
+      <div className="p-8 max-w-xl space-y-2">
+        <Label>Prompt tags</Label>
+        <TagsInput
+          value={values}
+          onValueChange={setValues}
+          options={[{ value: "marketing" }]}
+          placeholder="Add tag..."
+          searchPlaceholder="Search tags..."
+        />
+        <p data-testid="selected-tags">{values.join(", ")}</p>
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole("combobox"));
+    const input = await within(document.body).findByPlaceholderText("Search tags...");
+    await userEvent.type(input, "mark");
+    await userEvent.keyboard("{ArrowDown}{Enter}");
+
+    await expect(canvas.getByTestId("selected-tags")).toHaveTextContent(/^marketing$/);
+  },
 };

--- a/packages/ui/src/components/tags-input.tsx
+++ b/packages/ui/src/components/tags-input.tsx
@@ -205,10 +205,6 @@ export function TagsInput({
               placeholder={atMax ? "Maximum reached" : searchPlaceholder}
               disabled={disabled || atMax}
               onKeyDown={(e) => {
-                if (e.key === "Enter" && showCreate) {
-                  e.preventDefault();
-                  handleCreate();
-                }
                 if (e.key === "Backspace" && query === "" && value.length > 0 && canRemove) {
                   e.preventDefault();
                   onValueChange(value.slice(0, -1));


### PR DESCRIPTION
## Summary
- let cmdk activate the highlighted prompt tag when Enter is pressed
- add a browser regression test for ArrowDown + Enter selection

## Testing
- pnpm --filter @workspace/web check-types
- pnpm --filter @workspace/web exec vitest run --project=storybook src/stories/tags-input.stories.tsx