### PR TITLE
Add database-backed evaluation configuration

### DIFF
--- a/.changeset/database-evaluation-configuration.md
+++ b/.changeset/database-evaluation-configuration.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Evaluation targets and scoped run settings can now be configured in the database instead of requiring `SCRAPE_TARGETS`, with plan configuration caps enforced by scope.

--- a/apps/web/src/hooks/use-brands.tsx
+++ b/apps/web/src/hooks/use-brands.tsx
@@ -6,13 +6,13 @@ import { getBrands, getBrand, getCompetitors } from "@/server/brands";
 
 export type BrandWithPromptsAndDataInfo = BrandWithPrompts & {
 	earliestDataDate?: string | null;
-	/** Deployment-configured model ids this brand actually runs, after
-	 *  `brand.enabledModels` is applied. Comes from the server so the UI
-	 *  doesn't have to hardcode a model list. */
+	/** Database-configured model ids this brand actually runs. */
 	effectiveModels: string[];
 	/** Same as `effectiveModels` but with provider / version / webSearch
 	 *  metadata, for pages that render per-model details. */
 	effectiveModelConfigs: ModelConfig[];
+	/** Fastest resolved cadence across the targets this brand currently runs. */
+	effectiveCadenceHours?: number;
 };
 
 // ============================================================================

--- a/apps/web/src/lib/__tests__/evaluation-config-policy.test.ts
+++ b/apps/web/src/lib/__tests__/evaluation-config-policy.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { canEditEvaluationConfig, canEditEvaluationEntitlements } from "../evaluation-config-policy";
+
+describe("canEditEvaluationConfig", () => {
+	it("gives the single local install user access at every configuration scope", () => {
+		for (const scope of ["instance", "organization", "brand", "prompt"] as const) {
+			expect(canEditEvaluationConfig({ mode: "local", isGlobalAdmin: false, scope })).toBe(true);
+		}
+	});
+
+	it("keeps demo mode read-only", () => {
+		expect(canEditEvaluationConfig({ mode: "demo", isGlobalAdmin: true, scope: "instance" })).toBe(false);
+	});
+
+	it("allows cloud organization administrators but not members below instance scope", () => {
+		expect(
+			canEditEvaluationConfig({ mode: "cloud", isGlobalAdmin: false, organizationRole: "admin", scope: "brand" }),
+		).toBe(true);
+		expect(
+			canEditEvaluationConfig({ mode: "cloud", isGlobalAdmin: false, organizationRole: "member", scope: "brand" }),
+		).toBe(false);
+		expect(
+			canEditEvaluationConfig({ mode: "cloud", isGlobalAdmin: false, organizationRole: "owner", scope: "instance" }),
+		).toBe(false);
+	});
+
+	it("keeps cloud sampling and cadence under server-side plan control", () => {
+		expect(
+			canEditEvaluationConfig({
+				mode: "cloud",
+				isGlobalAdmin: false,
+				organizationRole: "admin",
+				scope: "brand",
+				action: "target-selection",
+			}),
+		).toBe(true);
+		expect(
+			canEditEvaluationConfig({
+				mode: "cloud",
+				isGlobalAdmin: false,
+				organizationRole: "admin",
+				scope: "brand",
+				action: "run-policy",
+			}),
+		).toBe(false);
+	});
+
+	it("keeps whitelabel organization and prompt configuration unavailable and requires a global admin", () => {
+		expect(
+			canEditEvaluationConfig({ mode: "whitelabel", isGlobalAdmin: false, organizationRole: "admin", scope: "brand" }),
+		).toBe(false);
+		expect(canEditEvaluationConfig({ mode: "whitelabel", isGlobalAdmin: true, scope: "brand" })).toBe(true);
+		expect(canEditEvaluationConfig({ mode: "whitelabel", isGlobalAdmin: true, scope: "organization" })).toBe(false);
+		expect(canEditEvaluationConfig({ mode: "whitelabel", isGlobalAdmin: true, scope: "prompt" })).toBe(false);
+	});
+});
+
+describe("canEditEvaluationEntitlements", () => {
+	it("never exposes billing controls in whitelabel or demo", () => {
+		expect(canEditEvaluationEntitlements({ mode: "whitelabel", isGlobalAdmin: true })).toBe(false);
+		expect(canEditEvaluationEntitlements({ mode: "demo", isGlobalAdmin: true })).toBe(false);
+	});
+});

--- a/apps/web/src/lib/auth/helpers.ts
+++ b/apps/web/src/lib/auth/helpers.ts
@@ -3,7 +3,7 @@
  */
 import { getRequestHeaders } from "@tanstack/react-start/server";
 import { db } from "@workspace/lib/db/db";
-import { member, organization } from "@workspace/lib/db/schema";
+import { brands, member, organization } from "@workspace/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { getDeployment } from "@/lib/config/server";
 import { auth } from "./server";
@@ -44,6 +44,42 @@ export async function checkOrgAccess(userId: string, orgId: string): Promise<boo
 export async function requireOrgAccess(userId: string, orgId: string): Promise<void> {
 	if (!(await checkOrgAccess(userId, orgId))) {
 		throw new Error("Forbidden: No access to this organization");
+	}
+}
+
+export async function getBrandOrganizationId(brandId: string): Promise<string | undefined> {
+	const [brand] = await db
+		.select({ organizationId: brands.organizationId })
+		.from(brands)
+		.where(eq(brands.id, brandId))
+		.limit(1);
+	return brand?.organizationId;
+}
+
+export async function checkBrandAccess(userId: string, brandId: string): Promise<boolean> {
+	const organizationId = await getBrandOrganizationId(brandId);
+	return organizationId ? checkOrgAccess(userId, organizationId) : false;
+}
+
+export async function requireBrandAccess(userId: string, brandId: string): Promise<void> {
+	if (!(await checkBrandAccess(userId, brandId))) {
+		throw new Error("Forbidden: No access to this brand");
+	}
+}
+
+export async function getOrgMemberRole(userId: string, orgId: string): Promise<string | undefined> {
+	const [row] = await db
+		.select({ role: member.role })
+		.from(member)
+		.where(and(eq(member.userId, userId), eq(member.organizationId, orgId)))
+		.limit(1);
+	return row?.role;
+}
+
+export async function requireOrgAdminAccess(userId: string, orgId: string): Promise<void> {
+	const role = await getOrgMemberRole(userId, orgId);
+	if (role !== "admin" && role !== "owner") {
+		throw new Error("Forbidden: Organization administrator access required");
 	}
 }
 

--- a/apps/web/src/lib/chart-utils.ts
+++ b/apps/web/src/lib/chart-utils.ts
@@ -8,11 +8,11 @@ export type LookbackPeriod = "1w" | "1m" | "3m" | "6m" | "1y" | "all";
  * Determines the default lookback period based on the brand's data history.
  * Returns "1m" (1 month) if the brand has more than 1 week of data or if data hasn't loaded yet,
  * otherwise returns "1w" (1 week) for new brands with less than a week of data.
- * 
+ *
  * Note: We default to "1m" when data is unavailable because most established brands
  * have more than a week of data, and this prevents inconsistent defaults when brand
  * data loads asynchronously (which was causing chart type mismatches downstream).
- * 
+ *
  * @param earliestDataDate - ISO date string of the earliest data point, or null if no data
  * @returns The recommended default lookback period
  */
@@ -86,7 +86,13 @@ export function citationDateWindow(
 	const prevFrom = shift(prevTo, -(span - 1));
 	const dateRange: string[] = [];
 	for (let i = 0; i < span; i++) dateRange.push(iso(shift(from, i)));
-	return { fromDateStr: iso(from), toDateStr: iso(today), prevFromDateStr: iso(prevFrom), prevToDateStr: iso(prevTo), dateRange };
+	return {
+		fromDateStr: iso(from),
+		toDateStr: iso(today),
+		prevFromDateStr: iso(prevFrom),
+		prevToDateStr: iso(prevTo),
+		dateRange,
+	};
 }
 
 // ============================================================================
@@ -238,7 +244,12 @@ export function applyPerPromptCitationLVCF(
 	categorizeDomain: (domain: string) => CitationCategory,
 ): Map<string, CitationCategories> {
 	return applyPerPromptKeyedLVCF(
-		perPromptData.map((r) => ({ prompt_id: r.prompt_id, date: r.date, key: categorizeDomain(r.domain), count: Number(r.count) })),
+		perPromptData.map((r) => ({
+			prompt_id: r.prompt_id,
+			date: r.date,
+			key: categorizeDomain(r.domain),
+			count: Number(r.count),
+		})),
 		dateRange,
 		cadenceHours,
 		CITATION_CATEGORIES,
@@ -269,13 +280,19 @@ export interface ChartDataPoint {
 	[key: string]: number | string | boolean | null; // Dynamic keys for brand/competitor IDs and _extended_ flags
 }
 
-import type { PromptRun, Brand, Competitor } from "@workspace/lib/db/schema";
+import type { Brand, Competitor, PromptRun } from "@workspace/lib/db/schema";
+
+type VisibilityPromptRun = {
+	createdAt: Date;
+	brandMentioned: boolean;
+	competitorsMentioned: string[];
+};
 
 /**
  * Calculate visibility percentages for brand vs competitors from prompt runs
  */
 export function calculateVisibilityPercentages(
-	promptRuns: PromptRun[],
+	promptRuns: VisibilityPromptRun[],
 	brand: Brand,
 	competitors: Competitor[],
 	lookback: LookbackPeriod,
@@ -333,7 +350,7 @@ export function calculateVisibilityPercentages(
 			acc[dateKey].push(run);
 			return acc;
 		},
-		{} as Record<string, PromptRun[]>,
+		{} as Record<string, VisibilityPromptRun[]>,
 	);
 
 	// Calculate visibility percentages for each date in the UTC range
@@ -479,15 +496,12 @@ export function filterAndCompleteChartData(chartData: ChartDataPoint[], lookback
  * to fill the start of the chart, and extends the last non-null value forward
  * to fill the end of the chart. This prevents gaps at the edges of the chart
  * when data collection started mid-period or hasn't been collected yet for recent dates.
- * 
+ *
  * Extended points are marked with `_extended_{key}: true` so the chart can:
  * - Skip rendering dots for extended points
  * - Skip showing extended values in tooltips
  */
-export function extendLinesToChartEdges(
-	chartData: ChartDataPoint[],
-	dataKeys: string[]
-): ChartDataPoint[] {
+export function extendLinesToChartEdges(chartData: ChartDataPoint[], dataKeys: string[]): ChartDataPoint[] {
 	if (chartData.length === 0) return chartData;
 
 	// Deep clone the chart data to avoid mutating the original

--- a/apps/web/src/lib/evaluation-config-policy.ts
+++ b/apps/web/src/lib/evaluation-config-policy.ts
@@ -1,0 +1,43 @@
+import type { DeploymentMode } from "@workspace/config/types";
+
+export type EvaluationConfigEditScope = "instance" | "organization" | "brand" | "prompt";
+export type EvaluationConfigAction = "catalog" | "target-selection" | "run-policy";
+export type OrganizationConfigRole = "owner" | "admin" | "member" | undefined;
+
+export interface EvaluationConfigAccessInput {
+	mode: DeploymentMode;
+	isGlobalAdmin: boolean;
+	organizationRole?: OrganizationConfigRole;
+	scope: EvaluationConfigEditScope;
+	action?: EvaluationConfigAction;
+}
+
+/**
+ * Run configuration is intentionally distinct from ordinary brand content.
+ * Whitelabel members can keep editing brands, prompts, and competitors through
+ * their existing endpoints, but never gain access to model or cadence controls.
+ */
+export function canEditEvaluationConfig(input: EvaluationConfigAccessInput): boolean {
+	const { mode, isGlobalAdmin, organizationRole, scope, action = "target-selection" } = input;
+	if (mode === "demo") return false;
+
+	if (mode === "local") return true;
+
+	if (mode === "whitelabel") {
+		return isGlobalAdmin && (scope === "instance" || scope === "brand");
+	}
+
+	if (scope === "instance") return isGlobalAdmin;
+	if (isGlobalAdmin) return true;
+	if (organizationRole !== "owner" && organizationRole !== "admin") return false;
+
+	// Standard cloud plans can choose from their allowed target menu, but their
+	// schedule and sampling are plan-controlled. A custom plan is represented by
+	// a server-side administrator changing the organization-level run policy.
+	return action !== "run-policy";
+}
+
+export function canEditEvaluationEntitlements(input: Omit<EvaluationConfigAccessInput, "scope">): boolean {
+	if (input.mode === "demo" || input.mode === "whitelabel") return false;
+	return input.isGlobalAdmin || input.mode === "local";
+}

--- a/apps/web/src/lib/job-scheduler.ts
+++ b/apps/web/src/lib/job-scheduler.ts
@@ -1,7 +1,8 @@
-import { db } from "@workspace/lib/db/db";
-import { prompts, brands } from "@workspace/lib/db/schema";
-import { eq } from "drizzle-orm";
 import { getDefaultDelayHours } from "@workspace/lib/constants";
+import {
+	getEvaluationConfigurationVersion,
+	getPromptCadenceHours as getConfiguredPromptCadenceHours,
+} from "@workspace/lib/evaluation-config";
 import { getBoss } from "@/lib/boss-client";
 
 /**
@@ -11,43 +12,25 @@ export function hoursToMs(hours: number): number {
 	return hours * 60 * 60 * 1000;
 }
 
-/**
- * Gets the cadence (delay between runs) for a prompt based on its brand's delay override or the default
- */
+/** Gets the next scheduler cadence from the resolved evaluation configuration. */
 export async function getPromptCadenceHours(promptId: string): Promise<number> {
 	const defaultDelayHours = getDefaultDelayHours();
 	try {
-		// Get the prompt to find its brand
-		const prompt = await db.query.prompts.findFirst({
-			where: eq(prompts.id, promptId),
-		});
-
-		if (!prompt) {
-			console.warn(`Prompt ${promptId} not found, using default cadence`);
-			return defaultDelayHours;
-		}
-
-		// Get the brand to check for delay override
-		const brand = await db.query.brands.findFirst({
-			where: eq(brands.id, prompt.brandId),
-		});
-
-		if (!brand) {
-			console.warn(`Brand ${prompt.brandId} not found, using default cadence`);
-			return defaultDelayHours;
-		}
-
-		// Use override if set, otherwise use default
-		if (brand.delayOverrideHours !== null) {
-			console.log(`Using custom cadence for brand ${brand.name}: ${brand.delayOverrideHours}h`);
-			return brand.delayOverrideHours;
-		}
-
-		return defaultDelayHours;
+		return (await getConfiguredPromptCadenceHours(promptId)) ?? defaultDelayHours;
 	} catch (error) {
 		console.error(`Error fetching cadence for prompt ${promptId}:`, error);
 		return defaultDelayHours;
 	}
+}
+
+async function getPromptSchedulerConfiguration(
+	promptId: string,
+): Promise<{ cadenceHours: number; configurationVersion: number }> {
+	const [cadenceHours, configurationVersion] = await Promise.all([
+		getPromptCadenceHours(promptId),
+		getEvaluationConfigurationVersion(),
+	]);
+	return { cadenceHours, configurationVersion };
 }
 
 /**
@@ -59,13 +42,10 @@ type SchedulerOptions = {
 	sendImmediate?: boolean;
 };
 
-export async function createPromptJobScheduler(
-	promptId: string,
-	options: SchedulerOptions = {},
-): Promise<boolean> {
+export async function createPromptJobScheduler(promptId: string, options: SchedulerOptions = {}): Promise<boolean> {
 	try {
 		const boss = await getBoss();
-		const cadenceHours = await getPromptCadenceHours(promptId);
+		const { cadenceHours, configurationVersion } = await getPromptSchedulerConfiguration(promptId);
 		const sendImmediate = options.sendImmediate ?? true;
 
 		// Remove any old cron-based schedule (migration cleanup)
@@ -79,7 +59,7 @@ export async function createPromptJobScheduler(
 			// Send an immediate job
 			await boss.send(
 				"process-prompt",
-				{ promptId, cadenceHours },
+				{ promptId, cadenceHours, configurationVersion },
 				{
 					singletonKey: `prompt-${promptId}`,
 					singletonSeconds: 60 * 60, // 1 hour - prevent duplicate jobs
@@ -94,7 +74,7 @@ export async function createPromptJobScheduler(
 			const startAfterSeconds = cadenceHours * 60 * 60;
 			await boss.send(
 				"process-prompt",
-				{ promptId, cadenceHours },
+				{ promptId, cadenceHours, configurationVersion },
 				{
 					singletonKey: `prompt-${promptId}`,
 					singletonSeconds: startAfterSeconds, // Prevent duplicates for the cadence period
@@ -130,7 +110,7 @@ export async function removePromptJobScheduler(promptId: string): Promise<boolea
 		}
 
 		// Cancel any pending jobs for this prompt
-		// Note: pg-boss doesn't have a direct way to cancel by data, 
+		// Note: pg-boss doesn't have a direct way to cancel by data,
 		// but the singletonKey prevents duplicates
 		console.log(`Removed schedule for prompt ${promptId}`);
 		return true;
@@ -148,9 +128,7 @@ export async function createMultiplePromptJobSchedulers(
 	promptIds: string[],
 	options: SchedulerOptions = {},
 ): Promise<boolean[]> {
-	const results = await Promise.allSettled(
-		promptIds.map((promptId) => createPromptJobScheduler(promptId, options)),
-	);
+	const results = await Promise.allSettled(promptIds.map((promptId) => createPromptJobScheduler(promptId, options)));
 
 	return results.map((result) => (result.status === "fulfilled" ? result.value : false));
 }
@@ -169,10 +147,7 @@ export async function removeMultiplePromptJobSchedulers(promptIds: string[]): Pr
  * Recreates a schedule for a prompt (removes and creates).
  * Useful when cadence has changed or job needs to be reset.
  */
-export async function recreatePromptJobScheduler(
-	promptId: string,
-	options: SchedulerOptions = {},
-): Promise<boolean> {
+export async function recreatePromptJobScheduler(promptId: string, options: SchedulerOptions = {}): Promise<boolean> {
 	try {
 		// Remove existing schedule if any (ignore errors if it doesn't exist)
 		await removePromptJobScheduler(promptId);
@@ -191,11 +166,11 @@ export async function recreatePromptJobScheduler(
 export async function sendImmediatePromptJob(promptId: string): Promise<boolean> {
 	try {
 		const boss = await getBoss();
-		const cadenceHours = await getPromptCadenceHours(promptId);
+		const { cadenceHours, configurationVersion } = await getPromptSchedulerConfiguration(promptId);
 
 		await boss.send(
 			"process-prompt",
-			{ promptId, cadenceHours },
+			{ promptId, cadenceHours, configurationVersion, force: true },
 			{
 				retryLimit: 3,
 				retryDelay: 60,
@@ -219,11 +194,12 @@ export async function sendImmediatePromptJob(promptId: string): Promise<boolean>
 export async function scheduleNextPromptRun(promptId: string, cadenceHours: number): Promise<boolean> {
 	try {
 		const boss = await getBoss();
+		const configurationVersion = await getEvaluationConfigurationVersion();
 		const startAfterSeconds = cadenceHours * 60 * 60;
 
 		await boss.send(
 			"process-prompt",
-			{ promptId, cadenceHours },
+			{ promptId, cadenceHours, configurationVersion },
 			{
 				singletonKey: `prompt-${promptId}`,
 				singletonSeconds: startAfterSeconds, // Prevent duplicates for the cadence period

--- a/apps/web/src/routes/_authed/app/$brand.tsx
+++ b/apps/web/src/routes/_authed/app/$brand.tsx
@@ -9,7 +9,13 @@ import { createFileRoute, Outlet, notFound } from "@tanstack/react-router";
 import { getAppName } from "@/lib/route-head";
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
-import { requireAuthSession, isAdmin, hasReportAccess, checkOrgAccess, listUserOrganizations } from "@/lib/auth/helpers";
+import {
+	requireAuthSession,
+	isAdmin,
+	hasReportAccess,
+	checkOrgAccess,
+	listUserOrganizations,
+} from "@/lib/auth/helpers";
 import { db } from "@workspace/lib/db/db";
 import { brands, prompts, competitors } from "@workspace/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -23,58 +29,63 @@ import { validateBrandFilterSearch } from "@/hooks/use-list-filters";
 
 const getBrandData = createServerFn({ method: "GET" })
 	.validator(z.object({ brandId: z.string() }))
-	.handler(async ({ data }): Promise<{
-		brand: BrandWithPrompts | null;
-		brandName: string | null;
-		isAdmin: boolean;
-		hasReportAccess: boolean;
-		hasAccess: boolean;
-	}> => {
-		const session = await requireAuthSession();
+	.handler(
+		async ({
+			data,
+		}): Promise<{
+			brand: BrandWithPrompts | null;
+			brandName: string | null;
+			isAdmin: boolean;
+			hasReportAccess: boolean;
+			hasAccess: boolean;
+		}> => {
+			const session = await requireAuthSession();
 
-		// Verify access
-		const hasAccess = await checkOrgAccess(session.user.id, data.brandId);
-		if (!hasAccess) {
-			return { brand: null, brandName: null, isAdmin: false, hasReportAccess: false, hasAccess: false };
-		}
+			const brand = await db.query.brands.findFirst({
+				where: eq(brands.id, data.brandId),
+			});
+			// A route can temporarily point at an org before its brand row exists
+			// during onboarding. Once a brand exists, its explicit owner org is the
+			// only tenancy boundary used for access.
+			const organizationId = brand?.organizationId ?? data.brandId;
+			const hasAccess = await checkOrgAccess(session.user.id, organizationId);
+			if (!hasAccess) {
+				return { brand: null, brandName: null, isAdmin: false, hasReportAccess: false, hasAccess: false };
+			}
 
-		// Get brand metadata (name from org membership — org exists even if not in DB yet)
-		const orgs = await listUserOrganizations(session.user.id);
-		const orgMeta = orgs.find((o) => o.id === data.brandId);
-		const brandName = orgMeta?.name || data.brandId;
+			// Get brand metadata (name from org membership — org exists even if not in DB yet)
+			const orgs = await listUserOrganizations(session.user.id);
+			const orgMeta = orgs.find((o) => o.id === organizationId);
+			const brandName = orgMeta?.name || data.brandId;
 
-		const admin = isAdmin(session);
-		const reportAccess = hasReportAccess(session);
+			const admin = isAdmin(session);
+			const reportAccess = hasReportAccess(session);
 
-		// Get brand data from DB
-		const brand = await db.query.brands.findFirst({
-			where: eq(brands.id, data.brandId),
-		});
+			if (!brand) {
+				return { brand: null, brandName, isAdmin: admin, hasReportAccess: reportAccess, hasAccess: true };
+			}
 
-		if (!brand) {
-			return { brand: null, brandName, isAdmin: admin, hasReportAccess: reportAccess, hasAccess: true };
-		}
+			const brandPrompts = await db.query.prompts.findMany({
+				where: eq(prompts.brandId, data.brandId),
+			});
 
-		const brandPrompts = await db.query.prompts.findMany({
-			where: eq(prompts.brandId, data.brandId),
-		});
+			const brandCompetitors = await db.query.competitors.findMany({
+				where: eq(competitors.brandId, data.brandId),
+			});
 
-		const brandCompetitors = await db.query.competitors.findMany({
-			where: eq(competitors.brandId, data.brandId),
-		});
-
-		return {
-			brand: {
-				...brand,
-				prompts: brandPrompts,
-				competitors: brandCompetitors,
-			},
-			brandName: brand.name,
-			isAdmin: admin,
-			hasReportAccess: reportAccess,
-			hasAccess: true,
-		};
-	});
+			return {
+				brand: {
+					...brand,
+					prompts: brandPrompts,
+					competitors: brandCompetitors,
+				},
+				brandName: brand.name,
+				isAdmin: admin,
+				hasReportAccess: reportAccess,
+				hasAccess: true,
+			};
+		},
+	);
 
 function BrandLayoutSkeleton() {
 	return (
@@ -144,9 +155,7 @@ export const Route = createFileRoute("/_authed/app/$brand")({
 				{ title: brandName ? `${brandName} · ${appName}` : appName },
 				{
 					name: "description",
-					content: brandName
-						? `AI visibility tracking for ${brandName}.`
-						: "AI visibility tracking and optimization.",
+					content: brandName ? `AI visibility tracking for ${brandName}.` : "AI visibility tracking and optimization.",
 				},
 			],
 		};

--- a/apps/web/src/routes/_authed/app/$brand/index.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/index.tsx
@@ -123,9 +123,7 @@ function StatWithTooltip({
 					<IconInfoCircle className="h-3.5 w-3.5 opacity-50" />
 				</div>
 			</TooltipTrigger>
-			<TooltipContent className="max-w-xs text-sm">
-				{tooltip}
-			</TooltipContent>
+			<TooltipContent className="max-w-xs text-sm">{tooltip}</TooltipContent>
 		</Tooltip>
 	);
 }
@@ -146,9 +144,7 @@ function CardTitleWithTooltip({
 				<TooltipTrigger asChild>
 					<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
 				</TooltipTrigger>
-				<TooltipContent className="max-w-xs text-sm font-normal">
-					{tooltip}
-				</TooltipContent>
+				<TooltipContent className="max-w-xs text-sm font-normal">{tooltip}</TooltipContent>
 			</Tooltip>
 		</CardTitle>
 	);
@@ -175,6 +171,8 @@ function DashboardPage() {
 	const { data: sovData, isLoading: isLoadingSov } = useShareOfVoice(brand?.id, { lookback: "1m" });
 	const context = useRouteContext({ strict: false }) as { clientConfig?: ClientConfig };
 	const clientConfig = context.clientConfig;
+	const runCadenceHours =
+		brand?.effectiveCadenceHours ?? brand?.delayOverrideHours ?? clientConfig?.defaultDelayHours ?? 24;
 
 	const isLoading = isLoadingBrand || isLoadingSummary;
 
@@ -260,10 +258,22 @@ function DashboardPage() {
 					{/* Footer stats skeleton */}
 					<section className="pt-2">
 						<div className="flex flex-wrap justify-center items-center gap-x-8 gap-y-3 text-sm text-muted-foreground">
-							<div className="flex items-center gap-2"><IconList className="h-4 w-4 flex-shrink-0" /><Skeleton className="h-4 w-28" /></div>
-							<div className="flex items-center gap-2"><IconActivity className="h-4 w-4 flex-shrink-0" /><Skeleton className="h-4 w-32" /></div>
-							<div className="flex items-center gap-2"><IconClock className="h-4 w-4 flex-shrink-0" /><Skeleton className="h-4 w-24" /></div>
-							<div className="flex items-center gap-2"><IconRefresh className="h-4 w-4 flex-shrink-0" /><Skeleton className="h-4 w-24" /></div>
+							<div className="flex items-center gap-2">
+								<IconList className="h-4 w-4 flex-shrink-0" />
+								<Skeleton className="h-4 w-28" />
+							</div>
+							<div className="flex items-center gap-2">
+								<IconActivity className="h-4 w-4 flex-shrink-0" />
+								<Skeleton className="h-4 w-32" />
+							</div>
+							<div className="flex items-center gap-2">
+								<IconClock className="h-4 w-4 flex-shrink-0" />
+								<Skeleton className="h-4 w-24" />
+							</div>
+							<div className="flex items-center gap-2">
+								<IconRefresh className="h-4 w-4 flex-shrink-0" />
+								<Skeleton className="h-4 w-24" />
+							</div>
 						</div>
 					</section>
 				</div>
@@ -324,9 +334,7 @@ function DashboardPage() {
 				<h2 className="text-2xl font-bold mb-3">
 					{hasEnabledPrompts ? "Waiting for First Evaluation" : "No Data Yet"}
 				</h2>
-				<p className="text-muted-foreground mb-6 text-balance">
-					{getMessage()}
-				</p>
+				<p className="text-muted-foreground mb-6 text-balance">{getMessage()}</p>
 				<div className="flex flex-col gap-3 w-full">
 					{hasEnabledPrompts && (
 						<div className="flex items-center justify-between p-4 bg-muted/50 rounded-lg">
@@ -339,7 +347,8 @@ function DashboardPage() {
 					)}
 					<Button asChild variant="outline" className="w-full">
 						<Link to="/app/$brand/settings/prompts" params={{ brand: brandId }}>
-							{hasEnabledPrompts ? "View Your Prompts" : hasPrompts ? "Edit Prompts" : "Set Up Prompts"} <IconArrowRight className="h-4 w-4 ml-1" />
+							{hasEnabledPrompts ? "View Your Prompts" : hasPrompts ? "Edit Prompts" : "Set Up Prompts"}{" "}
+							<IconArrowRight className="h-4 w-4 ml-1" />
 						</Link>
 					</Button>
 				</div>
@@ -355,7 +364,6 @@ function DashboardPage() {
 	return (
 		<div className="flex flex-1 flex-col">
 			<div className="m-auto flex w-full max-w-[1600px] flex-col gap-3 p-4">
-
 				{/* Section 1: AI Visibility */}
 				<section className="space-y-2">
 					<div className="flex items-center justify-between">
@@ -372,7 +380,9 @@ function DashboardPage() {
 
 					<div className="grid gap-4 lg:grid-cols-4">
 						{/* Hero Visibility Score */}
-						<Card className={`shadow-none flex flex-col gap-3 py-4 ${currentVisibility === null ? "" : `${getVisibilityBgColor(currentVisibility)} ${getVisibilityBorderColor(currentVisibility)}`}`}>
+						<Card
+							className={`shadow-none flex flex-col gap-3 py-4 ${currentVisibility === null ? "" : `${getVisibilityBgColor(currentVisibility)} ${getVisibilityBorderColor(currentVisibility)}`}`}
+						>
 							<HeroStat value={currentVisibility} loading={isLoading} />
 						</Card>
 
@@ -414,7 +424,9 @@ function DashboardPage() {
 					</div>
 
 					<div className="grid gap-4 lg:grid-cols-4">
-						<Card className={`shadow-none flex flex-col gap-3 py-4 ${sovShare === null ? "" : `${getVisibilityBgColor(sovShare)} ${getVisibilityBorderColor(sovShare)}`}`}>
+						<Card
+							className={`shadow-none flex flex-col gap-3 py-4 ${sovShare === null ? "" : `${getVisibilityBgColor(sovShare)} ${getVisibilityBorderColor(sovShare)}`}`}
+						>
 							<HeroStat value={sovShare} loading={isLoadingSov} />
 						</Card>
 
@@ -445,10 +457,22 @@ function DashboardPage() {
 					<div className="flex flex-wrap justify-center items-center gap-x-8 gap-y-3 text-sm text-muted-foreground">
 						{isLoadingSummary ? (
 							<>
-								<div className="flex items-center gap-2"><IconList className="h-4 w-4 flex-shrink-0" /><Skeleton className="h-4 w-28" /></div>
-								<div className="flex items-center gap-2"><IconActivity className="h-4 w-4 flex-shrink-0" /><Skeleton className="h-4 w-32" /></div>
-								<div className="flex items-center gap-2"><IconClock className="h-4 w-4 flex-shrink-0" /><Skeleton className="h-4 w-24" /></div>
-								<div className="flex items-center gap-2"><IconRefresh className="h-4 w-4 flex-shrink-0" /><Skeleton className="h-4 w-24" /></div>
+								<div className="flex items-center gap-2">
+									<IconList className="h-4 w-4 flex-shrink-0" />
+									<Skeleton className="h-4 w-28" />
+								</div>
+								<div className="flex items-center gap-2">
+									<IconActivity className="h-4 w-4 flex-shrink-0" />
+									<Skeleton className="h-4 w-32" />
+								</div>
+								<div className="flex items-center gap-2">
+									<IconClock className="h-4 w-4 flex-shrink-0" />
+									<Skeleton className="h-4 w-24" />
+								</div>
+								<div className="flex items-center gap-2">
+									<IconRefresh className="h-4 w-4 flex-shrink-0" />
+									<Skeleton className="h-4 w-24" />
+								</div>
 							</>
 						) : (
 							<>
@@ -467,16 +491,17 @@ function DashboardPage() {
 								<StatWithTooltip
 									icon={IconClock}
 									label="run frequency"
-									value={formatRunFrequency(brand?.delayOverrideHours ?? clientConfig?.defaultDelayHours ?? 24)}
-									tooltip={`Prompts are automatically evaluated every ${formatRunFrequency(brand?.delayOverrideHours ?? clientConfig?.defaultDelayHours ?? 24).replace("~", "")} on average to track changes in AI model responses over time.`}
+									value={formatRunFrequency(runCadenceHours)}
+									tooltip={`Prompts are automatically evaluated every ${formatRunFrequency(runCadenceHours).replace("~", "")} on average to track changes in AI model responses over time.`}
 								/>
 								<StatWithTooltip
 									icon={IconRefresh}
 									label="last updated"
 									value={formatRelativeTime(lastUpdatedAt)}
-									tooltip={lastUpdatedAt
-										? `The last prompts we evaluated for your brand were run on ${new Date(lastUpdatedAt).toLocaleString()}`
-										: "No evaluations have been run yet."
+									tooltip={
+										lastUpdatedAt
+											? `The last prompts we evaluated for your brand were run on ${new Date(lastUpdatedAt).toLocaleString()}`
+											: "No evaluations have been run yet."
 									}
 								/>
 							</>

--- a/apps/web/src/routes/_authed/app/$brand/settings/llms.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/settings/llms.tsx
@@ -1,19 +1,42 @@
-/**
- * /app/$brand/settings/llms - LLM configuration page
- *
- * Lists the AI models this brand is tracked against, data-driven from the
- * deployment's `SCRAPE_TARGETS` + `brand.enabledModels`. Each card renders
- * from `brand.effectiveModelConfigs` rather than a hardcoded model list so
- * any deployment-configured model shows up automatically.
- */
+import { useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { getAppName, getBrandName, buildTitle } from "@/lib/route-head";
-import { Card, CardContent, CardHeader } from "@workspace/ui/components/card";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
 import { IconCircleCheck, IconCircleX, IconInfoCircle } from "@tabler/icons-react";
+import { Card, CardContent, CardHeader } from "@workspace/ui/components/card";
+import { Button } from "@workspace/ui/components/button";
+import { Input } from "@workspace/ui/components/input";
+import { Label } from "@workspace/ui/components/label";
 import { Skeleton } from "@workspace/ui/components/skeleton";
-import { useBrand } from "@/hooks/use-brands";
+import { Switch } from "@workspace/ui/components/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
 import { iconForModel } from "@/components/filter-bar";
+import { useBrand } from "@/hooks/use-brands";
+import { getAppName, getBrandName, buildTitle } from "@/lib/route-head";
+import {
+	createEvaluationTargetFn,
+	getBrandEvaluationConfigFn,
+	updateBrandEvaluationConfigFn,
+} from "@/server/evaluation-config";
+
+type Target = {
+	id: string;
+	model: string;
+	provider: string;
+	version: string | null;
+	webSearch: boolean;
+	enabled: boolean;
+	requiresPromptAssignment: boolean;
+	defaultCadenceHours: number;
+	defaultSamplesPerDispatch: number;
+};
+
+type ScopeConfig = {
+	targetId: string | null;
+	scope: "organization" | "brand" | "prompt";
+	enabled: boolean | null;
+	cadenceHours: number | null;
+	samplesPerDispatch: number | null;
+};
 
 export const Route = createFileRoute("/_authed/app/$brand/settings/llms")({
 	head: ({ matches, match }) => {
@@ -22,7 +45,7 @@ export const Route = createFileRoute("/_authed/app/$brand/settings/llms")({
 		return {
 			meta: [
 				{ title: buildTitle("LLMs", { appName, brandName }) },
-				{ name: "description", content: "View tracked AI models and configuration." },
+				{ name: "description", content: "View and configure tracked AI models." },
 			],
 		};
 	},
@@ -30,70 +53,194 @@ export const Route = createFileRoute("/_authed/app/$brand/settings/llms")({
 });
 
 function LlmsSettingsPage() {
-	const { brand, isLoading } = useBrand();
-	const configs = brand?.effectiveModelConfigs ?? [];
+	const { brand, brandId, isLoading, revalidate } = useBrand();
+	const queryClient = useQueryClient();
+	const [error, setError] = useState("");
+	const [addingTarget, setAddingTarget] = useState(false);
+	const evaluationConfig = useQuery({
+		queryKey: ["evaluation-config", brandId],
+		queryFn: () => getBrandEvaluationConfigFn({ data: { brandId: brandId! } }),
+		enabled: Boolean(brandId),
+	});
+
+	const refresh = async () => {
+		await queryClient.invalidateQueries({ queryKey: ["evaluation-config", brandId] });
+		await revalidate();
+	};
+
+	const updateBrandTarget = async (
+		targetId: string,
+		patch: { enabled?: boolean | null; cadenceHours?: number | null; samplesPerDispatch?: number | null },
+	) => {
+		setError("");
+		try {
+			await updateBrandEvaluationConfigFn({ data: { brandId: brandId!, targetId, ...patch } });
+			await refresh();
+		} catch (cause) {
+			setError(cause instanceof Error ? cause.message : "Could not update evaluation configuration");
+		}
+	};
+
+	const addTarget = async (formData: FormData) => {
+		setError("");
+		setAddingTarget(true);
+		try {
+			await createEvaluationTargetFn({
+				data: {
+					model: String(formData.get("model") ?? "").trim(),
+					provider: String(formData.get("provider") ?? "").trim(),
+					version: String(formData.get("version") ?? "").trim() || null,
+					webSearch: formData.get("webSearch") === "on",
+					defaultCadenceHours: Number(formData.get("cadenceHours")),
+					defaultSamplesPerDispatch: Number(formData.get("samplesPerDispatch")),
+				},
+			});
+			await refresh();
+		} catch (cause) {
+			setError(cause instanceof Error ? cause.message : "Could not add evaluation target");
+		} finally {
+			setAddingTarget(false);
+		}
+	};
+
+	if (isLoading || evaluationConfig.isLoading) {
+		return <LoadingState />;
+	}
+
+	if (!brand || !evaluationConfig.data) {
+		return (
+			<div className="space-y-6">
+				<h1 className="text-3xl font-bold">LLMs</h1>
+				<p className="text-destructive">LLM configuration could not be loaded.</p>
+			</div>
+		);
+	}
+
+	const config = evaluationConfig.data;
+	const effectiveTargetIds = new Set(config.effectiveTargets.map((target) => target.targetId));
+	const configuredTargets: Target[] =
+		config.targets.length > 0
+			? config.targets
+			: config.effectiveTargets.map((target) => ({
+					id: target.targetId,
+					model: target.model,
+					provider: target.provider,
+					version: target.version ?? null,
+					webSearch: target.webSearch,
+					enabled: true,
+					requiresPromptAssignment: false,
+					defaultCadenceHours: target.cadenceHours,
+					defaultSamplesPerDispatch: target.samplesPerDispatch,
+				}));
+	const visibleTargets =
+		config.mode === "whitelabel" && !config.canManageBrandTargets
+			? configuredTargets.filter((target) => effectiveTargetIds.has(target.id))
+			: configuredTargets;
+	const brandConfigs = new Map(
+		config.scopeConfigs
+			.filter((scopeConfig) => scopeConfig.scope === "brand")
+			.map((scopeConfig) => [scopeConfig.targetId, scopeConfig]),
+	);
 
 	return (
 		<div className="space-y-6 max-w-6xl">
 			<div>
 				<h1 className="text-3xl font-bold">LLMs</h1>
 				<p className="text-muted-foreground">
-					Your prompts are evaluated against these AI models to track how your brand appears across different types of AI
-					search.
+					Your prompts are evaluated against these AI models to track how your brand appears across different types of
+					AI search.
 				</p>
 			</div>
 
-			{isLoading && !brand ? (
-				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-					{[0, 1, 2].map((i) => (
-						<Card key={i} className="h-full">
-							<CardHeader className="py-2 border-b">
-								<Skeleton className="h-6 w-6 rounded" />
-							</CardHeader>
-							<CardContent className="pt-2 space-y-2">
-								<Skeleton className="h-4 w-full" />
-								<Skeleton className="h-4 w-3/4" />
-								<Skeleton className="h-4 w-2/3" />
-							</CardContent>
-						</Card>
-					))}
-				</div>
-			) : configs.length === 0 ? (
+			{error && <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>}
+
+			{config.canManageInstance && (
+				<Card>
+					<CardContent className="pt-6">
+						<h2 className="font-semibold">Add an instance target</h2>
+						<p className="mt-1 text-sm text-muted-foreground">
+							Credentials stay in the deployment environment for this migration path. Add the provider credential first,
+							then choose the model here.
+						</p>
+						<form className="mt-4 grid gap-3 md:grid-cols-3" action={addTarget}>
+							<div className="space-y-1.5">
+								<Label htmlFor="model">Model</Label>
+								<Input id="model" name="model" placeholder="chatgpt" required disabled={addingTarget} />
+							</div>
+							<div className="space-y-1.5">
+								<Label htmlFor="provider">Provider</Label>
+								<Input id="provider" name="provider" placeholder="brightdata" required disabled={addingTarget} />
+							</div>
+							<div className="space-y-1.5">
+								<Label htmlFor="version">Version</Label>
+								<Input id="version" name="version" placeholder="Optional provider version" disabled={addingTarget} />
+							</div>
+							<div className="space-y-1.5">
+								<Label htmlFor="cadenceHours">Cadence (hours)</Label>
+								<Input
+									id="cadenceHours"
+									name="cadenceHours"
+									type="number"
+									min="1"
+									defaultValue="24"
+									required
+									disabled={addingTarget}
+								/>
+							</div>
+							<div className="space-y-1.5">
+								<Label htmlFor="samplesPerDispatch">Samples per run</Label>
+								<Input
+									id="samplesPerDispatch"
+									name="samplesPerDispatch"
+									type="number"
+									min="1"
+									defaultValue="5"
+									required
+									disabled={addingTarget}
+								/>
+							</div>
+							<label className="flex items-center gap-2 self-end pb-2 text-sm">
+								<input name="webSearch" type="checkbox" />
+								Use web search
+							</label>
+							<div className="md:col-span-3">
+								<Button type="submit" disabled={addingTarget} className="cursor-pointer">
+									{addingTarget ? "Adding…" : "Add target"}
+								</Button>
+							</div>
+						</form>
+					</CardContent>
+				</Card>
+			)}
+
+			{visibleTargets.length === 0 ? (
 				<Card>
 					<CardContent className="pt-6 text-sm text-muted-foreground">
-						No models are configured for this brand. Set <code className="font-mono text-xs">SCRAPE_TARGETS</code> at the
-						deployment level, or adjust this brand&apos;s <code className="font-mono text-xs">enabledModels</code>.
+						No models are configured for this instance. An instance administrator can add a target above.
 					</CardContent>
 				</Card>
 			) : (
 				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-					{configs.map((config) => (
-						<Card key={config.model} className="h-full">
-							<CardHeader className="py-2 border-b">
-								{iconForModel(config.model, "h-6 w-6")}
-							</CardHeader>
-							<CardContent className="pt-2">
-								<div className="divide-y text-sm">
-									<ConfigRow label="Model" tooltip="Which AI model this card covers.">
-										<span className="font-mono text-xs text-foreground">{config.model}</span>
-									</ConfigRow>
-									<ConfigRow label="Provider" tooltip="How this deployment reaches the model — direct API, a scraping proxy, etc.">
-										<span className="font-mono text-xs text-foreground">{config.provider}</span>
-									</ConfigRow>
-									<ConfigRow label="Version" tooltip="Exact upstream model version requested from the provider.">
-										<span className="font-mono text-xs text-foreground">{config.version ?? "—"}</span>
-									</ConfigRow>
-									<ConfigRow label="Web search" tooltip="Is web search used to answer prompts?">
-										{config.webSearch ? (
-											<IconCircleCheck className="h-4 w-4 text-emerald-600" />
-										) : (
-											<IconCircleX className="h-4 w-4 text-muted-foreground" />
-										)}
-										<span className="sr-only">{config.webSearch ? "Enabled" : "Disabled"}</span>
-									</ConfigRow>
-								</div>
-							</CardContent>
-						</Card>
+					{visibleTargets.map((target) => (
+						<TargetCard
+							key={target.id}
+							target={target}
+							effective={effectiveTargetIds.has(target.id)}
+							brandConfig={brandConfigs.get(target.id) as ScopeConfig | undefined}
+							inheritedCadenceHours={resolveInheritedNumber(
+								target,
+								config.scopeConfigs as ScopeConfig[],
+								"cadenceHours",
+							)}
+							inheritedSamplesPerDispatch={resolveInheritedNumber(
+								target,
+								config.scopeConfigs as ScopeConfig[],
+								"samplesPerDispatch",
+							)}
+							canManageTargetSelection={config.canManageBrandTargets}
+							canManageRunPolicy={config.canManageBrandRunPolicy}
+							onSave={updateBrandTarget}
+						/>
 					))}
 				</div>
 			)}
@@ -101,27 +248,198 @@ function LlmsSettingsPage() {
 	);
 }
 
-function ConfigRow({
-	label,
-	tooltip,
-	children,
+function resolveInheritedNumber(
+	target: Target,
+	configs: ScopeConfig[],
+	field: "cadenceHours" | "samplesPerDispatch",
+): number {
+	let value = field === "cadenceHours" ? target.defaultCadenceHours : target.defaultSamplesPerDispatch;
+	for (const scope of ["organization", "brand"] as const) {
+		const scopeConfigs = configs.filter((config) => config.scope === scope);
+		const defaultConfig = scopeConfigs.find((config) => config.targetId === null);
+		const targetConfig = scopeConfigs.find((config) => config.targetId === target.id);
+		const override = targetConfig?.[field] ?? defaultConfig?.[field];
+		if (override !== null && override !== undefined) value = override;
+	}
+	return value;
+}
+
+function TargetCard({
+	target,
+	effective,
+	brandConfig,
+	inheritedCadenceHours,
+	inheritedSamplesPerDispatch,
+	canManageTargetSelection,
+	canManageRunPolicy,
+	onSave,
 }: {
-	label: string;
-	tooltip?: string;
-	children: React.ReactNode;
+	target: Target;
+	effective: boolean;
+	brandConfig?: ScopeConfig;
+	inheritedCadenceHours: number;
+	inheritedSamplesPerDispatch: number;
+	canManageTargetSelection: boolean;
+	canManageRunPolicy: boolean;
+	onSave: (
+		targetId: string,
+		patch: { enabled?: boolean | null; cadenceHours?: number | null; samplesPerDispatch?: number | null },
+	) => Promise<void>;
 }) {
+	const [cadenceHours, setCadenceHours] = useState(String(inheritedCadenceHours));
+	const [samplesPerDispatch, setSamplesPerDispatch] = useState(String(inheritedSamplesPerDispatch));
+	const [saving, setSaving] = useState(false);
+
+	useEffect(() => {
+		setCadenceHours(String(inheritedCadenceHours));
+		setSamplesPerDispatch(String(inheritedSamplesPerDispatch));
+	}, [inheritedCadenceHours, inheritedSamplesPerDispatch]);
+
+	const save = async () => {
+		setSaving(true);
+		try {
+			await onSave(target.id, {
+				cadenceHours: Number(cadenceHours),
+				samplesPerDispatch: Number(samplesPerDispatch),
+			});
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	const reset = async () => {
+		setSaving(true);
+		try {
+			await onSave(target.id, { enabled: null, cadenceHours: null, samplesPerDispatch: null });
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	return (
+		<Card className="h-full">
+			<CardHeader className="flex-row items-center justify-between py-2 border-b">
+				{iconForModel(target.model, "h-6 w-6")}
+				{canManageTargetSelection && target.requiresPromptAssignment ? (
+					<span className="text-xs text-muted-foreground">Prompt assignment required</span>
+				) : canManageTargetSelection ? (
+					<div className="flex items-center gap-2">
+						<span className="text-xs text-muted-foreground">Enabled</span>
+						<Switch
+							checked={effective}
+							disabled={saving || !target.enabled}
+							onCheckedChange={(enabled) => void onSave(target.id, { enabled })}
+						/>
+					</div>
+				) : null}
+			</CardHeader>
+			<CardContent className="space-y-3 pt-2">
+				<div className="divide-y text-sm">
+					<ConfigRow label="Model" tooltip="Which AI model this target covers.">
+						<span className="font-mono text-xs text-foreground">{target.model}</span>
+					</ConfigRow>
+					<ConfigRow label="Provider" tooltip="How this deployment reaches the model.">
+						<span className="font-mono text-xs text-foreground">{target.provider}</span>
+					</ConfigRow>
+					<ConfigRow label="Version" tooltip="Exact upstream model version requested from the provider.">
+						<span className="font-mono text-xs text-foreground">{target.version ?? "—"}</span>
+					</ConfigRow>
+					<ConfigRow label="Web search" tooltip="Whether web search is used for this target.">
+						{target.webSearch ? (
+							<IconCircleCheck className="h-4 w-4 text-emerald-600" />
+						) : (
+							<IconCircleX className="h-4 w-4 text-muted-foreground" />
+						)}
+					</ConfigRow>
+				</div>
+
+				{canManageRunPolicy && !target.requiresPromptAssignment && (
+					<div className="grid grid-cols-2 gap-2 border-t pt-3">
+						<div className="space-y-1">
+							<Label className="text-xs" htmlFor={`cadence-${target.id}`}>
+								Cadence (hours)
+							</Label>
+							<Input
+								id={`cadence-${target.id}`}
+								type="number"
+								min="1"
+								value={cadenceHours}
+								onChange={(event) => setCadenceHours(event.target.value)}
+								disabled={saving}
+							/>
+						</div>
+						<div className="space-y-1">
+							<Label className="text-xs" htmlFor={`samples-${target.id}`}>
+								Samples
+							</Label>
+							<Input
+								id={`samples-${target.id}`}
+								type="number"
+								min="1"
+								value={samplesPerDispatch}
+								onChange={(event) => setSamplesPerDispatch(event.target.value)}
+								disabled={saving}
+							/>
+						</div>
+						<div className="col-span-2 flex gap-2">
+							<Button type="button" size="sm" onClick={() => void save()} disabled={saving} className="cursor-pointer">
+								Save run settings
+							</Button>
+							{brandConfig && (
+								<Button
+									type="button"
+									size="sm"
+									variant="outline"
+									onClick={() => void reset()}
+									disabled={saving}
+									className="cursor-pointer"
+								>
+									Use inherited
+								</Button>
+							)}
+						</div>
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}
+
+function LoadingState() {
+	return (
+		<div className="space-y-6 max-w-6xl">
+			<div>
+				<h1 className="text-3xl font-bold">LLMs</h1>
+				<p className="text-muted-foreground">Loading...</p>
+			</div>
+			<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+				{[0, 1, 2].map((index) => (
+					<Card key={index} className="h-full">
+						<CardHeader className="py-2 border-b">
+							<Skeleton className="h-6 w-6 rounded" />
+						</CardHeader>
+						<CardContent className="pt-2 space-y-2">
+							<Skeleton className="h-4 w-full" />
+							<Skeleton className="h-4 w-3/4" />
+						</CardContent>
+					</Card>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function ConfigRow({ label, tooltip, children }: { label: string; tooltip: string; children: React.ReactNode }) {
 	return (
 		<div className="flex items-center justify-between py-2">
 			<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
 				<span>{label}</span>
-				{tooltip && (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<IconInfoCircle className="h-3.5 w-3.5 cursor-help" />
-						</TooltipTrigger>
-						<TooltipContent className="max-w-xs text-xs font-normal">{tooltip}</TooltipContent>
-					</Tooltip>
-				)}
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<IconInfoCircle className="h-3.5 w-3.5 cursor-help" />
+					</TooltipTrigger>
+					<TooltipContent className="max-w-xs text-xs font-normal">{tooltip}</TooltipContent>
+				</Tooltip>
 			</div>
 			<div className="flex items-center gap-2">{children}</div>
 		</div>

--- a/apps/web/src/routes/_authed/app/$brand/settings/prompts.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/settings/prompts.tsx
@@ -7,7 +7,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { getAppName, getBrandName, buildTitle } from "@/lib/route-head";
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
-import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
+import { requireAuthSession, requireBrandAccess } from "@/lib/auth/helpers";
 import { db } from "@workspace/lib/db/db";
 import { prompts } from "@workspace/lib/db/schema";
 import { eq, desc } from "drizzle-orm";
@@ -18,7 +18,7 @@ const getPromptsForEditing = createServerFn({ method: "GET" })
 	.validator(z.object({ brandId: z.string() }))
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		// Fetch all prompts (including disabled) for editing
 		const brandPrompts = await db

--- a/apps/web/src/server/admin.ts
+++ b/apps/web/src/server/admin.ts
@@ -8,17 +8,18 @@ import { requireAuthSession, isAdmin } from "@/lib/auth/helpers";
 import { db } from "@workspace/lib/db/db";
 import { brands, prompts, promptRuns } from "@workspace/lib/db/schema";
 import { eq, sql, desc } from "drizzle-orm";
-import {
-	getAdminRunsOverTime,
-	getAdminBrandRunStats,
-	getAdminActiveBrandsOverTime,
-} from "@/lib/postgres-read";
+import { getAdminRunsOverTime, getAdminBrandRunStats, getAdminActiveBrandsOverTime } from "@/lib/postgres-read";
 import { analyzeBrand } from "@workspace/lib/onboarding";
 import { getDefaultDelayHours } from "@workspace/lib/constants";
+import {
+	ensureEvaluationConfig,
+	getEffectiveEvaluationTargetsForBrand,
+	minimumCadenceHours,
+	updateEvaluationTargetScopeConfig,
+} from "@workspace/lib/evaluation-config";
 import { getModelOverdueStatus } from "@workspace/lib/overdue";
 import { sendImmediatePromptJob } from "@/lib/job-scheduler";
 import { Client } from "pg";
-import { parseScrapeTargets } from "@workspace/lib/providers";
 
 // ============================================================================
 // Admin guard helper
@@ -63,55 +64,49 @@ export const getAdminStatsFn = createServerFn({ method: "GET" }).handler(async (
 	const thirtyDaysAgo = new Date();
 	thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
-	const [
-		allBrands,
-		brandsOverTime,
-		promptsOverTime,
-		runsOverTimeData,
-		brandRunStats,
-		activeBrandsData,
-	] = await Promise.all([
-		db.query.brands.findMany({ orderBy: desc(brands.createdAt) }),
+	const [allBrands, brandsOverTime, promptsOverTime, runsOverTimeData, brandRunStats, activeBrandsData] =
+		await Promise.all([
+			db.query.brands.findMany({ orderBy: desc(brands.createdAt) }),
 
-		// Cumulative brand count over time (last 30 days)
-		db
-			.select({
-				date: sql<string>`date_series::date`,
-				count: sql<number>`COUNT(${brands.id})::int`,
-			})
-			.from(
-				sql`generate_series(
+			// Cumulative brand count over time (last 30 days)
+			db
+				.select({
+					date: sql<string>`date_series::date`,
+					count: sql<number>`COUNT(${brands.id})::int`,
+				})
+				.from(
+					sql`generate_series(
 					NOW()::date - INTERVAL '30 days',
 					NOW()::date,
 					INTERVAL '1 day'
 				) AS date_series`,
-			)
-			.leftJoin(brands, sql`${brands.createdAt}::date <= date_series::date`)
-			.groupBy(sql`date_series`)
-			.orderBy(sql`date_series`),
+				)
+				.leftJoin(brands, sql`${brands.createdAt}::date <= date_series::date`)
+				.groupBy(sql`date_series`)
+				.orderBy(sql`date_series`),
 
-		// Cumulative prompts count over time (enabled vs disabled)
-		db
-			.select({
-				date: sql<string>`date_series::date`,
-				enabled: sql<number>`COUNT(*) FILTER (WHERE ${prompts.enabled} = true)::int`,
-				disabled: sql<number>`COUNT(*) FILTER (WHERE ${prompts.enabled} = false)::int`,
-			})
-			.from(
-				sql`generate_series(
+			// Cumulative prompts count over time (enabled vs disabled)
+			db
+				.select({
+					date: sql<string>`date_series::date`,
+					enabled: sql<number>`COUNT(*) FILTER (WHERE ${prompts.enabled} = true)::int`,
+					disabled: sql<number>`COUNT(*) FILTER (WHERE ${prompts.enabled} = false)::int`,
+				})
+				.from(
+					sql`generate_series(
 					NOW()::date - INTERVAL '30 days',
 					NOW()::date,
 					INTERVAL '1 day'
 				) AS date_series`,
-			)
-			.leftJoin(prompts, sql`${prompts.createdAt}::date <= date_series::date`)
-			.groupBy(sql`date_series`)
-			.orderBy(sql`date_series`),
+				)
+				.leftJoin(prompts, sql`${prompts.createdAt}::date <= date_series::date`)
+				.groupBy(sql`date_series`)
+				.orderBy(sql`date_series`),
 
-		getAdminRunsOverTime(),
-		getAdminBrandRunStats(),
-		getAdminActiveBrandsOverTime(),
-	]);
+			getAdminRunsOverTime(),
+			getAdminBrandRunStats(),
+			getAdminActiveBrandsOverTime(),
+		]);
 
 	const brandRunStatsMap = new Map(brandRunStats.map((stat) => [stat.brand_id, stat]));
 
@@ -182,7 +177,16 @@ export const updateDelayOverrideFn = createServerFn({ method: "POST" })
 		}),
 	)
 	.handler(async ({ data }) => {
-		await requireAdmin();
+		const session = await requireAdmin();
+		await ensureEvaluationConfig();
+		await updateEvaluationTargetScopeConfig(
+			{ scope: "brand", brandId: data.brandId },
+			{ targetId: null, cadenceHours: data.delayOverrideHours },
+			session.user.id,
+		);
+
+		// Keep the legacy column in sync while older dashboards and API clients
+		// still read it. Scheduling always reads the scoped configuration above.
 		const result = await db
 			.update(brands)
 			.set({ delayOverrideHours: data.delayOverrideHours, updatedAt: new Date() })
@@ -540,6 +544,11 @@ export const getWorkflowDataFn = createServerFn({ method: "GET" }).handler(async
 
 	const allBrands = await db.query.brands.findMany({ orderBy: desc(brands.createdAt) });
 	const allPrompts = await db.query.prompts.findMany();
+	const effectiveTargetsByBrand = new Map(
+		await Promise.all(
+			allBrands.map(async (brand) => [brand.id, await getEffectiveEvaluationTargetsForBrand(brand.id)] as const),
+		),
+	);
 
 	const promptsByBrand: Record<string, typeof allPrompts> = {};
 	for (const prompt of allPrompts) {
@@ -586,14 +595,15 @@ export const getWorkflowDataFn = createServerFn({ method: "GET" }).handler(async
 
 	const brandSummaries = allBrands.map((brand) => {
 		const brandPrompts = promptsByBrand[brand.id] || [];
-		const delayHours = brand.delayOverrideHours ?? defaultDelayHours;
+		const targets = effectiveTargetsByBrand.get(brand.id) ?? [];
+		const delayHours = minimumCadenceHours(targets) ?? brand.delayOverrideHours ?? defaultDelayHours;
 		const runFrequencyMs = delayHours * 60 * 60 * 1000;
 
 		let overduePrompts = 0;
 		let onSchedulePrompts = 0;
 		let scheduledCount = 0;
 
-		const modelList = parseScrapeTargets(process.env.SCRAPE_TARGETS).map((t) => t.model);
+		const modelList = [...new Set(targets.map((target) => target.model))];
 		const promptStatuses = brandPrompts.map((prompt) => {
 			const lastRuns = lastRunsMap[prompt.id] || {};
 			const lastRunsByModel: Record<
@@ -783,7 +793,11 @@ export const getJobLogsFn = createServerFn({ method: "GET" })
 		if (job.output) {
 			try {
 				const output = typeof job.output === "string" ? JSON.parse(job.output) : job.output;
-				logs.push(job.state === "failed" ? `Error: ${JSON.stringify(output, null, 2)}` : `Output: ${JSON.stringify(output, null, 2)}`);
+				logs.push(
+					job.state === "failed"
+						? `Error: ${JSON.stringify(output, null, 2)}`
+						: `Output: ${JSON.stringify(output, null, 2)}`,
+				);
 			} catch {
 				logs.push(`Output: ${String(job.output)}`);
 			}

--- a/apps/web/src/server/analysis.ts
+++ b/apps/web/src/server/analysis.ts
@@ -15,7 +15,7 @@ import { db } from "@workspace/lib/db/db";
 import { brands } from "@workspace/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
-import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
+import { requireAuthSession, requireBrandAccess } from "@/lib/auth/helpers";
 import { generateDateRange, type LookbackPeriod } from "@/lib/chart-utils";
 import {
 	getBrandMentionTotals,
@@ -74,7 +74,7 @@ export const getShareOfVoiceFn = createServerFn({ method: "GET" })
 	)
 	.handler(async ({ data }): Promise<ShareOfVoiceResponse> => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		const { timezone, fromDateStr, toDateStr } = resolveRange(data.lookback as LookbackPeriod, data.timezone);
 

--- a/apps/web/src/server/brands.ts
+++ b/apps/web/src/server/brands.ts
@@ -4,7 +4,7 @@
  */
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
-import { requireAuthSession, requireOrgAccess, listUserOrganizations } from "@/lib/auth/helpers";
+import { requireAuthSession, requireBrandAccess, requireOrgAccess, listUserOrganizations } from "@/lib/auth/helpers";
 import { evaluateRequireCanCreateBrands } from "@/lib/auth/policies";
 import { getDeployment } from "@/lib/config/server";
 import { db } from "@workspace/lib/db/db";
@@ -15,36 +15,33 @@ import { MAX_COMPETITORS } from "@workspace/lib/constants";
 import { cleanAndValidateDomain } from "@/lib/domain-categories";
 import { validateWebsiteUrl } from "@/lib/brand-website";
 import { normalizeBrandUpdate } from "@/lib/brand-settings";
-import { parseScrapeTargets, selectTargetsForBrand } from "@workspace/lib/providers";
+import { getEffectiveEvaluationTargetsForBrand, minimumCadenceHours } from "@workspace/lib/evaluation-config";
 import type { ModelConfig } from "@workspace/lib/providers";
 
 /**
- * Deployment-configured models this brand actually runs, after applying
- * the brand's `enabledModels` override. The filter bar + LLMs info page +
- * any other UI that shows "which models is this brand tracking?" should
- * read from here instead of hardcoding a list — different deployments can
- * configure any arbitrary set of models via `SCRAPE_TARGETS`.
+ * Database-configured models this brand actually runs. The filter bar + LLMs
+ * info page + any other UI that shows "which models is this brand tracking?"
+ * should read from here instead of hardcoding a list.
  *
  * `effectiveModels` is the flat id list that most callers want; the full
  * `ModelConfig[]` (with provider, version, webSearch) is kept on the same
  * object for pages that render per-model metadata (e.g. settings/llms).
  */
-function computeEffectiveModels(brand: Brand): {
+async function computeEffectiveModels(brand: Brand): Promise<{
 	effectiveModels: string[];
 	effectiveModelConfigs: ModelConfig[];
-} {
+	effectiveCadenceHours?: number;
+}> {
 	try {
-		const configs = parseScrapeTargets(process.env.SCRAPE_TARGETS);
-		const effective = selectTargetsForBrand(configs, brand.enabledModels);
+		const effective = await getEffectiveEvaluationTargetsForBrand(brand.id);
 		return {
 			effectiveModels: effective.map((c) => c.model),
 			effectiveModelConfigs: effective,
+			effectiveCadenceHours: minimumCadenceHours(effective),
 		};
 	} catch {
-		// A misconfigured SCRAPE_TARGETS would already be surfacing via
-		// `validateScrapeTargets` at boot; here we'd rather degrade to empty
-		// lists than crash the brand fetch.
-		return { effectiveModels: [], effectiveModelConfigs: [] };
+		// A bad configuration should not make a brand inaccessible from the UI.
+		return { effectiveModels: [], effectiveModelConfigs: [], effectiveCadenceHours: undefined };
 	}
 }
 
@@ -63,10 +60,12 @@ function getDefaultBrandDomains(): string[] {
 // Helper functions (migrated from apps/web/src/lib/metadata.ts)
 // ============================================================================
 
-async function getBrandWithPromptsFromDb(
-	brandId: string,
-): Promise<
-	| (BrandWithPrompts & { effectiveModels: string[]; effectiveModelConfigs: ModelConfig[] })
+async function getBrandWithPromptsFromDb(brandId: string): Promise<
+	| (BrandWithPrompts & {
+			effectiveModels: string[];
+			effectiveModelConfigs: ModelConfig[];
+			effectiveCadenceHours?: number;
+	  })
 	| undefined
 > {
 	try {
@@ -86,7 +85,7 @@ async function getBrandWithPromptsFromDb(
 			...brand,
 			prompts: brandPrompts,
 			competitors: brandCompetitors,
-			...computeEffectiveModels(brand),
+			...(await computeEffectiveModels(brand)),
 		};
 	} catch (error) {
 		console.error("Error fetching brand with prompts:", error);
@@ -118,13 +117,16 @@ export const getBrands = createServerFn({ method: "GET" }).handler(async () => {
 		where: inArray(brands.organizationId, orgIds),
 	});
 
-	const brandsData = await Promise.all(
-		scopedBrands.map((brand) => getBrandWithPromptsFromDb(brand.id)),
-	);
+	const brandsData = await Promise.all(scopedBrands.map((brand) => getBrandWithPromptsFromDb(brand.id)));
 
 	return brandsData.filter(
-		(brand): brand is BrandWithPrompts & { effectiveModels: string[]; effectiveModelConfigs: ModelConfig[] } =>
-			brand !== undefined,
+		(
+			brand,
+		): brand is BrandWithPrompts & {
+			effectiveModels: string[];
+			effectiveModelConfigs: ModelConfig[];
+			effectiveCadenceHours?: number;
+		} => brand !== undefined,
 	);
 });
 
@@ -135,7 +137,7 @@ export const getBrand = createServerFn({ method: "GET" })
 	.validator(z.object({ brandId: z.string() }))
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		const brand = await getBrandWithPromptsFromDb(data.brandId);
 		if (!brand) {
@@ -260,7 +262,7 @@ export const updateBrandFn = createServerFn({ method: "POST" })
 	)
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		const normalized = normalizeBrandUpdate({
 			name: data.name,
@@ -293,7 +295,7 @@ export const getCompetitors = createServerFn({ method: "GET" })
 	.validator(z.object({ brandId: z.string() }))
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		return db.query.competitors.findMany({
 			where: eq(competitors.brandId, data.brandId),
@@ -318,7 +320,7 @@ export const updateCompetitors = createServerFn({ method: "POST" })
 	)
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		// Validate and clean domains
 		const cleanedCompetitors = data.competitors.map((c) => {
@@ -366,7 +368,7 @@ export const addDomainToBrandFn = createServerFn({ method: "POST" })
 	)
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		const domain = cleanAndValidateDomain(data.domain);
 		if (!domain) throw new Error(`Invalid domain: ${data.domain}`);
@@ -377,12 +379,7 @@ export const addDomainToBrandFn = createServerFn({ method: "POST" })
 				additionalDomains: sql`array_append(${brands.additionalDomains}, ${domain})`,
 				updatedAt: new Date(),
 			})
-			.where(
-				and(
-					eq(brands.id, data.brandId),
-					sql`NOT (${domain} = ANY(${brands.additionalDomains}))`,
-				),
-			)
+			.where(and(eq(brands.id, data.brandId), sql`NOT (${domain} = ANY(${brands.additionalDomains}))`))
 			.returning();
 
 		if (result) return result;
@@ -407,7 +404,7 @@ export const addDomainToCompetitorFn = createServerFn({ method: "POST" })
 	)
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		const existing = await db.query.competitors.findFirst({
 			where: and(eq(competitors.id, data.competitorId), eq(competitors.brandId, data.brandId)),
@@ -441,7 +438,7 @@ export const createCompetitorFromDomainFn = createServerFn({ method: "POST" })
 	)
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		const domain = cleanAndValidateDomain(data.domain);
 		if (!domain) throw new Error(`Invalid domain: ${data.domain}`);

--- a/apps/web/src/server/citations.ts
+++ b/apps/web/src/server/citations.ts
@@ -4,7 +4,7 @@
  */
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
-import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
+import { requireAuthSession, requireBrandAccess } from "@/lib/auth/helpers";
 import { db } from "@workspace/lib/db/db";
 import { brands, competitors, prompts, SYSTEM_TAGS } from "@workspace/lib/db/schema";
 import { eq, and } from "drizzle-orm";
@@ -24,8 +24,12 @@ import {
 	resolvePageType,
 	isGoogleSurfaceUrl,
 } from "@/lib/domain-categories";
-import { categorizeDomain as categorizeDomainShared, classifyUrl as classifyUrlShared } from "@/lib/domain-categories.server";
+import {
+	categorizeDomain as categorizeDomainShared,
+	classifyUrl as classifyUrlShared,
+} from "@/lib/domain-categories.server";
 import { buildGoogleModule, emptyGoogleModule } from "@/lib/google-module";
+import { getEffectiveEvaluationTargetsForBrand, minimumCadenceHours } from "@workspace/lib/evaluation-config";
 
 /**
  * Get citation statistics for a brand
@@ -41,22 +45,26 @@ export const getCitationsFn = createServerFn({ method: "GET" })
 	)
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		// Window: `data.days` calendar days ending today (inclusive), plus the
 		// contiguous equal-length previous window — all UTC (server-TZ independent).
 		// `dateRange` is reused for the trend charts so totals + charts span identically.
-		const { fromDateStr, toDateStr, prevFromDateStr, prevToDateStr, dateRange } = citationDateWindow(new Date(), data.days);
+		const { fromDateStr, toDateStr, prevFromDateStr, prevToDateStr, dateRange } = citationDateWindow(
+			new Date(),
+			data.days,
+		);
 		const timezone = "UTC";
 
 		// Get brand info, competitors, and all enabled prompts
-		const [brandResult, competitorsList, allPrompts] = await Promise.all([
+		const [brandResult, competitorsList, allPrompts, effectiveTargets] = await Promise.all([
 			db.select().from(brands).where(eq(brands.id, data.brandId)).limit(1),
 			db.select().from(competitors).where(eq(competitors.brandId, data.brandId)),
 			db
 				.select({ id: prompts.id, value: prompts.value, tags: prompts.tags, systemTags: prompts.systemTags })
 				.from(prompts)
 				.where(and(eq(prompts.brandId, data.brandId), eq(prompts.enabled, true))),
+			getEffectiveEvaluationTargetsForBrand(data.brandId),
 		]);
 
 		const primaryBrandDomain = extractDomain(brandResult[0]?.website || "");
@@ -83,9 +91,7 @@ export const getCitationsFn = createServerFn({ method: "GET" })
 		if (tagFilter.length > 0) {
 			const filterByBranded = tagFilter.includes(SYSTEM_TAGS.BRANDED);
 			const filterByUnbranded = tagFilter.includes(SYSTEM_TAGS.UNBRANDED);
-			const nonSystemFilterTags = tagFilter.filter(
-				(t) => t !== SYSTEM_TAGS.BRANDED && t !== SYSTEM_TAGS.UNBRANDED,
-			);
+			const nonSystemFilterTags = tagFilter.filter((t) => t !== SYSTEM_TAGS.BRANDED && t !== SYSTEM_TAGS.UNBRANDED);
 
 			const matchingPrompts = allPrompts.filter((p) => {
 				const systemTags = p.systemTags || [];
@@ -113,22 +119,62 @@ export const getCitationsFn = createServerFn({ method: "GET" })
 					totalCitations: 0,
 					uniqueDomains: 0,
 					categoryCounts: emptyCategoryCounts(),
-					domainDistribution: [] as { domain: string; count: number; category: CitationCategory; exampleTitle?: string; previousCount: number; changePercent: number | null }[],
-					specificUrls: [] as { url: string; title?: string; domain: string; count: number; category: CitationCategory; pageType: CitationPageType; avgPosition: number | null; promptCount: number; isNew: boolean }[],
+					domainDistribution: [] as {
+						domain: string;
+						count: number;
+						category: CitationCategory;
+						exampleTitle?: string;
+						previousCount: number;
+						changePercent: number | null;
+					}[],
+					specificUrls: [] as {
+						url: string;
+						title?: string;
+						domain: string;
+						count: number;
+						category: CitationCategory;
+						pageType: CitationPageType;
+						avgPosition: number | null;
+						promptCount: number;
+						isNew: boolean;
+					}[],
 					pageTypeDistribution: [] as { pageType: CitationPageType; count: number }[],
 					googleModule: emptyGoogleModule(),
 					availableTags,
 					citationTimeSeries: [] as ({ date: string } & Record<CitationCategory, number>)[],
 					pageTypeTimeSeries: [] as ({ date: string } & Record<CitationPageType, number>)[],
 					competitors: competitorSummary,
-				competitorOnlyPrompts: [] as { id: string; value: string; competitorCitationCount: number; uniqueCompetitors: number }[],
-				whatsChanged: {
-					newUrls: [] as { url: string; domain: string; count: number; promptCount: number; category: CitationCategory }[],
-					droppedUrls: [] as { url: string; domain: string; previousCount: number; currentCount: number; category: CitationCategory }[],
-					titleChanges: [] as { url: string; domain: string; currentTitle: string; previousTitle: string; category: CitationCategory }[],
-					newDomains: [] as { domain: string; count: number; category: CitationCategory }[],
-					droppedDomains: [] as { domain: string; previousCount: number; category: CitationCategory }[],
-				},
+					competitorOnlyPrompts: [] as {
+						id: string;
+						value: string;
+						competitorCitationCount: number;
+						uniqueCompetitors: number;
+					}[],
+					whatsChanged: {
+						newUrls: [] as {
+							url: string;
+							domain: string;
+							count: number;
+							promptCount: number;
+							category: CitationCategory;
+						}[],
+						droppedUrls: [] as {
+							url: string;
+							domain: string;
+							previousCount: number;
+							currentCount: number;
+							category: CitationCategory;
+						}[],
+						titleChanges: [] as {
+							url: string;
+							domain: string;
+							currentTitle: string;
+							previousTitle: string;
+							category: CitationCategory;
+						}[],
+						newDomains: [] as { domain: string; count: number; category: CitationCategory }[],
+						droppedDomains: [] as { domain: string; previousCount: number; category: CitationCategory }[],
+					},
 				};
 			}
 		}
@@ -170,7 +216,10 @@ export const getCitationsFn = createServerFn({ method: "GET" })
 		}
 
 		// Categorize and normalize specific URLs with new fields
-		const urlCounts = new Map<string, { count: number; title?: string; domain: string; positionSum: number; positionCount: number; promptCount: number }>();
+		const urlCounts = new Map<
+			string,
+			{ count: number; title?: string; domain: string; positionSum: number; positionCount: number; promptCount: number }
+		>();
 		for (const { url, domain, title, count, avg_position, prompt_count } of urlStats) {
 			if (isGoogleSurfaceUrl(url)) continue;
 			const normalizedUrl = normalizeUrl(url);
@@ -216,7 +265,10 @@ export const getCitationsFn = createServerFn({ method: "GET" })
 		// Domain distribution rebuilt from URL-level data: count + a per-domain
 		// category taken from its top-cited URL (so a domain that's mostly review
 		// articles reads as editorial rather than other), sorted by count.
-		const domainAgg = new Map<string, { count: number; category: CitationCategory; topCount: number; exampleTitle?: string }>();
+		const domainAgg = new Map<
+			string,
+			{ count: number; category: CitationCategory; topCount: number; exampleTitle?: string }
+		>();
 		for (const u of specificUrls) {
 			const cur = domainAgg.get(u.domain);
 			if (cur) {
@@ -252,9 +304,10 @@ export const getCitationsFn = createServerFn({ method: "GET" })
 			pageTypeCounts[u.pageType] += u.count;
 		}
 		const totalCitations = CITATION_CATEGORIES.reduce((s, c) => s + categoryCounts[c], 0);
-		const pageTypeDistribution = CITATION_PAGE_TYPES
-			.map((pageType) => ({ pageType, count: pageTypeCounts[pageType] }))
-			.filter((d) => d.count > 0);
+		const pageTypeDistribution = CITATION_PAGE_TYPES.map((pageType) => ({
+			pageType,
+			count: pageTypeCounts[pageType],
+		})).filter((d) => d.count > 0);
 
 		// Google AI Mode module: Shopping products (brand vs competitor) + search
 		// queries, each tied to the prompts that triggered them.
@@ -270,7 +323,7 @@ export const getCitationsFn = createServerFn({ method: "GET" })
 		// axes are classified at the URL level (surfaces excluded), so the trends
 		// match the breakdown above and show every category / page type. `dateRange`
 		// (the current window) was computed once up top so charts + totals stay aligned.
-		const cadenceHours = brandResult[0]?.delayOverrideHours;
+		const cadenceHours = minimumCadenceHours(effectiveTargets) ?? brandResult[0]?.delayOverrideHours;
 		// Classify each URL ONCE (from specificUrls) and reuse it here, keyed by the
 		// normalized URL. The per-(prompt,day) rows carry their own title, so
 		// re-classifying them could land an "other"-domain URL in a different category
@@ -312,7 +365,13 @@ export const getCitationsFn = createServerFn({ method: "GET" })
 			.slice(0, 10)
 			.map((u) => ({ url: u.url, domain: u.domain, count: u.count, promptCount: u.promptCount, category: u.category }));
 
-		const droppedUrls: { url: string; domain: string; previousCount: number; currentCount: number; category: CitationCategory }[] = [];
+		const droppedUrls: {
+			url: string;
+			domain: string;
+			previousCount: number;
+			currentCount: number;
+			category: CitationCategory;
+		}[] = [];
 		for (const [url, prevData] of prevUrlMap.entries()) {
 			if (prevData.count < MIN_COUNT_FOR_WHATS_CHANGED) continue;
 			const current = urlCounts.get(url);
@@ -330,7 +389,13 @@ export const getCitationsFn = createServerFn({ method: "GET" })
 		}
 		droppedUrls.sort((a, b) => b.previousCount - a.previousCount);
 
-		const titleChanges: { url: string; domain: string; currentTitle: string; previousTitle: string; category: CitationCategory }[] = [];
+		const titleChanges: {
+			url: string;
+			domain: string;
+			currentTitle: string;
+			previousTitle: string;
+			category: CitationCategory;
+		}[] = [];
 		for (const [url, currentData] of urlCounts.entries()) {
 			const prevData = prevUrlMap.get(url);
 			if (!prevData) continue;
@@ -363,9 +428,9 @@ export const getCitationsFn = createServerFn({ method: "GET" })
 		droppedDomains.sort((a, b) => b.previousCount - a.previousCount);
 
 		// Prompts with competitor citations but no brand citations (computed from already-fetched data)
-		const competitorDomainEntries = competitorsList.flatMap((c) =>
-			c.domains.map((d) => ({ domain: extractDomain(d), competitorId: c.id })),
-		).filter((e) => e.domain);
+		const competitorDomainEntries = competitorsList
+			.flatMap((c) => c.domains.map((d) => ({ domain: extractDomain(d), competitorId: c.id })))
+			.filter((e) => e.domain);
 
 		function resolveCompetitorId(citationDomain: string): string | undefined {
 			const normalized = extractDomain(citationDomain);
@@ -377,7 +442,10 @@ export const getCitationsFn = createServerFn({ method: "GET" })
 			return undefined;
 		}
 
-		const promptCitationFlags = new Map<string, { hasBrand: boolean; hasCompetitor: boolean; competitorCount: number; competitorIds: Set<string> }>();
+		const promptCitationFlags = new Map<
+			string,
+			{ hasBrand: boolean; hasCompetitor: boolean; competitorCount: number; competitorIds: Set<string> }
+		>();
 		for (const row of perPromptPages) {
 			const cat = categorizeDomain(row.domain);
 			let entry = promptCitationFlags.get(row.prompt_id);
@@ -399,7 +467,12 @@ export const getCitationsFn = createServerFn({ method: "GET" })
 			.map(([id, data]) => {
 				const prompt = promptLookup.get(id);
 				if (!prompt) return null;
-				return { id, value: prompt.value, competitorCitationCount: data.competitorCount, uniqueCompetitors: data.competitorIds.size };
+				return {
+					id,
+					value: prompt.value,
+					competitorCitationCount: data.competitorCount,
+					uniqueCompetitors: data.competitorIds.size,
+				};
 			})
 			.filter((p): p is NonNullable<typeof p> => p !== null)
 			.sort((a, b) => b.competitorCitationCount - a.competitorCitationCount);

--- a/apps/web/src/server/dashboard.ts
+++ b/apps/web/src/server/dashboard.ts
@@ -4,11 +4,16 @@
  */
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
-import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
+import { requireAuthSession, requireBrandAccess } from "@/lib/auth/helpers";
 import { db } from "@workspace/lib/db/db";
 import { prompts, competitors, brands } from "@workspace/lib/db/schema";
 import { eq, and, count } from "drizzle-orm";
-import { generateDateRange, applyPerPromptLVCF, applyPerPromptCitationLVCF, type LookbackPeriod } from "@/lib/chart-utils";
+import {
+	generateDateRange,
+	applyPerPromptLVCF,
+	applyPerPromptCitationLVCF,
+	type LookbackPeriod,
+} from "@/lib/chart-utils";
 import { getTimezoneLookbackRange, resolveTimezone } from "@/lib/timezone-utils";
 import {
 	getDashboardSummary,
@@ -16,8 +21,14 @@ import {
 	getPerPromptDailyCitationStats,
 } from "@/lib/postgres-read";
 import { getEffectiveBrandedStatus } from "@workspace/lib/tag-utils";
-import { type CitationCategory, extractDomain, toRoundedPercentages, emptyCategoryCounts } from "@/lib/domain-categories";
+import {
+	type CitationCategory,
+	extractDomain,
+	toRoundedPercentages,
+	emptyCategoryCounts,
+} from "@/lib/domain-categories";
 import { categorizeDomain } from "@/lib/domain-categories.server";
+import { getEffectiveEvaluationTargetsForBrand, minimumCadenceHours } from "@workspace/lib/evaluation-config";
 
 export interface VisibilityTimeSeriesPoint {
 	date: string;
@@ -56,7 +67,7 @@ export const getDashboardSummaryFn = createServerFn({ method: "GET" })
 	)
 	.handler(async ({ data }): Promise<DashboardSummaryResponse> => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		const lookbackParam = data.lookback as LookbackPeriod;
 		const timezone = resolveTimezone(data.timezone);
@@ -70,11 +81,25 @@ export const getDashboardSummaryFn = createServerFn({ method: "GET" })
 
 		// Get brand info, competitors, and prompts from PostgreSQL
 		const [brandResult, competitorsList, enabledPromptsResult, totalPromptsResult] = await Promise.all([
-			db.select({ name: brands.name, website: brands.website, additionalDomains: brands.additionalDomains, delayOverrideHours: brands.delayOverrideHours }).from(brands).where(eq(brands.id, data.brandId)).limit(1),
+			db
+				.select({
+					name: brands.name,
+					website: brands.website,
+					additionalDomains: brands.additionalDomains,
+					delayOverrideHours: brands.delayOverrideHours,
+				})
+				.from(brands)
+				.where(eq(brands.id, data.brandId))
+				.limit(1),
 			db.select().from(competitors).where(eq(competitors.brandId, data.brandId)),
-			db.select({ id: prompts.id, value: prompts.value, systemTags: prompts.systemTags, tags: prompts.tags })
-				.from(prompts).where(and(eq(prompts.brandId, data.brandId), eq(prompts.enabled, true))),
-			db.select({ count: count() }).from(prompts).where(and(eq(prompts.brandId, data.brandId), eq(prompts.enabled, true))),
+			db
+				.select({ id: prompts.id, value: prompts.value, systemTags: prompts.systemTags, tags: prompts.tags })
+				.from(prompts)
+				.where(and(eq(prompts.brandId, data.brandId), eq(prompts.enabled, true))),
+			db
+				.select({ count: count() })
+				.from(prompts)
+				.where(and(eq(prompts.brandId, data.brandId), eq(prompts.enabled, true))),
 		]);
 
 		const brandWebsite = brandResult[0]?.website || "";
@@ -89,10 +114,11 @@ export const getDashboardSummaryFn = createServerFn({ method: "GET" })
 			.filter((p) => getEffectiveBrandedStatus(p.systemTags || [], p.tags || []).isBranded)
 			.map((p) => p.id);
 
-		const [summaryResult, perPromptVisibility, perPromptCitations] = await Promise.all([
+		const [summaryResult, perPromptVisibility, perPromptCitations, effectiveTargets] = await Promise.all([
 			getDashboardSummary(data.brandId, fromDateStr, toDateStr, timezone, enabledPromptIds),
 			getPerPromptVisibilityTimeSeries(data.brandId, fromDateStr, toDateStr, timezone, enabledPromptIds),
 			getPerPromptDailyCitationStats(data.brandId, fromDateStr, toDateStr, timezone, enabledPromptIds),
+			getEffectiveEvaluationTargetsForBrand(data.brandId),
 		]);
 
 		// Process summary
@@ -116,7 +142,8 @@ export const getDashboardSummaryFn = createServerFn({ method: "GET" })
 		const totalQualifyingRuns = totalBrandedRuns + totalNonBrandedRuns;
 		const totalMentioned = totalBrandedMentioned + totalNonBrandedMentioned;
 		const averageVisibility = totalQualifyingRuns > 0 ? Math.round((totalMentioned / totalQualifyingRuns) * 100) : 0;
-		const nonBrandedVisibility = totalNonBrandedRuns > 0 ? Math.round((totalNonBrandedMentioned / totalNonBrandedRuns) * 100) : 0;
+		const nonBrandedVisibility =
+			totalNonBrandedRuns > 0 ? Math.round((totalNonBrandedMentioned / totalNonBrandedRuns) * 100) : 0;
 		const brandedVisibility = totalBrandedRuns > 0 ? Math.round((totalBrandedMentioned / totalBrandedRuns) * 100) : 100;
 
 		// Build visibility time series directly from LVCF-smoothed data (no rolling window needed)
@@ -135,7 +162,9 @@ export const getDashboardSummaryFn = createServerFn({ method: "GET" })
 		});
 
 		const smoothedCitations = applyPerPromptCitationLVCF(
-			perPromptCitations, dateRange, brandResult[0]?.delayOverrideHours,
+			perPromptCitations,
+			dateRange,
+			minimumCadenceHours(effectiveTargets) ?? brandResult[0]?.delayOverrideHours,
 			(domain: string) => categorizeDomain(domain, brandDomains, competitorDomains),
 		);
 		const citationTimeSeries: CitationTimeSeriesPoint[] = dateRange.map((date) => {

--- a/apps/web/src/server/evaluation-config.ts
+++ b/apps/web/src/server/evaluation-config.ts
@@ -1,0 +1,304 @@
+import { createServerFn } from "@tanstack/react-start";
+import {
+	createEvaluationTarget,
+	ensureEvaluationConfig,
+	getBrandOrganizationIdForEvaluation,
+	getEffectiveEvaluationTargetsForBrand,
+	getEvaluationEntitlementLimits,
+	listEvaluationScopeConfigsForBrand,
+	listEvaluationTargets,
+	updateEvaluationEntitlement,
+	updateEvaluationTarget,
+	updateEvaluationTargetScopeConfig,
+	type EvaluationScopeOwner,
+} from "@workspace/lib/evaluation-config";
+import { db } from "@workspace/lib/db/db";
+import { brands, prompts } from "@workspace/lib/db/schema";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import {
+	getOrgMemberRole,
+	isAdmin,
+	requireAuthSession,
+	requireBrandAccess,
+	requireOrgAccess,
+} from "@/lib/auth/helpers";
+import {
+	canEditEvaluationConfig,
+	canEditEvaluationEntitlements,
+	type EvaluationConfigAction,
+	type EvaluationConfigEditScope,
+	type OrganizationConfigRole,
+} from "@/lib/evaluation-config-policy";
+import { getDeployment } from "@/lib/config/server";
+
+const positiveNullable = z.number().int().positive().nullable().optional();
+
+async function requireEvaluationConfigAccess(input: {
+	userId: string;
+	isGlobalAdmin: boolean;
+	scope: EvaluationConfigEditScope;
+	organizationId?: string;
+	brandId?: string;
+	promptId?: string;
+	actions?: readonly EvaluationConfigAction[];
+}): Promise<{ organizationId?: string; brandId?: string; promptId?: string }> {
+	const deployment = getDeployment();
+	let organizationId = input.organizationId;
+	let brandId = input.brandId;
+	let promptId = input.promptId;
+
+	if (input.scope === "brand") {
+		if (!brandId) throw new Error("Brand ID is required");
+		organizationId = await getBrandOrganizationIdForEvaluation(brandId);
+		if (!organizationId) throw new Error("Brand not found");
+	}
+
+	if (input.scope === "prompt") {
+		if (!promptId) throw new Error("Prompt ID is required");
+		const [prompt] = await db
+			.select({ promptId: prompts.id, brandId: brands.id, organizationId: brands.organizationId })
+			.from(prompts)
+			.innerJoin(brands, eq(prompts.brandId, brands.id))
+			.where(eq(prompts.id, promptId))
+			.limit(1);
+		if (!prompt) throw new Error("Prompt not found");
+		brandId = prompt.brandId;
+		organizationId = prompt.organizationId;
+	}
+
+	let organizationRole: OrganizationConfigRole;
+	if (input.scope !== "instance") {
+		if (!organizationId) throw new Error("Organization ID is required");
+		organizationRole = (await getOrgMemberRole(input.userId, organizationId)) as OrganizationConfigRole;
+		if (!input.isGlobalAdmin && !organizationRole) {
+			throw new Error("Forbidden: No access to this organization");
+		}
+	}
+
+	const actions = input.actions?.length ? input.actions : (["target-selection"] as const);
+	if (
+		!actions.every((action) =>
+			canEditEvaluationConfig({
+				mode: deployment.mode,
+				isGlobalAdmin: input.isGlobalAdmin,
+				organizationRole,
+				scope: input.scope,
+				action,
+			}),
+		)
+	) {
+		throw new Error("Forbidden: You cannot edit evaluation configuration at this scope");
+	}
+
+	return { organizationId, brandId, promptId };
+}
+
+async function requireBrandConfigReadAccess(userId: string, isGlobalAdmin: boolean, brandId: string): Promise<string> {
+	const organizationId = await getBrandOrganizationIdForEvaluation(brandId);
+	if (!organizationId) throw new Error("Brand not found");
+	if (!isGlobalAdmin) await requireBrandAccess(userId, brandId);
+	return organizationId;
+}
+
+export const getBrandEvaluationConfigFn = createServerFn({ method: "GET" })
+	.validator(z.object({ brandId: z.string() }))
+	.handler(async ({ data }) => {
+		const session = await requireAuthSession();
+		const globalAdmin = isAdmin(session);
+		const organizationId = await requireBrandConfigReadAccess(session.user.id, globalAdmin, data.brandId);
+		await ensureEvaluationConfig();
+		const organizationRole = (await getOrgMemberRole(session.user.id, organizationId)) as OrganizationConfigRole;
+		const deployment = getDeployment();
+
+		const canManageBrandTargets = canEditEvaluationConfig({
+			mode: deployment.mode,
+			isGlobalAdmin: globalAdmin,
+			organizationRole,
+			scope: "brand",
+			action: "target-selection",
+		});
+		const canManageBrandRunPolicy = canEditEvaluationConfig({
+			mode: deployment.mode,
+			isGlobalAdmin: globalAdmin,
+			organizationRole,
+			scope: "brand",
+			action: "run-policy",
+		});
+		const canReadEvaluationConfiguration = canManageBrandTargets || canManageBrandRunPolicy;
+		const [targets, effectiveTargets, scopeConfigs, entitlements] = await Promise.all([
+			listEvaluationTargets(),
+			getEffectiveEvaluationTargetsForBrand(data.brandId),
+			canReadEvaluationConfiguration ? listEvaluationScopeConfigsForBrand(data.brandId) : Promise.resolve([]),
+			canReadEvaluationConfiguration ? getEvaluationEntitlementLimits(organizationId) : Promise.resolve(null),
+		]);
+		const effectiveTargetIds = new Set(effectiveTargets.map((target) => target.targetId));
+
+		return {
+			mode: deployment.mode,
+			targets: canManageBrandTargets ? targets : targets.filter((target) => effectiveTargetIds.has(target.id)),
+			effectiveTargets,
+			scopeConfigs,
+			entitlements,
+			canManageBrandTargets,
+			canManageBrandRunPolicy,
+			canManageInstance: canEditEvaluationConfig({
+				mode: deployment.mode,
+				isGlobalAdmin: globalAdmin,
+				organizationRole,
+				scope: "instance",
+				action: "catalog",
+			}),
+		};
+	});
+
+export const createEvaluationTargetFn = createServerFn({ method: "POST" })
+	.validator(
+		z.object({
+			model: z.string().trim().min(1).max(100),
+			provider: z.string().trim().min(1).max(100),
+			version: z.string().trim().min(1).max(300).nullable().optional(),
+			webSearch: z.boolean(),
+			requiresPromptAssignment: z.boolean().optional(),
+			defaultCadenceHours: z
+				.number()
+				.int()
+				.positive()
+				.max(24 * 365),
+			defaultSamplesPerDispatch: z.number().int().positive().max(100),
+			enabled: z.boolean().optional(),
+		}),
+	)
+	.handler(async ({ data }) => {
+		const session = await requireAuthSession();
+		await requireEvaluationConfigAccess({
+			userId: session.user.id,
+			isGlobalAdmin: isAdmin(session),
+			scope: "instance",
+			actions: ["catalog"],
+		});
+		return createEvaluationTarget(data, session.user.id);
+	});
+
+export const updateEvaluationTargetFn = createServerFn({ method: "POST" })
+	.validator(
+		z.object({
+			targetId: z.string(),
+			enabled: z.boolean().optional(),
+			requiresPromptAssignment: z.boolean().optional(),
+			defaultCadenceHours: z
+				.number()
+				.int()
+				.positive()
+				.max(24 * 365)
+				.optional(),
+			defaultSamplesPerDispatch: z.number().int().positive().max(100).optional(),
+		}),
+	)
+	.handler(async ({ data }) => {
+		const session = await requireAuthSession();
+		await requireEvaluationConfigAccess({
+			userId: session.user.id,
+			isGlobalAdmin: isAdmin(session),
+			scope: "instance",
+			actions: ["catalog", "run-policy"],
+		});
+		return updateEvaluationTarget(data, session.user.id);
+	});
+
+const scopePatchSchema = z.object({
+	targetId: z.string().nullable(),
+	enabled: z.boolean().nullable().optional(),
+	cadenceHours: positiveNullable,
+	samplesPerDispatch: positiveNullable,
+});
+
+function scopePatchActions(data: z.infer<typeof scopePatchSchema>): EvaluationConfigAction[] {
+	const actions: EvaluationConfigAction[] = [];
+	if (data.enabled !== undefined) actions.push("target-selection");
+	if (data.cadenceHours !== undefined || data.samplesPerDispatch !== undefined) actions.push("run-policy");
+	if (actions.length === 0) throw new Error("At least one evaluation configuration value is required");
+	return actions;
+}
+
+export const updateOrganizationEvaluationConfigFn = createServerFn({ method: "POST" })
+	.validator(z.object({ organizationId: z.string(), ...scopePatchSchema.shape }))
+	.handler(async ({ data }) => {
+		const session = await requireAuthSession();
+		const access = await requireEvaluationConfigAccess({
+			userId: session.user.id,
+			isGlobalAdmin: isAdmin(session),
+			scope: "organization",
+			organizationId: data.organizationId,
+			actions: scopePatchActions(data),
+		});
+		const owner: EvaluationScopeOwner = { scope: "organization", organizationId: access.organizationId! };
+		return updateEvaluationTargetScopeConfig(owner, data, session.user.id);
+	});
+
+export const updateBrandEvaluationConfigFn = createServerFn({ method: "POST" })
+	.validator(z.object({ brandId: z.string(), ...scopePatchSchema.shape }))
+	.handler(async ({ data }) => {
+		const session = await requireAuthSession();
+		const access = await requireEvaluationConfigAccess({
+			userId: session.user.id,
+			isGlobalAdmin: isAdmin(session),
+			scope: "brand",
+			brandId: data.brandId,
+			actions: scopePatchActions(data),
+		});
+		const owner: EvaluationScopeOwner = { scope: "brand", brandId: access.brandId! };
+		return updateEvaluationTargetScopeConfig(owner, data, session.user.id);
+	});
+
+export const updatePromptEvaluationConfigFn = createServerFn({ method: "POST" })
+	.validator(z.object({ promptId: z.string(), ...scopePatchSchema.shape }))
+	.handler(async ({ data }) => {
+		const session = await requireAuthSession();
+		const access = await requireEvaluationConfigAccess({
+			userId: session.user.id,
+			isGlobalAdmin: isAdmin(session),
+			scope: "prompt",
+			promptId: data.promptId,
+			actions: scopePatchActions(data),
+		});
+		const owner: EvaluationScopeOwner = { scope: "prompt", promptId: access.promptId! };
+		return updateEvaluationTargetScopeConfig(owner, data, session.user.id);
+	});
+
+export const updateEvaluationEntitlementFn = createServerFn({ method: "POST" })
+	.validator(
+		z.object({
+			scope: z.enum(["instance", "organization"]),
+			organizationId: z.string().optional(),
+			maxConfiguredTargets: z.number().int().nonnegative().nullable(),
+			maxConfiguredTargetsPerBrand: z.number().int().nonnegative().nullable(),
+			maxConfiguredTargetsPerPrompt: z.number().int().nonnegative().nullable(),
+			maxSamplesPerDispatch: z.number().int().nonnegative().nullable(),
+			maxRunsPerDay: z.number().int().nonnegative().nullable(),
+		}),
+	)
+	.handler(async ({ data }) => {
+		const session = await requireAuthSession();
+		const deployment = getDeployment();
+		const globalAdmin = isAdmin(session);
+		if (!canEditEvaluationEntitlements({ mode: deployment.mode, isGlobalAdmin: globalAdmin })) {
+			throw new Error("Forbidden: You cannot edit evaluation entitlements");
+		}
+		if (data.scope === "organization") {
+			if (!data.organizationId) throw new Error("Organization ID is required");
+			if (!globalAdmin) await requireOrgAccess(session.user.id, data.organizationId);
+		}
+		return updateEvaluationEntitlement(
+			data.scope,
+			{
+				maxConfiguredTargets: data.maxConfiguredTargets,
+				maxConfiguredTargetsPerBrand: data.maxConfiguredTargetsPerBrand,
+				maxConfiguredTargetsPerPrompt: data.maxConfiguredTargetsPerPrompt,
+				maxSamplesPerDispatch: data.maxSamplesPerDispatch,
+				maxRunsPerDay: data.maxRunsPerDay,
+			},
+			session.user.id,
+			data.organizationId,
+		);
+	});

--- a/apps/web/src/server/onboarding.ts
+++ b/apps/web/src/server/onboarding.ts
@@ -13,7 +13,7 @@
  */
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
-import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
+import { requireAuthSession, requireBrandAccess } from "@/lib/auth/helpers";
 import {
 	cancelAnalyzeBrand,
 	enqueueAnalyzeBrand,
@@ -44,7 +44,7 @@ export const startAnalyzeBrandFn = createServerFn({ method: "POST" })
 	)
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 		await enqueueAnalyzeBrand(data);
 		return { ok: true };
 	});
@@ -60,7 +60,7 @@ export const getAnalyzeBrandStatusFn = createServerFn({ method: "POST" })
 	.validator(z.object({ brandId: z.string().min(1) }))
 	.handler(async ({ data }): Promise<AnalyzeBrandStatus> => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 		return getAnalyzeBrandStatus(data.brandId);
 	});
 
@@ -69,7 +69,7 @@ export const cancelAnalyzeBrandFn = createServerFn({ method: "POST" })
 	.validator(z.object({ brandId: z.string().min(1) }))
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 		await cancelAnalyzeBrand(data.brandId);
 		return { ok: true };
 	});
@@ -82,6 +82,6 @@ export const updateOnboardedBrandFn = createServerFn({ method: "POST" })
 	.validator(wizardOnboardingInputSchema)
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 		return saveWizardOnboarding(data);
 	});

--- a/apps/web/src/server/opportunities.ts
+++ b/apps/web/src/server/opportunities.ts
@@ -22,7 +22,7 @@ import { brandOpportunities, brands, competitors } from "@workspace/lib/db/schem
 import { runStructuredCompletionPrompt } from "@workspace/lib/onboarding";
 import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
-import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
+import { requireAuthSession, requireBrandAccess } from "@/lib/auth/helpers";
 import { extractDomain } from "@/lib/domain-categories";
 import { categorizeDomain } from "@/lib/domain-categories.server";
 import {
@@ -473,7 +473,7 @@ export const getOpportunitiesFn = createServerFn({ method: "GET" })
 	.validator(z.object({ brandId: z.string(), timezone: z.string().default("UTC") }))
 	.handler(async ({ data }): Promise<OpportunitiesResponse> => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		// Serve the most recent stored report while it's fresh. Every generation is
 		// kept (append-only); we regenerate only when the latest is stale.

--- a/apps/web/src/server/prompts.ts
+++ b/apps/web/src/server/prompts.ts
@@ -4,7 +4,7 @@
  */
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
-import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
+import { requireAuthSession, requireBrandAccess } from "@/lib/auth/helpers";
 import { db } from "@workspace/lib/db/db";
 import { prompts, promptRuns, brands, competitors, SYSTEM_TAGS } from "@workspace/lib/db/schema";
 import { eq, and, desc, gte, count, sql } from "drizzle-orm";
@@ -42,7 +42,7 @@ export const getPromptMetadataFn = createServerFn({ method: "GET" })
 	.validator(z.object({ brandId: z.string(), promptId: z.string() }))
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		const prompt = await db.query.prompts.findFirst({
 			where: and(eq(prompts.id, data.promptId), eq(prompts.brandId, data.brandId)),
@@ -98,7 +98,7 @@ export const getPromptsSummaryFn = createServerFn({ method: "GET" })
 	)
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		// Get all prompts for the brand from DB
 		const allPrompts = await db
@@ -123,11 +123,21 @@ export const getPromptsSummaryFn = createServerFn({ method: "GET" })
 			const toDate = new Date();
 			const fromDate = new Date();
 			switch (lookbackParam) {
-				case "1w": fromDate.setDate(fromDate.getDate() - 7); break;
-				case "1m": fromDate.setMonth(fromDate.getMonth() - 1); break;
-				case "3m": fromDate.setMonth(fromDate.getMonth() - 3); break;
-				case "6m": fromDate.setMonth(fromDate.getMonth() - 6); break;
-				case "1y": fromDate.setFullYear(fromDate.getFullYear() - 1); break;
+				case "1w":
+					fromDate.setDate(fromDate.getDate() - 7);
+					break;
+				case "1m":
+					fromDate.setMonth(fromDate.getMonth() - 1);
+					break;
+				case "3m":
+					fromDate.setMonth(fromDate.getMonth() - 3);
+					break;
+				case "6m":
+					fromDate.setMonth(fromDate.getMonth() - 6);
+					break;
+				case "1y":
+					fromDate.setFullYear(fromDate.getFullYear() - 1);
+					break;
 			}
 			fromDateStr = fromDate.toISOString().split("T")[0];
 			toDateStr = toDate.toISOString().split("T")[0];
@@ -137,15 +147,7 @@ export const getPromptsSummaryFn = createServerFn({ method: "GET" })
 		const webSearchEnabled = data.webSearchEnabled != null ? data.webSearchEnabled === "true" : undefined;
 
 		const [summaryData, firstEvaluatedData] = await Promise.all([
-			getPromptsSummary(
-				data.brandId,
-				fromDateStr,
-				toDateStr,
-				timezone,
-				webSearchEnabled,
-				data.model,
-				promptIds,
-			),
+			getPromptsSummary(data.brandId, fromDateStr, toDateStr, timezone, webSearchEnabled, data.model, promptIds),
 			getPromptsFirstEvaluatedAt(data.brandId, promptIds),
 		]);
 
@@ -183,7 +185,9 @@ export const getPromptsSummaryFn = createServerFn({ method: "GET" })
 				brandMentionRate: stats ? Number(stats.brand_mention_rate) : 0,
 				competitorMentionRate: stats ? Number(stats.competitor_mention_rate) : 0,
 				averageWeightedMentions,
-				hasVisibilityData: totalRuns > 0 && (Number(stats?.brand_mention_rate || 0) > 0 || Number(stats?.competitor_mention_rate || 0) > 0),
+				hasVisibilityData:
+					totalRuns > 0 &&
+					(Number(stats?.brand_mention_rate || 0) > 0 || Number(stats?.competitor_mention_rate || 0) > 0),
 				lastRunAt: stats?.last_run_date ? new Date(stats.last_run_date) : null,
 				firstEvaluatedAt: firstEvalMap.get(p.id) ? new Date(firstEvalMap.get(p.id)!) : null,
 				tags: effectiveTags,
@@ -191,9 +195,8 @@ export const getPromptsSummaryFn = createServerFn({ method: "GET" })
 		});
 
 		// Apply tag filter
-		const filteredPrompts = tagFilter.length > 0
-			? promptSummaries.filter((p) => tagFilter.some((t) => p.tags.includes(t)))
-			: promptSummaries;
+		const filteredPrompts =
+			tagFilter.length > 0 ? promptSummaries.filter((p) => tagFilter.some((t) => p.tags.includes(t))) : promptSummaries;
 
 		// Sort by visibility data priority, then by weighted mentions, then alphabetically
 		const sortedPrompts = filteredPrompts.sort((a, b) => {
@@ -255,7 +258,7 @@ export const getPromptStatsFn = createServerFn({ method: "GET" })
 			.limit(1);
 
 		if (prompt.length === 0) throw new Error("Prompt not found");
-		await requireOrgAccess(session.user.id, prompt[0].brandId);
+		await requireBrandAccess(session.user.id, prompt[0].brandId);
 
 		const fromDate = new Date();
 		fromDate.setDate(fromDate.getDate() - data.days);
@@ -267,29 +270,28 @@ export const getPromptStatsFn = createServerFn({ method: "GET" })
 
 		// Run aggregation queries in parallel. Web-query stats used to be computed
 		// here too — the Web Queries tab now goes through getQueryFanoutFn instead.
-		const [mentionStatsResult, competitorMentionsResult] =
-			await Promise.all([
-				// Total runs + brand mentions
-				db
-					.select({
-						totalRuns: count(),
-						brandMentions: sql<number>`SUM(CASE WHEN ${promptRuns.brandMentioned} THEN 1 ELSE 0 END)`,
-					})
-					.from(promptRuns)
-					.where(and(eq(promptRuns.promptId, data.promptId), timeCondition)),
+		const [mentionStatsResult, competitorMentionsResult] = await Promise.all([
+			// Total runs + brand mentions
+			db
+				.select({
+					totalRuns: count(),
+					brandMentions: sql<number>`SUM(CASE WHEN ${promptRuns.brandMentioned} THEN 1 ELSE 0 END)`,
+				})
+				.from(promptRuns)
+				.where(and(eq(promptRuns.promptId, data.promptId), timeCondition)),
 
-				// Competitor mentions (separate to avoid unnest issues)
-				db
-					.select({ competitorsMentioned: promptRuns.competitorsMentioned })
-					.from(promptRuns)
-					.where(
-						and(
-							eq(promptRuns.promptId, data.promptId),
-							timeCondition,
-							sql`array_length(${promptRuns.competitorsMentioned}, 1) > 0`,
-						),
+			// Competitor mentions (separate to avoid unnest issues)
+			db
+				.select({ competitorsMentioned: promptRuns.competitorsMentioned })
+				.from(promptRuns)
+				.where(
+					and(
+						eq(promptRuns.promptId, data.promptId),
+						timeCondition,
+						sql`array_length(${promptRuns.competitorsMentioned}, 1) > 0`,
 					),
-			]);
+				),
+		]);
 
 		// ---- Process mention stats ----
 		const mentionData = mentionStatsResult[0];
@@ -308,7 +310,9 @@ export const getPromptStatsFn = createServerFn({ method: "GET" })
 
 			// Initialize all competitors with 0 counts
 			const competitorCounts: Record<string, number> = {};
-			allCompetitors.forEach((c) => { competitorCounts[c.name] = 0; });
+			allCompetitors.forEach((c) => {
+				competitorCounts[c.name] = 0;
+			});
 
 			// Tally competitor mentions
 			competitorMentionsResult.forEach((row: any) => {
@@ -352,8 +356,15 @@ export const getPromptStatsFn = createServerFn({ method: "GET" })
 		// Shopping module, and rebuild the domain distribution from the URL data.
 		let citationStats = undefined;
 		const [brandInfo, competitorsList] = await Promise.all([
-			db.select({ name: brands.name, website: brands.website, additionalDomains: brands.additionalDomains }).from(brands).where(eq(brands.id, prompt[0].brandId)).limit(1),
-			db.select({ id: competitors.id, name: competitors.name, domains: competitors.domains }).from(competitors).where(eq(competitors.brandId, prompt[0].brandId)),
+			db
+				.select({ name: brands.name, website: brands.website, additionalDomains: brands.additionalDomains })
+				.from(brands)
+				.where(eq(brands.id, prompt[0].brandId))
+				.limit(1),
+			db
+				.select({ id: competitors.id, name: competitors.name, domains: competitors.domains })
+				.from(competitors)
+				.where(eq(competitors.brandId, prompt[0].brandId)),
 		]);
 
 		const primaryBrandDomain = brandInfo[0] ? extractDomain(brandInfo[0].website) : "";
@@ -368,13 +379,22 @@ export const getPromptStatsFn = createServerFn({ method: "GET" })
 			// queries. Built from the raw URL rows (it picks out the Google surfaces);
 			// those same surfaces are excluded from the source mix below.
 			const googleModule = buildGoogleModule(
-				urlStats.map((u) => ({ prompt_id: data.promptId, url: u.url, domain: u.domain, title: u.title, count: u.count })),
+				urlStats.map((u) => ({
+					prompt_id: data.promptId,
+					url: u.url,
+					domain: u.domain,
+					title: u.title,
+					count: u.count,
+				})),
 				brandInfo[0]?.name ?? "",
 				competitorsList.map((c) => ({ id: c.id, name: c.name })),
 				() => prompt[0].value,
 			);
 
-			const urlCounts = new Map<string, { count: number; title?: string; domain: string; positionSum: number; positionCount: number }>();
+			const urlCounts = new Map<
+				string,
+				{ count: number; title?: string; domain: string; positionSum: number; positionCount: number }
+			>();
 			for (const { url, domain, title, count: cnt, avg_position } of urlStats) {
 				if (isGoogleSurfaceUrl(url)) continue;
 				const normalized = normalizeUrl(url);
@@ -396,7 +416,11 @@ export const getPromptStatsFn = createServerFn({ method: "GET" })
 				.map(([url, { count: cnt, title, domain, positionSum, positionCount }]) => {
 					const category = classifyUrl(domain, url, title, brandDomains, competitorDomains);
 					return {
-						url, title, domain, count: cnt, category,
+						url,
+						title,
+						domain,
+						count: cnt,
+						category,
 						pageType: resolvePageType(url, title, category),
 						avgPosition: positionCount > 0 ? Math.round((positionSum / positionCount) * 10) / 10 : null,
 					};
@@ -405,7 +429,10 @@ export const getPromptStatsFn = createServerFn({ method: "GET" })
 
 			// Domain distribution rebuilt from URL-level data, each domain taking its
 			// category from its top-cited URL (matches the brand-wide view).
-			const domainAgg = new Map<string, { count: number; category: (typeof specificUrls)[number]["category"]; topCount: number; exampleTitle?: string }>();
+			const domainAgg = new Map<
+				string,
+				{ count: number; category: (typeof specificUrls)[number]["category"]; topCount: number; exampleTitle?: string }
+			>();
 			for (const u of specificUrls) {
 				const cur = domainAgg.get(u.domain);
 				if (cur) {
@@ -430,9 +457,10 @@ export const getPromptStatsFn = createServerFn({ method: "GET" })
 				pageTypeCounts[u.pageType] += u.count;
 			}
 			const totalCitations = domainDistribution.reduce((s, d) => s + d.count, 0);
-			const pageTypeDistribution = CITATION_PAGE_TYPES
-				.map((pageType) => ({ pageType, count: pageTypeCounts[pageType] }))
-				.filter((d) => d.count > 0);
+			const pageTypeDistribution = CITATION_PAGE_TYPES.map((pageType) => ({
+				pageType,
+				count: pageTypeCounts[pageType],
+			})).filter((d) => d.count > 0);
 
 			if (totalCitations > 0) {
 				citationStats = {
@@ -476,7 +504,7 @@ export const getPromptRunsFn = createServerFn({ method: "GET" })
 		if (!prompt) throw new Error("Prompt not found");
 
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, prompt.brandId);
+		await requireBrandAccess(session.user.id, prompt.brandId);
 
 		const fromDate = new Date();
 		fromDate.setDate(fromDate.getDate() - data.days);
@@ -485,10 +513,7 @@ export const getPromptRunsFn = createServerFn({ method: "GET" })
 
 		const [runs, totalResult] = await Promise.all([
 			db.query.promptRuns.findMany({
-				where: and(
-					eq(promptRuns.promptId, data.promptId),
-					gte(promptRuns.createdAt, fromDate),
-				),
+				where: and(eq(promptRuns.promptId, data.promptId), gte(promptRuns.createdAt, fromDate)),
 				orderBy: desc(promptRuns.createdAt),
 				limit: data.limit,
 				offset,
@@ -527,7 +552,7 @@ export const updatePromptsFn = createServerFn({ method: "POST" })
 	)
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		const brand = await db.query.brands.findFirst({
 			where: eq(brands.id, data.brandId),
@@ -535,8 +560,7 @@ export const updatePromptsFn = createServerFn({ method: "POST" })
 		if (!brand) throw new Error("Brand not found");
 
 		const existingIds = new Set(
-			(await db.select({ id: prompts.id }).from(prompts).where(eq(prompts.brandId, data.brandId)))
-				.map((p) => p.id),
+			(await db.select({ id: prompts.id }).from(prompts).where(eq(prompts.brandId, data.brandId))).map((p) => p.id),
 		);
 
 		const saved = await db.transaction(async (tx) => {
@@ -599,7 +623,7 @@ export const getPromptChartDataFn = createServerFn({ method: "GET" })
 	)
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		const timezone = data.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
 		const lookbackParam = (data.lookback || "1m") as LookbackPeriod;
@@ -617,11 +641,21 @@ export const getPromptChartDataFn = createServerFn({ method: "GET" })
 			toDateStr = todayStr;
 			const fromDate = new Date(now);
 			switch (lookbackParam) {
-				case "1w": fromDate.setDate(fromDate.getDate() - 6); break;
-				case "1m": fromDate.setMonth(fromDate.getMonth() - 1); break;
-				case "3m": fromDate.setMonth(fromDate.getMonth() - 3); break;
-				case "6m": fromDate.setMonth(fromDate.getMonth() - 6); break;
-				case "1y": fromDate.setFullYear(fromDate.getFullYear() - 1); break;
+				case "1w":
+					fromDate.setDate(fromDate.getDate() - 6);
+					break;
+				case "1m":
+					fromDate.setMonth(fromDate.getMonth() - 1);
+					break;
+				case "3m":
+					fromDate.setMonth(fromDate.getMonth() - 3);
+					break;
+				case "6m":
+					fromDate.setMonth(fromDate.getMonth() - 6);
+					break;
+				case "1y":
+					fromDate.setFullYear(fromDate.getFullYear() - 1);
+					break;
 			}
 			fromDateStr = fromDate.toLocaleDateString("en-CA", { timeZone: timezone });
 			startDate = new Date(fromDateStr);
@@ -634,8 +668,11 @@ export const getPromptChartDataFn = createServerFn({ method: "GET" })
 
 		// Get metadata from DB
 		const [promptData, brandData, competitorsData] = await Promise.all([
-			db.select({ id: prompts.id, value: prompts.value, brandId: prompts.brandId })
-				.from(prompts).where(eq(prompts.id, data.promptId)).limit(1),
+			db
+				.select({ id: prompts.id, value: prompts.value, brandId: prompts.brandId })
+				.from(prompts)
+				.where(eq(prompts.id, data.promptId))
+				.limit(1),
 			db.select().from(brands).where(eq(brands.id, data.brandId)).limit(1),
 			db.select().from(competitors).where(eq(competitors.brandId, data.brandId)),
 		]);
@@ -689,7 +726,9 @@ export const getPromptChartDataFn = createServerFn({ method: "GET" })
 
 			if (totalRuns === 0) {
 				dataPoint[brand.id] = null;
-				sortedCompetitors.forEach((c) => { dataPoint[c.id] = null; });
+				sortedCompetitors.forEach((c) => {
+					dataPoint[c.id] = null;
+				});
 				return dataPoint;
 			}
 
@@ -773,7 +812,7 @@ export const getPromptWebQueryFn = createServerFn({ method: "GET" })
 	)
 	.handler(async ({ data }) => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		const timezone = data.timezone || "UTC";
 		const now = new Date();
@@ -784,22 +823,26 @@ export const getPromptWebQueryFn = createServerFn({ method: "GET" })
 		if (data.lookback && data.lookback !== "all") {
 			const fromDate = new Date(now);
 			switch (data.lookback) {
-				case "1w": fromDate.setDate(fromDate.getDate() - 6); break;
-				case "1m": fromDate.setMonth(fromDate.getMonth() - 1); break;
-				case "3m": fromDate.setMonth(fromDate.getMonth() - 3); break;
-				case "6m": fromDate.setMonth(fromDate.getMonth() - 6); break;
-				case "1y": fromDate.setFullYear(fromDate.getFullYear() - 1); break;
+				case "1w":
+					fromDate.setDate(fromDate.getDate() - 6);
+					break;
+				case "1m":
+					fromDate.setMonth(fromDate.getMonth() - 1);
+					break;
+				case "3m":
+					fromDate.setMonth(fromDate.getMonth() - 3);
+					break;
+				case "6m":
+					fromDate.setMonth(fromDate.getMonth() - 6);
+					break;
+				case "1y":
+					fromDate.setFullYear(fromDate.getFullYear() - 1);
+					break;
 			}
 			fromDateStr = fromDate.toLocaleDateString("en-CA", { timeZone: timezone });
 		}
 
-		const webQueryData = await getPromptWebQueryCounts(
-			data.promptId,
-			fromDateStr,
-			toDateStr,
-			timezone,
-			data.model,
-		);
+		const webQueryData = await getPromptWebQueryCounts(data.promptId, fromDateStr, toDateStr, timezone, data.model);
 
 		let webQuery: string | null = null;
 		const modelWebQueries: Record<string, string> = {};

--- a/apps/web/src/server/query-fanout.ts
+++ b/apps/web/src/server/query-fanout.ts
@@ -13,7 +13,7 @@ import { db } from "@workspace/lib/db/db";
 import { brands } from "@workspace/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
-import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
+import { requireAuthSession, requireBrandAccess } from "@/lib/auth/helpers";
 import type { LookbackPeriod } from "@/lib/chart-utils";
 import { LOOKBACK, resolveRange } from "@/server/analysis";
 import { getFanoutBreakdown, getFanoutModelTotals, getFanoutPromptTotals } from "@/lib/postgres-read";
@@ -60,7 +60,7 @@ export const getQueryFanoutFn = createServerFn({ method: "GET" })
 	)
 	.handler(async ({ data }): Promise<QueryFanoutResponse> => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		const { timezone, fromDateStr, toDateStr } = resolveRange(data.lookback as LookbackPeriod, data.timezone);
 		const model = data.model;

--- a/apps/web/src/server/team.ts
+++ b/apps/web/src/server/team.ts
@@ -12,7 +12,7 @@ import { db } from "@workspace/lib/db/db";
 import { invitation, member, user } from "@workspace/lib/db/schema";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
-import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
+import { getBrandOrganizationId, requireAuthSession, requireBrandAccess } from "@/lib/auth/helpers";
 import { auth } from "@/lib/auth/server";
 import { getDeployment } from "@/lib/config/server";
 
@@ -36,7 +36,9 @@ export const listTeamFn = createServerFn({ method: "GET" })
 	.handler(async ({ data }): Promise<TeamData> => {
 		requireTeamInvites();
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
+		const organizationId = await getBrandOrganizationId(data.brandId);
+		if (!organizationId) throw new Error("Brand not found");
 
 		const members = await db
 			.select({
@@ -49,7 +51,7 @@ export const listTeamFn = createServerFn({ method: "GET" })
 			})
 			.from(member)
 			.innerJoin(user, eq(member.userId, user.id))
-			.where(eq(member.organizationId, data.brandId));
+			.where(eq(member.organizationId, organizationId));
 
 		const invitations = await db
 			.select({
@@ -59,7 +61,7 @@ export const listTeamFn = createServerFn({ method: "GET" })
 				expiresAt: invitation.expiresAt,
 			})
 			.from(invitation)
-			.where(and(eq(invitation.organizationId, data.brandId), eq(invitation.status, "pending")));
+			.where(and(eq(invitation.organizationId, organizationId), eq(invitation.status, "pending")));
 
 		return { members, invitations, currentUserId: session.user.id };
 	});
@@ -75,10 +77,12 @@ export const inviteTeamMemberFn = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		requireTeamInvites();
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
+		const organizationId = await getBrandOrganizationId(data.brandId);
+		if (!organizationId) throw new Error("Brand not found");
 
 		await auth.api.createInvitation({
-			body: { email: data.email, role: data.role, organizationId: data.brandId },
+			body: { email: data.email, role: data.role, organizationId },
 			headers: getRequestHeaders(),
 		});
 
@@ -90,7 +94,16 @@ export const cancelInvitationFn = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		requireTeamInvites();
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
+		const organizationId = await getBrandOrganizationId(data.brandId);
+		if (!organizationId) throw new Error("Brand not found");
+
+		const [pendingInvitation] = await db
+			.select({ id: invitation.id })
+			.from(invitation)
+			.where(and(eq(invitation.id, data.invitationId), eq(invitation.organizationId, organizationId)))
+			.limit(1);
+		if (!pendingInvitation) throw new Error("Invitation not found");
 
 		await auth.api.cancelInvitation({
 			body: { invitationId: data.invitationId },
@@ -105,19 +118,21 @@ export const removeTeamMemberFn = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		requireTeamInvites();
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
+		const organizationId = await getBrandOrganizationId(data.brandId);
+		if (!organizationId) throw new Error("Brand not found");
 
 		const [row] = await db
 			.select({ userId: member.userId })
 			.from(member)
-			.where(and(eq(member.id, data.memberId), eq(member.organizationId, data.brandId)))
+			.where(and(eq(member.id, data.memberId), eq(member.organizationId, organizationId)))
 			.limit(1);
 		if (row?.userId === session.user.id) {
 			throw new Error("You cannot remove yourself from the team");
 		}
 
 		await auth.api.removeMember({
-			body: { memberIdOrEmail: data.memberId, organizationId: data.brandId },
+			body: { memberIdOrEmail: data.memberId, organizationId },
 			headers: getRequestHeaders(),
 		});
 

--- a/apps/web/src/server/visibility.ts
+++ b/apps/web/src/server/visibility.ts
@@ -6,7 +6,7 @@
  */
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
-import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
+import { requireAuthSession, requireBrandAccess } from "@/lib/auth/helpers";
 import { db } from "@workspace/lib/db/db";
 import { brands, competitors } from "@workspace/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -72,7 +72,7 @@ export const getBatchChartDataFn = createServerFn({ method: "GET" })
 	)
 	.handler(async ({ data }): Promise<BatchChartDataResponse> => {
 		const session = await requireAuthSession();
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		const timezone = resolveTimezone(data.timezone);
 		const lookbackParam = data.lookback as LookbackPeriod;
@@ -93,11 +93,7 @@ export const getBatchChartDataFn = createServerFn({ method: "GET" })
 
 		// Get brand and competitors from PostgreSQL
 		const [brandResult, competitorsResult] = await Promise.all([
-			db
-				.select({ id: brands.id, name: brands.name })
-				.from(brands)
-				.where(eq(brands.id, data.brandId))
-				.limit(1),
+			db.select({ id: brands.id, name: brands.name }).from(brands).where(eq(brands.id, data.brandId)).limit(1),
 			db
 				.select({ id: competitors.id, name: competitors.name })
 				.from(competitors)
@@ -158,7 +154,7 @@ export const getFilteredVisibilityFn = createServerFn({ method: "GET" })
 		const session = await requireAuthSession();
 		const lookbackParam = data.lookback as LookbackPeriod;
 
-		await requireOrgAccess(session.user.id, data.brandId);
+		await requireBrandAccess(session.user.id, data.brandId);
 
 		// Resolve the in-scope prompts server-side from the filter criteria so
 		// the client never ships the full prompt-id list (issue #68).
@@ -191,22 +187,12 @@ export const getFilteredVisibilityFn = createServerFn({ method: "GET" })
 		// the visibility bar matches the chart section. Every other lookback
 		// already returns concrete bounds, so we can destructure without
 		// null-checking.
-		const { fromDateStr: fromDate, toDateStr: toDate } = getTimezoneLookbackRange(
-			lookbackParam,
-			timezone,
-			{ allStrategy: "1y" },
-		) as { fromDateStr: string; toDateStr: string };
+		const { fromDateStr: fromDate, toDateStr: toDate } = getTimezoneLookbackRange(lookbackParam, timezone, {
+			allStrategy: "1y",
+		}) as { fromDateStr: string; toDateStr: string };
 
 		const [daily, totalCitations] = await Promise.all([
-			getVisibilityDailyAggregate(
-				data.brandId,
-				fromDate,
-				toDate,
-				timezone,
-				promptIds,
-				brandedPromptIds,
-				data.model,
-			),
+			getVisibilityDailyAggregate(data.brandId, fromDate, toDate, timezone, promptIds, brandedPromptIds, data.model),
 			getCitationsTotalCount(data.brandId, fromDate, toDate, timezone, promptIds, data.model),
 		]);
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/node";
 import { getDeployment } from "@workspace/deployment";
-import { getProvider, parseScrapeTargets, validateScrapeTargets } from "@workspace/lib/providers";
+import { ensureEvaluationConfig, validateConfiguredEvaluationTargets } from "@workspace/lib/evaluation-config";
 import boss from "./boss";
 import { registerHandlers } from "./handlers";
 import { shutdownTelemetry } from "./telemetry";
@@ -16,10 +16,9 @@ if (process.env.SENTRY_DSN) {
 async function main() {
 	console.log("Starting pg-boss worker...");
 
-	// Fail fast on misconfigured SCRAPE_TARGETS — surfaces unknown providers,
-	// missing API keys, and per-provider target errors before any job runs.
-	validateScrapeTargets(parseScrapeTargets(process.env.SCRAPE_TARGETS), getProvider);
-	console.log("SCRAPE_TARGETS validated");
+	const bootstrap = await ensureEvaluationConfig();
+	await validateConfiguredEvaluationTargets();
+	console.log(`Evaluation configuration validated (${bootstrap.status})`);
 
 	boss.on("error", (error) => {
 		console.error("pg-boss error:", error);
@@ -70,21 +69,11 @@ async function main() {
 	}
 	console.log("Queues created");
 
-	await boss.schedule(
-		"schedule-maintenance",
-		"*/5 * * * *",
-		{ source: "scheduled" },
-		{ tz: "UTC" },
-	);
+	await boss.schedule("schedule-maintenance", "*/5 * * * *", { source: "scheduled" }, { tz: "UTC" });
 	console.log("Scheduled maintenance job (every 5 minutes)");
 
 	if (process.env.DEPLOYMENT_MODE === "whitelabel") {
-		await boss.schedule(
-			"sync-auth0-memberships",
-			"*/15 * * * *",
-			{ source: "scheduled" },
-			{ tz: "UTC" },
-		);
+		await boss.schedule("sync-auth0-memberships", "*/15 * * * *", { source: "scheduled" }, { tz: "UTC" });
 		console.log("Scheduled Auth0 membership sync (every 15 minutes)");
 	}
 

--- a/apps/worker/src/jobs/process-prompt.ts
+++ b/apps/worker/src/jobs/process-prompt.ts
@@ -1,16 +1,23 @@
 import * as Sentry from "@sentry/node";
 import type { Job } from "pg-boss";
 import { db } from "@workspace/lib/db/db";
-import { brands, citations, competitors, promptRuns, prompts, type Brand, type Competitor } from "@workspace/lib/db/schema";
-import { eq } from "drizzle-orm";
-import { RUNS_PER_PROMPT, getDefaultDelayHours } from "@workspace/lib/constants";
 import {
-	getProvider,
-	parseScrapeTargets,
-	selectTargetsForBrand,
-	type ModelConfig,
-	type Provider,
-} from "@workspace/lib/providers";
+	brands,
+	citations,
+	competitors,
+	promptRuns,
+	prompts,
+	type Brand,
+	type Competitor,
+} from "@workspace/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { getDefaultDelayHours } from "@workspace/lib/constants";
+import {
+	getEffectiveEvaluationTargetsForPrompt,
+	getPromptCadenceHours,
+	type EffectiveEvaluationTarget,
+} from "@workspace/lib/evaluation-config";
+import { getProvider, type Provider } from "@workspace/lib/providers";
 import type { Citation } from "@workspace/lib/text-extraction";
 import boss from "../boss";
 import { trackWorkerEvent } from "../telemetry";
@@ -58,6 +65,9 @@ async function scheduleNextRun(promptId: string, cadenceHours: number): Promise<
  */
 async function getCadenceHours(promptId: string): Promise<number> {
 	const defaultDelayHours = getDefaultDelayHours();
+	const configuredCadenceHours = await getPromptCadenceHours(promptId);
+	if (configuredCadenceHours !== undefined) return configuredCadenceHours;
+
 	const prompt = await db.query.prompts.findFirst({
 		where: eq(prompts.id, promptId),
 	});
@@ -128,16 +138,13 @@ function analyzeMentions(
 		...(brand.additionalDomains || []).map(extractDomainFromUrl),
 	];
 	const brandMentioned =
-		brandNames.some((n) => contentLower.includes(n)) ||
-		brandDomains.some((d) => contentLower.includes(d));
+		brandNames.some((n) => contentLower.includes(n)) || brandDomains.some((d) => contentLower.includes(d));
 
 	const competitorsMentioned = competitorsList
 		.filter((competitor) => {
 			const names = [competitor.name, ...(competitor.aliases || [])].map((n) => n.toLowerCase());
 			const nameMatch = names.some((n) => contentLower.includes(n));
-			const domainMatch = (competitor.domains || []).some((d) =>
-				contentLower.includes(extractDomainFromUrl(d)),
-			);
+			const domainMatch = (competitor.domains || []).some((d) => contentLower.includes(extractDomainFromUrl(d)));
 			return nameMatch || domainMatch;
 		})
 		.map((competitor) => competitor.name);
@@ -148,6 +155,7 @@ function analyzeMentions(
 async function savePromptRun(
 	promptId: string,
 	brandId: string,
+	evaluationTargetId: string,
 	model: string,
 	provider: string | null,
 	version: string,
@@ -162,6 +170,7 @@ async function savePromptRun(
 		.values({
 			promptId,
 			brandId,
+			evaluationTargetId,
 			model,
 			provider,
 			version,
@@ -201,7 +210,6 @@ async function saveCitations(
 	);
 }
 
-
 async function runModelIteration({
 	promptId,
 	promptValue,
@@ -215,7 +223,7 @@ async function runModelIteration({
 	promptValue: string;
 	brand: Brand;
 	competitorsList: Competitor[];
-	config: ModelConfig;
+	config: EffectiveEvaluationTarget;
 	providerImpl: Provider;
 	runIndex: number;
 }): Promise<void> {
@@ -244,6 +252,7 @@ async function runModelIteration({
 		const { id: promptRunId, createdAt } = await savePromptRun(
 			promptId,
 			brand.id,
+			config.targetId,
 			config.model,
 			config.provider,
 			recordedVersion,
@@ -276,8 +285,6 @@ async function runModelIteration({
  * After successful completion, schedules the next run.
  */
 export async function processPromptJob(jobs: Job<ProcessPromptData>[]): Promise<void> {
-	const scrapeConfigs = parseScrapeTargets(process.env.SCRAPE_TARGETS);
-
 	// pg-boss v12 passes an array of jobs - process each one
 	for (const job of jobs) {
 		const { promptId, cadenceHours: providedCadence } = job.data;
@@ -303,9 +310,10 @@ export async function processPromptJob(jobs: Job<ProcessPromptData>[]): Promise<
 			continue;
 		}
 
-		const selectedConfigs = selectTargetsForBrand(scrapeConfigs, brand.enabledModels);
-		if (selectedConfigs.length === 0) {
-			console.log(`Prompt ${promptId} for brand ${brand.id} has no targets (brand.enabledModels=[])`);
+		const selectedTargets = await getEffectiveEvaluationTargetsForPrompt(promptId);
+		if (selectedTargets.length === 0) {
+			console.log(`Prompt ${promptId} for brand ${brand.id} has no effective evaluation targets`);
+			continue;
 		}
 
 		console.log(`Processing prompt "${prompt.value}" for brand "${brand.name}"`);
@@ -313,9 +321,9 @@ export async function processPromptJob(jobs: Job<ProcessPromptData>[]): Promise<
 		// Run all model iterations in parallel
 		const runPromises: Promise<void>[] = [];
 
-		for (const config of selectedConfigs) {
+		for (const config of selectedTargets) {
 			const providerImpl = getProvider(config.provider);
-			for (let i = 0; i < RUNS_PER_PROMPT; i++) {
+			for (let i = 0; i < config.samplesPerDispatch; i++) {
 				runPromises.push(
 					runModelIteration({
 						promptId,
@@ -352,14 +360,15 @@ export async function processPromptJob(jobs: Job<ProcessPromptData>[]): Promise<
 
 		trackWorkerEvent("prompt_processed", {
 			brand_id: brand.id,
-			models: [...new Set(selectedConfigs.map((c) => c.model))],
-			providers: [...new Set(selectedConfigs.map((c) => c.provider))],
+			models: [...new Set(selectedTargets.map((c) => c.model))],
+			providers: [...new Set(selectedTargets.map((c) => c.provider))],
 			total_runs: runPromises.length,
 			successful_runs: successCount,
 			failed_runs: failures.length,
 		});
 
 		// Schedule the next run
-		await scheduleNextRun(promptId, cadenceHours);
+		const nextCadenceHours = Math.min(...selectedTargets.map((target) => target.cadenceHours));
+		await scheduleNextRun(promptId, nextCadenceHours);
 	}
 }

--- a/apps/worker/src/jobs/process-prompt.ts
+++ b/apps/worker/src/jobs/process-prompt.ts
@@ -10,11 +10,15 @@ import {
 	type Brand,
 	type Competitor,
 } from "@workspace/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { getDefaultDelayHours } from "@workspace/lib/constants";
 import {
 	getEffectiveEvaluationTargetsForPrompt,
+	getEvaluationConfigurationVersion,
 	getPromptCadenceHours,
+	mapLastRunsToEffectiveTargets,
+	minimumCadenceHours,
+	selectDueEvaluationTargets,
 	type EffectiveEvaluationTarget,
 } from "@workspace/lib/evaluation-config";
 import { getProvider, type Provider } from "@workspace/lib/providers";
@@ -25,6 +29,8 @@ import { trackWorkerEvent } from "../telemetry";
 export interface ProcessPromptData {
 	promptId: string;
 	cadenceHours?: number; // Hours until next run (for self-rescheduling)
+	configurationVersion?: number;
+	force?: boolean; // An explicit admin run may bypass cadence checks.
 }
 
 interface PromptContext {
@@ -36,13 +42,13 @@ interface PromptContext {
 /**
  * Schedule the next run for a prompt after the specified cadence.
  */
-async function scheduleNextRun(promptId: string, cadenceHours: number): Promise<void> {
+async function scheduleNextRun(promptId: string, cadenceHours: number, configurationVersion?: number): Promise<void> {
 	const startAfterSeconds = cadenceHours * 60 * 60;
 
 	try {
 		await boss.send(
 			"process-prompt",
-			{ promptId, cadenceHours },
+			{ promptId, cadenceHours, configurationVersion },
 			{
 				singletonKey: `prompt-${promptId}`,
 				singletonSeconds: startAfterSeconds, // Prevent duplicates for the cadence period
@@ -111,6 +117,26 @@ async function getPromptContext(promptId: string): Promise<PromptContext | null>
 		brand,
 		competitors: brandCompetitors,
 	};
+}
+
+async function getLastRunByTargetId(
+	promptId: string,
+	targets: readonly EffectiveEvaluationTarget[],
+): Promise<Map<string, Date>> {
+	const history = await db
+		.select({
+			evaluationTargetId: promptRuns.evaluationTargetId,
+			model: promptRuns.model,
+			lastRunAt: sql<Date>`MAX(${promptRuns.createdAt})`.as("last_run_at"),
+		})
+		.from(promptRuns)
+		.where(eq(promptRuns.promptId, promptId))
+		.groupBy(promptRuns.evaluationTargetId, promptRuns.model);
+
+	return mapLastRunsToEffectiveTargets(
+		targets,
+		history.map((run) => ({ ...run, lastRunAt: new Date(run.lastRunAt) })),
+	);
 }
 
 function extractDomainFromUrl(urlOrDomain: string): string {
@@ -287,7 +313,12 @@ async function runModelIteration({
 export async function processPromptJob(jobs: Job<ProcessPromptData>[]): Promise<void> {
 	// pg-boss v12 passes an array of jobs - process each one
 	for (const job of jobs) {
-		const { promptId, cadenceHours: providedCadence } = job.data;
+		const {
+			promptId,
+			cadenceHours: providedCadence,
+			configurationVersion: queuedConfigurationVersion,
+			force = false,
+		} = job.data;
 		console.log(`Processing prompt ${promptId}`);
 
 		// Get cadence hours - use provided value or look it up
@@ -315,13 +346,28 @@ export async function processPromptJob(jobs: Job<ProcessPromptData>[]): Promise<
 			console.log(`Prompt ${promptId} for brand ${brand.id} has no effective evaluation targets`);
 			continue;
 		}
+		const configurationVersion = await getEvaluationConfigurationVersion();
+		const uniformCadence = new Set(selectedTargets.map((target) => target.cadenceHours)).size <= 1;
+		const mustCheckDueHistory =
+			!uniformCadence ||
+			(queuedConfigurationVersion !== undefined && queuedConfigurationVersion !== configurationVersion);
+		const dueTargets =
+			force || !mustCheckDueHistory
+				? selectedTargets
+				: selectDueEvaluationTargets(selectedTargets, await getLastRunByTargetId(promptId, selectedTargets));
+		const nextCadenceHours = minimumCadenceHours(selectedTargets);
+		if (dueTargets.length === 0) {
+			console.log(`Prompt ${promptId} has no targets due at this firing`);
+			if (nextCadenceHours !== undefined) await scheduleNextRun(promptId, nextCadenceHours, configurationVersion);
+			continue;
+		}
 
 		console.log(`Processing prompt "${prompt.value}" for brand "${brand.name}"`);
 
 		// Run all model iterations in parallel
 		const runPromises: Promise<void>[] = [];
 
-		for (const config of selectedTargets) {
+		for (const config of dueTargets) {
 			const providerImpl = getProvider(config.provider);
 			for (let i = 0; i < config.samplesPerDispatch; i++) {
 				runPromises.push(
@@ -360,15 +406,14 @@ export async function processPromptJob(jobs: Job<ProcessPromptData>[]): Promise<
 
 		trackWorkerEvent("prompt_processed", {
 			brand_id: brand.id,
-			models: [...new Set(selectedTargets.map((c) => c.model))],
-			providers: [...new Set(selectedTargets.map((c) => c.provider))],
+			models: [...new Set(dueTargets.map((c) => c.model))],
+			providers: [...new Set(dueTargets.map((c) => c.provider))],
 			total_runs: runPromises.length,
 			successful_runs: successCount,
 			failed_runs: failures.length,
 		});
 
 		// Schedule the next run
-		const nextCadenceHours = Math.min(...selectedTargets.map((target) => target.cadenceHours));
-		await scheduleNextRun(promptId, nextCadenceHours);
+		if (nextCadenceHours !== undefined) await scheduleNextRun(promptId, nextCadenceHours, configurationVersion);
 	}
 }

--- a/apps/worker/src/jobs/schedule-maintenance.ts
+++ b/apps/worker/src/jobs/schedule-maintenance.ts
@@ -3,10 +3,13 @@ import { db } from "@workspace/lib/db/db";
 import { brands, promptRuns, prompts } from "@workspace/lib/db/schema";
 import {
 	getEffectiveEvaluationTargetsForPrompts,
+	getEvaluationConfigurationVersion,
+	isEffectiveEvaluationTargetOverdue,
+	mapLastRunsToEffectiveTargets,
 	minimumCadenceHours,
+	selectDueEvaluationTargets,
 	type EffectiveEvaluationTarget,
 } from "@workspace/lib/evaluation-config";
-import { isPromptOverdue } from "@workspace/lib/overdue";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import type { Job } from "pg-boss";
 import boss from "../boss";
@@ -35,16 +38,14 @@ const EXPEDITE_MIN_INTERVAL_MS = 60 * 60 * 1000;
 function getLastRunsForTargets(
 	lastRuns: Record<string, Date>,
 	targets: readonly EffectiveEvaluationTarget[],
-): Record<string, Date> {
-	return Object.fromEntries(
-		targets.flatMap((target) => {
-			const targetRun = lastRuns[target.targetId];
-			const legacyModelRun = lastRuns[`legacy:${target.model}`];
-			const latest = [targetRun, legacyModelRun]
-				.filter((run): run is Date => run !== undefined)
-				.reduce<Date | undefined>((newest, run) => (!newest || run > newest ? run : newest), undefined);
-			return latest ? [[target.targetId, latest]] : [];
-		}),
+): Map<string, Date> {
+	return mapLastRunsToEffectiveTargets(
+		targets,
+		Object.entries(lastRuns).map(([key, lastRunAt]) => ({
+			evaluationTargetId: key.startsWith("legacy:") ? null : key,
+			model: key.startsWith("legacy:") ? key.slice("legacy:".length) : "",
+			lastRunAt,
+		})),
 	);
 }
 
@@ -94,6 +95,7 @@ async function runMaintenanceCheck(): Promise<void> {
 	const effectiveTargetsByPrompt = await getEffectiveEvaluationTargetsForPrompts(
 		enabledPrompts.map((prompt) => prompt.id),
 	);
+	const configurationVersion = await getEvaluationConfigurationVersion();
 	const schedulablePrompts = enabledPrompts.filter(
 		(prompt) => (effectiveTargetsByPrompt.get(prompt.id)?.length ?? 0) > 0,
 	);
@@ -157,26 +159,21 @@ async function runMaintenanceCheck(): Promise<void> {
 
 		const cadenceHours = minimumCadenceHours(targets);
 		if (cadenceHours === undefined) continue;
-		const runFrequencyMs = cadenceHours * 60 * 60 * 1000;
 		const lastRuns = getLastRunsForTargets(lastRunsMap[prompt.id] || {}, targets);
+		const dueTargets = selectDueEvaluationTargets(targets, lastRuns, new Date(now));
 
-		const isOverdue = isPromptOverdue({
-			models: targets.map((target) => target.targetId),
-			lastRunByModel: lastRuns,
-			promptCreatedAt: prompt.createdAt,
-			runFrequencyMs,
-			now,
-		});
-
-		if (!isOverdue) continue;
+		if (dueTargets.length === 0) continue;
 
 		if (pendingJob && pendingJob.state === "created") {
 			// Throttle: if the prompt ran within the window it isn't really stalled,
 			// so don't drag its next job forward again. A never-recording target
 			// would otherwise keep it perpetually "overdue" and re-fire it every tick.
-			const lastRunTimes = Object.values(lastRuns).map((d) => new Date(d).getTime());
+			const lastRunTimes = [...lastRuns.values()].map((d) => d.getTime());
 			const mostRecentRunMs = lastRunTimes.length > 0 ? Math.max(...lastRunTimes) : null;
-			if (mostRecentRunMs !== null && now - mostRecentRunMs < Math.min(runFrequencyMs, EXPEDITE_MIN_INTERVAL_MS)) {
+			if (
+				mostRecentRunMs !== null &&
+				now - mostRecentRunMs < Math.min(cadenceHours * 60 * 60 * 1000, EXPEDITE_MIN_INTERVAL_MS)
+			) {
 				continue;
 			}
 			// There's a future job scheduled - expedite it to run now
@@ -227,7 +224,7 @@ async function runMaintenanceCheck(): Promise<void> {
 				batch.map(({ promptId, cadenceHours }) =>
 					boss.send(
 						"process-prompt",
-						{ promptId, cadenceHours },
+						{ promptId, cadenceHours, configurationVersion },
 						{
 							singletonKey: `prompt-${promptId}`,
 							singletonSeconds: 60 * 60, // 1 hour - prevent duplicates
@@ -273,17 +270,16 @@ function reportOverduePrompts(input: {
 	let overduePrompts = 0;
 	for (const prompt of enabled) {
 		const targets = effectiveTargetsByPrompt.get(prompt.id) ?? [];
-		const cadenceHours = minimumCadenceHours(targets);
-		if (cadenceHours === undefined) continue;
-		const runFrequencyMs = cadenceHours * 60 * 60 * 1000;
-		const overdue = isPromptOverdue({
-			models: targets.map((target) => target.targetId),
-			lastRunByModel: getLastRunsForTargets(lastRunsMap[prompt.id] ?? {}, targets),
-			promptCreatedAt: prompt.createdAt,
-			runFrequencyMs,
-			now,
-			graceMs: OVERDUE_ALERT_GRACE_MS,
-		});
+		const lastRuns = getLastRunsForTargets(lastRunsMap[prompt.id] ?? {}, targets);
+		const overdue = targets.some((target) =>
+			isEffectiveEvaluationTargetOverdue({
+				target,
+				lastRunAt: lastRuns.get(target.targetId),
+				promptCreatedAt: prompt.createdAt,
+				now,
+				graceMs: OVERDUE_ALERT_GRACE_MS,
+			}),
+		);
 		if (overdue) overduePrompts++;
 	}
 

--- a/apps/worker/src/jobs/schedule-maintenance.ts
+++ b/apps/worker/src/jobs/schedule-maintenance.ts
@@ -1,9 +1,12 @@
 import * as Sentry from "@sentry/node";
-import { getDefaultDelayHours } from "@workspace/lib/constants";
 import { db } from "@workspace/lib/db/db";
 import { brands, promptRuns, prompts } from "@workspace/lib/db/schema";
+import {
+	getEffectiveEvaluationTargetsForPrompts,
+	minimumCadenceHours,
+	type EffectiveEvaluationTarget,
+} from "@workspace/lib/evaluation-config";
 import { isPromptOverdue } from "@workspace/lib/overdue";
-import { parseScrapeTargets } from "@workspace/lib/providers";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import type { Job } from "pg-boss";
 import boss from "../boss";
@@ -28,6 +31,22 @@ let lastOverdueAlertMs = 0;
  * fleet-wide run/cost storm. Mirrors the 1h throttle on the job-creation path.
  */
 const EXPEDITE_MIN_INTERVAL_MS = 60 * 60 * 1000;
+
+function getLastRunsForTargets(
+	lastRuns: Record<string, Date>,
+	targets: readonly EffectiveEvaluationTarget[],
+): Record<string, Date> {
+	return Object.fromEntries(
+		targets.flatMap((target) => {
+			const targetRun = lastRuns[target.targetId];
+			const legacyModelRun = lastRuns[`legacy:${target.model}`];
+			const latest = [targetRun, legacyModelRun]
+				.filter((run): run is Date => run !== undefined)
+				.reduce<Date | undefined>((newest, run) => (!newest || run > newest ? run : newest), undefined);
+			return latest ? [[target.targetId, latest]] : [];
+		}),
+	);
+}
 
 /**
  * Maintenance job that ensures all enabled prompts have scheduled jobs.
@@ -60,12 +79,6 @@ async function runMaintenanceCheck(): Promise<void> {
 	}
 
 	const brandIds = enabledBrands.map((b) => b.id);
-	const defaultDelayHours = getDefaultDelayHours();
-	const brandDelayMap: Record<string, number> = {};
-	for (const brand of enabledBrands) {
-		brandDelayMap[brand.id] = brand.delayOverrideHours ?? defaultDelayHours;
-	}
-
 	// Get all enabled prompts for enabled brands
 	const enabledPrompts = await db.query.prompts.findMany({
 		where: and(eq(prompts.enabled, true), inArray(prompts.brandId, brandIds)),
@@ -78,25 +91,45 @@ async function runMaintenanceCheck(): Promise<void> {
 
 	console.log(`[schedule-maintenance] Checking ${enabledPrompts.length} enabled prompts`);
 
-	const allModels = parseScrapeTargets(process.env.SCRAPE_TARGETS);
-	const modelNames = allModels.map((cfg) => cfg.model);
+	const effectiveTargetsByPrompt = await getEffectiveEvaluationTargetsForPrompts(
+		enabledPrompts.map((prompt) => prompt.id),
+	);
+	const schedulablePrompts = enabledPrompts.filter(
+		(prompt) => (effectiveTargetsByPrompt.get(prompt.id)?.length ?? 0) > 0,
+	);
+	if (schedulablePrompts.length === 0) {
+		console.log("[schedule-maintenance] No enabled prompts have effective evaluation targets");
+		return;
+	}
 
-	// Get last runs per prompt per model (matches dashboard overdue logic)
+	// New rows are identified by target ID. Historical rows have no target ID,
+	// so retain a model-key fallback until their normal cadence replaces them.
 	const lastRunsQuery = await db
 		.select({
 			promptId: promptRuns.promptId,
 			model: promptRuns.model,
+			evaluationTargetId: promptRuns.evaluationTargetId,
 			lastRunAt: sql<Date>`MAX(${promptRuns.createdAt})`.as("last_run_at"),
 		})
 		.from(promptRuns)
-		.groupBy(promptRuns.promptId, promptRuns.model);
+		.where(
+			inArray(
+				promptRuns.promptId,
+				schedulablePrompts.map((prompt) => prompt.id),
+			),
+		)
+		.groupBy(promptRuns.promptId, promptRuns.evaluationTargetId, promptRuns.model);
 
 	const lastRunsMap: Record<string, Record<string, Date>> = {};
 	for (const run of lastRunsQuery) {
 		if (!lastRunsMap[run.promptId]) {
 			lastRunsMap[run.promptId] = {};
 		}
-		lastRunsMap[run.promptId][run.model] = run.lastRunAt;
+		const key = run.evaluationTargetId ?? `legacy:${run.model}`;
+		const current = lastRunsMap[run.promptId][key];
+		if (!current || run.lastRunAt > current) {
+			lastRunsMap[run.promptId][key] = run.lastRunAt;
+		}
 	}
 
 	// Get all pending jobs with their state info
@@ -107,15 +140,14 @@ async function runMaintenanceCheck(): Promise<void> {
 	const jobsToExpedite: string[] = []; // Job IDs to expedite (move start_after to now)
 
 	reportOverduePrompts({
-		prompts: enabledPrompts,
-		brandDelayHours: brandDelayMap,
-		defaultDelayHours,
+		prompts: schedulablePrompts,
+		effectiveTargetsByPrompt,
 		lastRunsMap,
-		modelNames,
 		now,
 	});
 
-	for (const prompt of enabledPrompts) {
+	for (const prompt of schedulablePrompts) {
+		const targets = effectiveTargetsByPrompt.get(prompt.id) ?? [];
 		const pendingJob = pendingJobMap.get(prompt.id);
 
 		// Skip if there's an active or retry job (already being worked on)
@@ -123,12 +155,13 @@ async function runMaintenanceCheck(): Promise<void> {
 			continue;
 		}
 
-		const cadenceHours = brandDelayMap[prompt.brandId] ?? defaultDelayHours;
+		const cadenceHours = minimumCadenceHours(targets);
+		if (cadenceHours === undefined) continue;
 		const runFrequencyMs = cadenceHours * 60 * 60 * 1000;
-		const lastRuns = lastRunsMap[prompt.id] || {};
+		const lastRuns = getLastRunsForTargets(lastRunsMap[prompt.id] || {}, targets);
 
 		const isOverdue = isPromptOverdue({
-			models: modelNames,
+			models: targets.map((target) => target.targetId),
 			lastRunByModel: lastRuns,
 			promptCreatedAt: prompt.createdAt,
 			runFrequencyMs,
@@ -231,20 +264,21 @@ async function runMaintenanceCheck(): Promise<void> {
  */
 function reportOverduePrompts(input: {
 	prompts: { id: string; brandId: string; createdAt: Date }[];
-	brandDelayHours: Record<string, number>;
-	defaultDelayHours: number;
+	effectiveTargetsByPrompt: Map<string, EffectiveEvaluationTarget[]>;
 	lastRunsMap: Record<string, Record<string, Date>>;
-	modelNames: string[];
 	now: number;
 }): void {
-	const { prompts: enabled, brandDelayHours, defaultDelayHours, lastRunsMap, modelNames, now } = input;
+	const { prompts: enabled, effectiveTargetsByPrompt, lastRunsMap, now } = input;
 
 	let overduePrompts = 0;
 	for (const prompt of enabled) {
-		const runFrequencyMs = (brandDelayHours[prompt.brandId] ?? defaultDelayHours) * 60 * 60 * 1000;
+		const targets = effectiveTargetsByPrompt.get(prompt.id) ?? [];
+		const cadenceHours = minimumCadenceHours(targets);
+		if (cadenceHours === undefined) continue;
+		const runFrequencyMs = cadenceHours * 60 * 60 * 1000;
 		const overdue = isPromptOverdue({
-			models: modelNames,
-			lastRunByModel: lastRunsMap[prompt.id] ?? {},
+			models: targets.map((target) => target.targetId),
+			lastRunByModel: getLastRunsForTargets(lastRunsMap[prompt.id] ?? {}, targets),
 			promptCreatedAt: prompt.createdAt,
 			runFrequencyMs,
 			now,

--- a/apps/worker/src/report-worker.ts
+++ b/apps/worker/src/report-worker.ts
@@ -1,8 +1,11 @@
 import { db } from "@workspace/lib/db/db";
 import { reports, type Brand, brands } from "@workspace/lib/db/schema";
 import { eq } from "drizzle-orm";
-import { RUNS_PER_PROMPT } from "@workspace/lib/constants";
-import { getProvider, parseScrapeTargets, type ModelConfig } from "@workspace/lib/providers";
+import {
+	getEffectiveEvaluationTargetsForInstance,
+	type EffectiveEvaluationTarget,
+} from "@workspace/lib/evaluation-config";
+import { getProvider } from "@workspace/lib/providers";
 import { analyzeBrand } from "@workspace/lib/onboarding";
 import { isPromptBranded, computeSystemTags } from "@workspace/lib/tag-utils";
 
@@ -26,28 +29,26 @@ const MIN_BRAND_MENTIONS = 14;
 const MAX_BRAND_MENTIONS = 28;
 
 // Whitelabel deployments preserve the legacy asymmetric per-candidate sample
-// counts used before SCRAPE_TARGETS drove dispatch. Any model outside this map
-// on a whitelabel deployment is a configuration error (the legacy report flow
-// only knew how to sample these three). Other deployment modes use
-// RUNS_PER_PROMPT (same frequency as day-to-day prompt tracking).
+// counts. Any model outside this map is a configuration error because the
+// report renderer only knew how to sample these three surfaces.
 const WHITELABEL_REPORT_RUNS_PER_MODEL: Record<string, number> = {
 	chatgpt: 2,
 	claude: 1,
 	"google-ai-mode": 1,
 };
 
-function getReportRunsForModel(model: string): number {
+function getReportRunsForTarget(target: EffectiveEvaluationTarget): number {
 	if (process.env.DEPLOYMENT_MODE === "whitelabel") {
-		const count = WHITELABEL_REPORT_RUNS_PER_MODEL[model];
+		const count = WHITELABEL_REPORT_RUNS_PER_MODEL[target.model];
 		if (count === undefined) {
 			throw new Error(
-				`Whitelabel report generation has no run count configured for model "${model}". ` +
+				`Whitelabel report generation has no run count configured for model "${target.model}". ` +
 					`Known models: ${Object.keys(WHITELABEL_REPORT_RUNS_PER_MODEL).join(", ")}.`,
 			);
 		}
 		return count;
 	}
-	return RUNS_PER_PROMPT;
+	return target.samplesPerDispatch;
 }
 
 export interface ReportJobData {
@@ -101,13 +102,13 @@ function selectOptimalPrompts(
 		const totalRuns = candidate.runs.length;
 		const brandMentionCount = candidate.runs.filter((r) => r.brandMentioned).length;
 		const competitorMentionCount = candidate.runs.filter((r) => r.competitorsMentioned.length > 0).length;
-		
+
 		const brandMentionRate = totalRuns > 0 ? brandMentionCount / totalRuns : 0;
 		const competitorMentionRate = totalRuns > 0 ? competitorMentionCount / totalRuns : 0;
-		
+
 		// Check if prompt is actually branded (contains brand name/domain)
 		const isActuallyBranded = isPromptBranded(candidate.promptValue, brandName, brandWebsite);
-		
+
 		return {
 			promptValue: candidate.promptValue,
 			brandedPrompt: candidate.brandedPrompt || isActuallyBranded,
@@ -117,11 +118,11 @@ function selectOptimalPrompts(
 			hasCompetitorMention: competitorMentionCount > 0,
 		};
 	});
-	
+
 	// Separate branded and non-branded prompts
 	const nonBrandedPrompts = scoredCandidates.filter((c) => !c.brandedPrompt);
 	const brandedPrompts = scoredCandidates.filter((c) => c.brandedPrompt);
-	
+
 	// Sort non-branded by: 1) has brand mention, 2) competitor mention rate, 3) brand mention rate
 	nonBrandedPrompts.sort((a, b) => {
 		if (a.hasBrandMention !== b.hasBrandMention) {
@@ -132,7 +133,7 @@ function selectOptimalPrompts(
 		}
 		return b.brandMentionRate - a.brandMentionRate;
 	});
-	
+
 	// Sort branded by: 1) brand mention rate, 2) competitor mention rate
 	brandedPrompts.sort((a, b) => {
 		if (Math.abs(a.brandMentionRate - b.brandMentionRate) > 0.1) {
@@ -140,21 +141,21 @@ function selectOptimalPrompts(
 		}
 		return b.competitorMentionRate - a.competitorMentionRate;
 	});
-	
+
 	// Select prompts to meet brand mention requirements
 	const selectedPrompts: string[] = [];
 	let currentBrandMentions = 0;
-	
+
 	// First, add non-branded prompts with brand mentions
 	for (const prompt of nonBrandedPrompts) {
 		if (selectedPrompts.length >= TARGET_PROMPTS_COUNT) break;
-		
+
 		selectedPrompts.push(prompt.promptValue);
 		if (prompt.hasBrandMention) {
 			currentBrandMentions++;
 		}
 	}
-	
+
 	// If we need more prompts or more brand mentions, add branded prompts
 	while (selectedPrompts.length < TARGET_PROMPTS_COUNT && brandedPrompts.length > 0) {
 		const prompt = brandedPrompts.shift()!;
@@ -163,10 +164,10 @@ function selectOptimalPrompts(
 			currentBrandMentions++;
 		}
 	}
-	
+
 	// Log selection summary
 	console.log(`Selected ${selectedPrompts.length} prompts with estimated ${currentBrandMentions} brand mentions`);
-	
+
 	return selectedPrompts;
 }
 
@@ -184,8 +185,8 @@ function analyzeMentions(
 	const brandNameLower = brandName.toLowerCase();
 
 	// Extract domain from brandWebsite using URL constructor
-	const url = new URL(brandWebsite.startsWith('http') ? brandWebsite : `https://${brandWebsite}`);
-	const domain = url.hostname.replace(/^www\./, '').toLowerCase();
+	const url = new URL(brandWebsite.startsWith("http") ? brandWebsite : `https://${brandWebsite}`);
+	const domain = url.hostname.replace(/^www\./, "").toLowerCase();
 
 	// Check for brand mention (brand name or domain)
 	const brandMentioned = contentLower.includes(brandNameLower) || contentLower.includes(domain);
@@ -194,11 +195,13 @@ function analyzeMentions(
 	const competitorsMentioned = competitors
 		.filter((competitor) => {
 			const nameMatch = contentLower.includes(competitor.name.toLowerCase());
-			
+
 			// Extract domain from competitor website
-			const competitorUrl = new URL(competitor.domain.startsWith('http') ? competitor.domain : `https://${competitor.domain}`);
-			const competitorDomain = competitorUrl.hostname.replace(/^www\./, '').toLowerCase();
-			
+			const competitorUrl = new URL(
+				competitor.domain.startsWith("http") ? competitor.domain : `https://${competitor.domain}`,
+			);
+			const competitorDomain = competitorUrl.hostname.replace(/^www\./, "").toLowerCase();
+
 			const domainMatch = contentLower.includes(competitorDomain);
 			return nameMatch || domainMatch;
 		})
@@ -207,19 +210,16 @@ function analyzeMentions(
 	return { brandMentioned, competitorsMentioned };
 }
 
-// Function to run a prompt across different models and return results.
-// Iterates SCRAPE_TARGETS; per-model run count comes from getReportRunsForModel
-// (whitelabel preserves the legacy 2+1+1 mapping; other modes match day-to-day
-// tracking frequency).
+// Function to run a prompt across configured instance targets and return results.
 async function runPrompt(
 	promptValue: string,
 	brandName: string,
 	brandWebsite: string,
 	competitors: CompetitorResult[],
-	scrapeConfigs: ModelConfig[],
+	targets: EffectiveEvaluationTarget[],
 	job: ReportJobContext,
 ): Promise<PromptRunResult> {
-	const runOne = async (config: ModelConfig) => {
+	const runOne = async (config: EffectiveEvaluationTarget) => {
 		const providerImpl = getProvider(config.provider);
 		const result = await providerImpl.run(config.model, promptValue, {
 			webSearch: config.webSearch,
@@ -243,8 +243,8 @@ async function runPrompt(
 		};
 	};
 
-	const runPromises = scrapeConfigs.flatMap((config) => {
-		const count = getReportRunsForModel(config.model);
+	const runPromises = targets.flatMap((config) => {
+		const count = getReportRunsForTarget(config);
 		return Array.from({ length: count }, () => runOne(config));
 	});
 
@@ -264,7 +264,10 @@ export async function processReportJob(job: ReportJobContext) {
 
 	job.log(`Processing report ID: ${reportId} for brand: ${brandName}`);
 
-	const scrapeConfigs = parseScrapeTargets(process.env.SCRAPE_TARGETS);
+	const scrapeConfigs = await getEffectiveEvaluationTargetsForInstance();
+	if (scrapeConfigs.length === 0) {
+		throw new Error("No instance evaluation targets are configured for report generation");
+	}
 
 	// Determine if we're using manual prompts
 	const useManualPrompts = manualPrompts && manualPrompts.length > 0;
@@ -334,7 +337,7 @@ export async function processReportJob(job: ReportJobContext) {
 				competitorsMentioned: string[];
 			}>;
 		}> = [];
-		
+
 		const totalCandidates = candidatePrompts.length;
 		let completedCandidates = 0;
 

--- a/packages/config/src/env-registry.ts
+++ b/packages/config/src/env-registry.ts
@@ -156,9 +156,9 @@ export const ENV_REGISTRY: EnvVarSpec[] = [
 	{
 		name: "SCRAPE_TARGETS",
 		scope: "server",
-		requiredBy: VALIDATED_MODES,
+		requiredBy: "optional",
 		description:
-			"Comma-separated model:provider[:version][:online] entries. Example: chatgpt:olostep:online,google-ai-mode:olostep:online,copilot:olostep:online",
+			"Legacy one-time import source for database-backed evaluation targets. New deployments configure targets in the application.",
 	},
 	{
 		name: "OLOSTEP_API_KEY",
@@ -411,6 +411,7 @@ export const ENV_REGISTRY: EnvVarSpec[] = [
 		name: "RESEND_FROM_EMAIL",
 		scope: "server",
 		requiredBy: ["cloud"],
-		description: "Sender address for transactional email, in the form: Elmo <notifications@updates.example.com>. The domain must be verified in Resend.",
+		description:
+			"Sender address for transactional email, in the form: Elmo <notifications@updates.example.com>. The domain must be verified in Resend.",
 	},
 ];

--- a/packages/config/src/env.test.ts
+++ b/packages/config/src/env.test.ts
@@ -12,7 +12,7 @@ const CLOUD_ONLY_VARS = [
 	"RESEND_FROM_EMAIL",
 ];
 // Infra vars every validated mode needs — cloud now among them.
-const CLOUD_SHARED_VARS = ["DATABASE_URL", "BETTER_AUTH_SECRET", "SCRAPE_TARGETS", "DEPLOYMENT_MODE"];
+const CLOUD_SHARED_VARS = ["DATABASE_URL", "BETTER_AUTH_SECRET", "DEPLOYMENT_MODE"];
 
 describe("cloud env requirements", () => {
 	const cloudReqs = getEnvRequirements("cloud");
@@ -44,7 +44,6 @@ describe("cloud env requirements", () => {
 			DEPLOYMENT_MODE: "cloud",
 			DATABASE_URL: "postgres://localhost/elmo",
 			BETTER_AUTH_SECRET: "secret",
-			SCRAPE_TARGETS: "chatgpt:olostep:online",
 			APP_URL: "https://app.elmo.com/",
 			STRIPE_SECRET_KEY: "sk_test_x",
 			STRIPE_WEBHOOK_SECRET: "whsec_x",

--- a/packages/docs/content/docs/developer-guide/architecture.mdx
+++ b/packages/docs/content/docs/developer-guide/architecture.mdx
@@ -87,8 +87,8 @@ Migrations are generated with `drizzle-kit generate` and applied with `drizzle-k
 
 All AI scraping flows through a single `Provider` interface in `packages/lib/src/providers/`. The runtime wiring:
 
-1. `SCRAPE_TARGETS` (env var) holds comma-separated `model:provider[:version][:online]` entries.
-2. `parseScrapeTargets()` turns the string into `ModelConfig[]`.
+1. `evaluation_targets` and `evaluation_target_scope_configs` resolve the instance → organization → brand → prompt target list.
+2. `SCRAPE_TARGETS` remains only as a one-time compatibility import for existing installs.
 3. `getProvider(providerId).run(model, prompt, { webSearch, version })` dispatches to a concrete `registry/` implementation and returns a normalized `ScrapeResult` (`textContent`, `rawOutput`, `webQueries`, `citations`, `modelVersion`).
 
 User-facing setup is documented in [Providers](/docs/user-guide/providers).

--- a/packages/docs/content/docs/developer-guide/configuration.mdx
+++ b/packages/docs/content/docs/developer-guide/configuration.mdx
@@ -41,7 +41,17 @@ At least one provider is required for Elmo to track visibility. See [Providers](
 | `OPENROUTER_API_KEY` | OpenRouter key — one key for Claude + other hosted models |
 | `DATAFORSEO_LOGIN` | DataForSEO login — optional, enables DataForSEO targets such as `google-ai-mode:dataforseo:online`, `chatgpt:dataforseo:online`, `perplexity:dataforseo:online`, and `gemini:dataforseo:online` |
 | `DATAFORSEO_PASSWORD` | DataForSEO password |
-| `SCRAPE_TARGETS` | Comma-separated `model:provider[:version][:online]` entries. See [Providers](/docs/user-guide/providers#scrape_targets-format). |
+| `SCRAPE_TARGETS` | Optional legacy import source for `model:provider[:version][:online]` entries. On first startup, Elmo imports it into database-backed evaluation targets. See [Providers](/docs/user-guide/providers#scrape_targets-format). |
+
+### Evaluation targets
+
+Which models run, how frequently they run, and how many samples each run takes are stored in the database. In a local deployment, open **Settings → LLMs** to add instance targets and set brand-level overrides. Provider credentials remain server-side environment variables during this migration.
+
+Existing deployments can keep `SCRAPE_TARGETS` for one startup: Elmo imports the instance targets plus existing `enabledModels` and `delayOverrideHours` overrides into the database. Once the import is complete, removing `SCRAPE_TARGETS` is safe. New deployments can skip it and add their first target in the UI.
+
+Cloud configuration resolves instance → organization → brand → prompt. Organization owners and admins can select targets from their allowed catalog, while sampling and cadence stay server-controlled by the plan. Local supports instance → organization or brand → prompt. Whitelabel preserves its existing member experience: members can edit brand content, prompts, and competitors, but not evaluation targets or cadence. Demo mode never writes configuration.
+
+Plan entitlements constrain configuration atomically: target counts and samples per dispatch are checked after inheritance is resolved, so a child scope cannot use an override to exceed the plan. Daily execution allowance is deliberately stored separately from configuration limits; it belongs to the runtime metering layer, so changing a configured target never grants additional executions.
 
 ## Updating Configuration
 

--- a/packages/docs/content/docs/user-guide/providers.mdx
+++ b/packages/docs/content/docs/user-guide/providers.mdx
@@ -126,6 +126,8 @@ DataForSEO prompt text is limited to 500 characters. Country localization is int
 
 ## Recommended setups
 
+The examples below can be used as a legacy first-start import. New local deployments can instead add the provider key to `.env`, then create the target in **Settings → LLMs**. After a legacy import has completed, `SCRAPE_TARGETS` is no longer needed.
+
 **Starter (scrape the two that matter).** Pick one scraper and you're done:
 
 ```bash
@@ -157,6 +159,8 @@ SCRAPE_TARGETS=chatgpt:openai-api:gpt-5-mini:online,claude:anthropic-api:claude-
 ```
 
 ## SCRAPE_TARGETS format
+
+This format is retained for the legacy one-time import path.
 
 ```
 model:provider[:version][:online]

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,54 +1,55 @@
 {
-  "name": "@workspace/lib",
-  "version": "0.2.16",
-  "private": true,
-  "license": "MIT",
-  "scripts": {
-    "test": "vitest run",
-    "compare:onboarding": "tsx scripts/compare-onboarding.ts",
-    "generate:auth-schema": "bash scripts/generate-auth-schema.sh"
-  },
-  "exports": {
-    "./db/db": "./src/db/db.ts",
-    "./db/schema": "./src/db/schema.ts",
-    "./db/auth-sync": "./src/db/auth-sync.ts",
-    "./db/provisioning": "./src/db/provisioning.ts",
-    "./auth/server": "./src/auth/server.ts",
-    "./auth/client": "./src/auth/client.ts",
-    "./auth/permissions": "./src/auth/permissions.ts",
-    "./constants": "./src/constants.ts",
-    "./overdue": "./src/overdue.ts",
-    "./text-extraction": "./src/text-extraction.ts",
-    "./dataforseo": "./src/dataforseo.ts",
-    "./onboarding": "./src/onboarding/index.ts",
-    "./tag-utils": "./src/tag-utils.ts",
-    "./website-excerpt": "./src/website-excerpt.ts",
-    "./report-metrics": "./src/report-metrics.ts",
-    "./providers": "./src/providers/index.ts",
-    "./providers/models": "./src/providers/models.ts",
-    "./providers/types": "./src/providers/types.ts"
-  },
-  "dependencies": {
-    "@ai-sdk/anthropic": "^4.0.12",
-    "@ai-sdk/openai": "^4.0.11",
-    "@anthropic-ai/sdk": "^0.111.0",
-    "@better-auth/sso": "^1.6.23",
-    "@brightdata/sdk": "^1.1.0",
-    "@mozilla/readability": "^0.6.0",
-    "@workspace/config": "workspace:*",
-    "ai": "^7.0.22",
-    "better-auth": "^1.6.23",
-    "dataforseo-client": "^2.0.25",
-    "drizzle-orm": "^0.45.2",
-    "linkedom": "^0.18.13",
-    "olostep": "^1.2.2",
-    "pg": "^8.22.0",
-    "zod": "^4.4.3"
-  },
-  "devDependencies": {
-    "@types/pg": "^8.20.0",
-    "drizzle-kit": "^0.31.10",
-    "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
-  }
+	"name": "@workspace/lib",
+	"version": "0.2.16",
+	"private": true,
+	"license": "MIT",
+	"scripts": {
+		"test": "vitest run",
+		"compare:onboarding": "tsx scripts/compare-onboarding.ts",
+		"generate:auth-schema": "bash scripts/generate-auth-schema.sh"
+	},
+	"exports": {
+		"./db/db": "./src/db/db.ts",
+		"./db/schema": "./src/db/schema.ts",
+		"./db/auth-sync": "./src/db/auth-sync.ts",
+		"./db/provisioning": "./src/db/provisioning.ts",
+		"./auth/server": "./src/auth/server.ts",
+		"./auth/client": "./src/auth/client.ts",
+		"./auth/permissions": "./src/auth/permissions.ts",
+		"./constants": "./src/constants.ts",
+		"./overdue": "./src/overdue.ts",
+		"./text-extraction": "./src/text-extraction.ts",
+		"./dataforseo": "./src/dataforseo.ts",
+		"./onboarding": "./src/onboarding/index.ts",
+		"./tag-utils": "./src/tag-utils.ts",
+		"./website-excerpt": "./src/website-excerpt.ts",
+		"./report-metrics": "./src/report-metrics.ts",
+		"./evaluation-config": "./src/evaluation-config/index.ts",
+		"./providers": "./src/providers/index.ts",
+		"./providers/models": "./src/providers/models.ts",
+		"./providers/types": "./src/providers/types.ts"
+	},
+	"dependencies": {
+		"@ai-sdk/anthropic": "^4.0.12",
+		"@ai-sdk/openai": "^4.0.11",
+		"@anthropic-ai/sdk": "^0.111.0",
+		"@better-auth/sso": "^1.6.23",
+		"@brightdata/sdk": "^1.1.0",
+		"@mozilla/readability": "^0.6.0",
+		"@workspace/config": "workspace:*",
+		"ai": "^7.0.22",
+		"better-auth": "^1.6.23",
+		"dataforseo-client": "^2.0.25",
+		"drizzle-orm": "^0.45.2",
+		"linkedom": "^0.18.13",
+		"olostep": "^1.2.2",
+		"pg": "^8.22.0",
+		"zod": "^4.4.3"
+	},
+	"devDependencies": {
+		"@types/pg": "^8.20.0",
+		"drizzle-kit": "^0.31.10",
+		"typescript": "^7.0.2",
+		"vitest": "^4.1.10"
+	}
 }

--- a/packages/lib/src/db/migrations/0011_evaluation_configuration.sql
+++ b/packages/lib/src/db/migrations/0011_evaluation_configuration.sql
@@ -1,0 +1,132 @@
+CREATE TYPE "public"."evaluation_config_scope" AS ENUM('organization', 'brand', 'prompt');--> statement-breakpoint
+CREATE TYPE "public"."evaluation_entitlement_scope" AS ENUM('instance', 'organization');--> statement-breakpoint
+CREATE TYPE "public"."provider_credential_source" AS ENUM('legacy_env', 'encrypted_db', 'external_reference');--> statement-breakpoint
+CREATE TABLE "evaluation_config_audit_logs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"actor_user_id" text,
+	"action" text NOT NULL,
+	"scope" "evaluation_config_scope",
+	"organization_id" text,
+	"brand_id" text,
+	"prompt_id" uuid,
+	"diff" json,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "evaluation_config_audit_logs" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "evaluation_entitlements" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"scope" "evaluation_entitlement_scope" NOT NULL,
+	"organization_id" text,
+	"max_configured_targets" integer,
+	"max_configured_targets_per_brand" integer,
+	"max_configured_targets_per_prompt" integer,
+	"max_samples_per_dispatch" integer,
+	"max_runs_per_day" integer,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "evaluation_entitlements_scope_owner_check" CHECK ((
+				("evaluation_entitlements"."scope" = 'instance' AND "evaluation_entitlements"."organization_id" IS NULL)
+				OR ("evaluation_entitlements"."scope" = 'organization' AND "evaluation_entitlements"."organization_id" IS NOT NULL)
+			)),
+	CONSTRAINT "evaluation_entitlements_limits_check" CHECK (("evaluation_entitlements"."max_configured_targets" IS NULL OR "evaluation_entitlements"."max_configured_targets" >= 0)
+				AND ("evaluation_entitlements"."max_configured_targets_per_brand" IS NULL OR "evaluation_entitlements"."max_configured_targets_per_brand" >= 0)
+				AND ("evaluation_entitlements"."max_configured_targets_per_prompt" IS NULL OR "evaluation_entitlements"."max_configured_targets_per_prompt" >= 0)
+				AND ("evaluation_entitlements"."max_samples_per_dispatch" IS NULL OR "evaluation_entitlements"."max_samples_per_dispatch" >= 0)
+				AND ("evaluation_entitlements"."max_runs_per_day" IS NULL OR "evaluation_entitlements"."max_runs_per_day" >= 0))
+);
+--> statement-breakpoint
+ALTER TABLE "evaluation_entitlements" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "evaluation_target_scope_configs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"target_id" uuid,
+	"scope" "evaluation_config_scope" NOT NULL,
+	"organization_id" text,
+	"brand_id" text,
+	"prompt_id" uuid,
+	"enabled" boolean,
+	"cadence_hours" integer,
+	"samples_per_dispatch" integer,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "evaluation_target_scope_configs_scope_owner_check" CHECK ((
+				("evaluation_target_scope_configs"."scope" = 'organization' AND "evaluation_target_scope_configs"."organization_id" IS NOT NULL AND "evaluation_target_scope_configs"."brand_id" IS NULL AND "evaluation_target_scope_configs"."prompt_id" IS NULL)
+				OR ("evaluation_target_scope_configs"."scope" = 'brand' AND "evaluation_target_scope_configs"."organization_id" IS NULL AND "evaluation_target_scope_configs"."brand_id" IS NOT NULL AND "evaluation_target_scope_configs"."prompt_id" IS NULL)
+				OR ("evaluation_target_scope_configs"."scope" = 'prompt' AND "evaluation_target_scope_configs"."organization_id" IS NULL AND "evaluation_target_scope_configs"."brand_id" IS NULL AND "evaluation_target_scope_configs"."prompt_id" IS NOT NULL)
+			)),
+	CONSTRAINT "evaluation_target_scope_configs_cadence_check" CHECK ("evaluation_target_scope_configs"."cadence_hours" IS NULL OR "evaluation_target_scope_configs"."cadence_hours" > 0),
+	CONSTRAINT "evaluation_target_scope_configs_samples_check" CHECK ("evaluation_target_scope_configs"."samples_per_dispatch" IS NULL OR "evaluation_target_scope_configs"."samples_per_dispatch" > 0)
+);
+--> statement-breakpoint
+ALTER TABLE "evaluation_target_scope_configs" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "evaluation_targets" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"key" text NOT NULL,
+	"model" text NOT NULL,
+	"provider_connection_id" uuid NOT NULL,
+	"version" text,
+	"web_search" boolean DEFAULT false NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"requires_prompt_assignment" boolean DEFAULT false NOT NULL,
+	"default_cadence_hours" integer NOT NULL,
+	"default_samples_per_dispatch" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "evaluation_targets_defaults_check" CHECK ("evaluation_targets"."default_cadence_hours" > 0 AND "evaluation_targets"."default_samples_per_dispatch" > 0)
+);
+--> statement-breakpoint
+ALTER TABLE "evaluation_targets" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "instance_settings" (
+	"id" text PRIMARY KEY DEFAULT 'default' NOT NULL,
+	"configuration_version" integer DEFAULT 0 NOT NULL,
+	"legacy_bootstrap_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "instance_settings" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "provider_connections" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"key" text NOT NULL,
+	"provider" text NOT NULL,
+	"credential_source" "provider_credential_source" NOT NULL,
+	"credential_reference" json,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "provider_connections" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "prompt_runs" ADD COLUMN "evaluation_target_id" uuid;--> statement-breakpoint
+ALTER TABLE "evaluation_config_audit_logs" ADD CONSTRAINT "evaluation_config_audit_logs_actor_user_id_user_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "evaluation_config_audit_logs" ADD CONSTRAINT "evaluation_config_audit_logs_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "evaluation_config_audit_logs" ADD CONSTRAINT "evaluation_config_audit_logs_brand_id_brands_id_fk" FOREIGN KEY ("brand_id") REFERENCES "public"."brands"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "evaluation_config_audit_logs" ADD CONSTRAINT "evaluation_config_audit_logs_prompt_id_prompts_id_fk" FOREIGN KEY ("prompt_id") REFERENCES "public"."prompts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "evaluation_entitlements" ADD CONSTRAINT "evaluation_entitlements_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "evaluation_target_scope_configs" ADD CONSTRAINT "evaluation_target_scope_configs_target_id_evaluation_targets_id_fk" FOREIGN KEY ("target_id") REFERENCES "public"."evaluation_targets"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "evaluation_target_scope_configs" ADD CONSTRAINT "evaluation_target_scope_configs_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "evaluation_target_scope_configs" ADD CONSTRAINT "evaluation_target_scope_configs_brand_id_brands_id_fk" FOREIGN KEY ("brand_id") REFERENCES "public"."brands"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "evaluation_target_scope_configs" ADD CONSTRAINT "evaluation_target_scope_configs_prompt_id_prompts_id_fk" FOREIGN KEY ("prompt_id") REFERENCES "public"."prompts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "evaluation_targets" ADD CONSTRAINT "evaluation_targets_provider_connection_id_provider_connections_id_fk" FOREIGN KEY ("provider_connection_id") REFERENCES "public"."provider_connections"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "evaluation_config_audit_logs_created_at_idx" ON "evaluation_config_audit_logs" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "evaluation_config_audit_logs_organization_id_idx" ON "evaluation_config_audit_logs" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "evaluation_config_audit_logs_brand_id_idx" ON "evaluation_config_audit_logs" USING btree ("brand_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "evaluation_entitlements_instance_uidx" ON "evaluation_entitlements" USING btree ("scope") WHERE "evaluation_entitlements"."scope" = 'instance';--> statement-breakpoint
+CREATE UNIQUE INDEX "evaluation_entitlements_organization_uidx" ON "evaluation_entitlements" USING btree ("organization_id") WHERE "evaluation_entitlements"."scope" = 'organization';--> statement-breakpoint
+CREATE INDEX "evaluation_entitlements_organization_id_idx" ON "evaluation_entitlements" USING btree ("organization_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "evaluation_target_scope_configs_org_target_uidx" ON "evaluation_target_scope_configs" USING btree ("organization_id","target_id") WHERE "evaluation_target_scope_configs"."scope" = 'organization' AND "evaluation_target_scope_configs"."target_id" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "evaluation_target_scope_configs_org_default_uidx" ON "evaluation_target_scope_configs" USING btree ("organization_id") WHERE "evaluation_target_scope_configs"."scope" = 'organization' AND "evaluation_target_scope_configs"."target_id" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "evaluation_target_scope_configs_brand_target_uidx" ON "evaluation_target_scope_configs" USING btree ("brand_id","target_id") WHERE "evaluation_target_scope_configs"."scope" = 'brand' AND "evaluation_target_scope_configs"."target_id" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "evaluation_target_scope_configs_brand_default_uidx" ON "evaluation_target_scope_configs" USING btree ("brand_id") WHERE "evaluation_target_scope_configs"."scope" = 'brand' AND "evaluation_target_scope_configs"."target_id" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "evaluation_target_scope_configs_prompt_target_uidx" ON "evaluation_target_scope_configs" USING btree ("prompt_id","target_id") WHERE "evaluation_target_scope_configs"."scope" = 'prompt' AND "evaluation_target_scope_configs"."target_id" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "evaluation_target_scope_configs_prompt_default_uidx" ON "evaluation_target_scope_configs" USING btree ("prompt_id") WHERE "evaluation_target_scope_configs"."scope" = 'prompt' AND "evaluation_target_scope_configs"."target_id" IS NULL;--> statement-breakpoint
+CREATE INDEX "evaluation_target_scope_configs_organization_id_idx" ON "evaluation_target_scope_configs" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "evaluation_target_scope_configs_brand_id_idx" ON "evaluation_target_scope_configs" USING btree ("brand_id");--> statement-breakpoint
+CREATE INDEX "evaluation_target_scope_configs_prompt_id_idx" ON "evaluation_target_scope_configs" USING btree ("prompt_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "evaluation_targets_key_uidx" ON "evaluation_targets" USING btree ("key");--> statement-breakpoint
+CREATE INDEX "evaluation_targets_provider_connection_id_idx" ON "evaluation_targets" USING btree ("provider_connection_id");--> statement-breakpoint
+CREATE INDEX "evaluation_targets_model_idx" ON "evaluation_targets" USING btree ("model");--> statement-breakpoint
+CREATE UNIQUE INDEX "provider_connections_key_uidx" ON "provider_connections" USING btree ("key");--> statement-breakpoint
+CREATE INDEX "provider_connections_provider_idx" ON "provider_connections" USING btree ("provider");--> statement-breakpoint
+ALTER TABLE "prompt_runs" ADD CONSTRAINT "prompt_runs_evaluation_target_id_evaluation_targets_id_fk" FOREIGN KEY ("evaluation_target_id") REFERENCES "public"."evaluation_targets"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "prompt_runs_evaluation_target_id_idx" ON "prompt_runs" USING btree ("evaluation_target_id");

--- a/packages/lib/src/db/migrations/meta/0011_snapshot.json
+++ b/packages/lib/src/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,2584 @@
+{
+	"id": "816ec8d8-d1a8-47a1-a30a-3808373defb7",
+	"prevId": "0a10c0de-0010-4010-8010-000000000010",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.brand_opportunities": {
+			"name": "brand_opportunities",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"brand_id": {
+					"name": "brand_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"report": {
+					"name": "report",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"brand_opportunities_brand_id_created_at_idx": {
+					"name": "brand_opportunities_brand_id_created_at_idx",
+					"columns": [
+						{
+							"expression": "brand_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"brand_opportunities_brand_id_brands_id_fk": {
+					"name": "brand_opportunities_brand_id_brands_id_fk",
+					"tableFrom": "brand_opportunities",
+					"tableTo": "brands",
+					"columnsFrom": ["brand_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.brands": {
+			"name": "brands",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"website": {
+					"name": "website",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"additional_domains": {
+					"name": "additional_domains",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				},
+				"aliases": {
+					"name": "aliases",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"onboarded": {
+					"name": "onboarded",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"delay_override_hours": {
+					"name": "delay_override_hours",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enabled_models": {
+					"name": "enabled_models",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"brands_organization_id_idx": {
+					"name": "brands_organization_id_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"brands_organization_id_organization_id_fk": {
+					"name": "brands_organization_id_organization_id_fk",
+					"tableFrom": "brands",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.citations": {
+			"name": "citations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"prompt_run_id": {
+					"name": "prompt_run_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"prompt_id": {
+					"name": "prompt_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"brand_id": {
+					"name": "brand_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"citation_index": {
+					"name": "citation_index",
+					"type": "smallint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"idx_citations_brand_analytics": {
+					"name": "idx_citations_brand_analytics",
+					"columns": [
+						{
+							"expression": "brand_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "title",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "prompt_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "model",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"citations_prompt_id_created_at_idx": {
+					"name": "citations_prompt_id_created_at_idx",
+					"columns": [
+						{
+							"expression": "prompt_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"citations_domain_idx": {
+					"name": "citations_domain_idx",
+					"columns": [
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"citations_prompt_run_id_prompt_runs_id_fk": {
+					"name": "citations_prompt_run_id_prompt_runs_id_fk",
+					"tableFrom": "citations",
+					"tableTo": "prompt_runs",
+					"columnsFrom": ["prompt_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"citations_prompt_id_prompts_id_fk": {
+					"name": "citations_prompt_id_prompts_id_fk",
+					"tableFrom": "citations",
+					"tableTo": "prompts",
+					"columnsFrom": ["prompt_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"citations_brand_id_brands_id_fk": {
+					"name": "citations_brand_id_brands_id_fk",
+					"tableFrom": "citations",
+					"tableTo": "brands",
+					"columnsFrom": ["brand_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.competitors": {
+			"name": "competitors",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"brand_id": {
+					"name": "brand_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domains": {
+					"name": "domains",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				},
+				"aliases": {
+					"name": "aliases",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"competitors_brand_id_brands_id_fk": {
+					"name": "competitors_brand_id_brands_id_fk",
+					"tableFrom": "competitors",
+					"tableTo": "brands",
+					"columnsFrom": ["brand_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.evaluation_config_audit_logs": {
+			"name": "evaluation_config_audit_logs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope": {
+					"name": "scope",
+					"type": "evaluation_config_scope",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"brand_id": {
+					"name": "brand_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"prompt_id": {
+					"name": "prompt_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"diff": {
+					"name": "diff",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"evaluation_config_audit_logs_created_at_idx": {
+					"name": "evaluation_config_audit_logs_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"evaluation_config_audit_logs_organization_id_idx": {
+					"name": "evaluation_config_audit_logs_organization_id_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"evaluation_config_audit_logs_brand_id_idx": {
+					"name": "evaluation_config_audit_logs_brand_id_idx",
+					"columns": [
+						{
+							"expression": "brand_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"evaluation_config_audit_logs_actor_user_id_user_id_fk": {
+					"name": "evaluation_config_audit_logs_actor_user_id_user_id_fk",
+					"tableFrom": "evaluation_config_audit_logs",
+					"tableTo": "user",
+					"columnsFrom": ["actor_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"evaluation_config_audit_logs_organization_id_organization_id_fk": {
+					"name": "evaluation_config_audit_logs_organization_id_organization_id_fk",
+					"tableFrom": "evaluation_config_audit_logs",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"evaluation_config_audit_logs_brand_id_brands_id_fk": {
+					"name": "evaluation_config_audit_logs_brand_id_brands_id_fk",
+					"tableFrom": "evaluation_config_audit_logs",
+					"tableTo": "brands",
+					"columnsFrom": ["brand_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"evaluation_config_audit_logs_prompt_id_prompts_id_fk": {
+					"name": "evaluation_config_audit_logs_prompt_id_prompts_id_fk",
+					"tableFrom": "evaluation_config_audit_logs",
+					"tableTo": "prompts",
+					"columnsFrom": ["prompt_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.evaluation_entitlements": {
+			"name": "evaluation_entitlements",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"scope": {
+					"name": "scope",
+					"type": "evaluation_entitlement_scope",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"max_configured_targets": {
+					"name": "max_configured_targets",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"max_configured_targets_per_brand": {
+					"name": "max_configured_targets_per_brand",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"max_configured_targets_per_prompt": {
+					"name": "max_configured_targets_per_prompt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"max_samples_per_dispatch": {
+					"name": "max_samples_per_dispatch",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"max_runs_per_day": {
+					"name": "max_runs_per_day",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"evaluation_entitlements_instance_uidx": {
+					"name": "evaluation_entitlements_instance_uidx",
+					"columns": [
+						{
+							"expression": "scope",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"evaluation_entitlements\".\"scope\" = 'instance'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"evaluation_entitlements_organization_uidx": {
+					"name": "evaluation_entitlements_organization_uidx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"evaluation_entitlements\".\"scope\" = 'organization'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"evaluation_entitlements_organization_id_idx": {
+					"name": "evaluation_entitlements_organization_id_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"evaluation_entitlements_organization_id_organization_id_fk": {
+					"name": "evaluation_entitlements_organization_id_organization_id_fk",
+					"tableFrom": "evaluation_entitlements",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"evaluation_entitlements_scope_owner_check": {
+					"name": "evaluation_entitlements_scope_owner_check",
+					"value": "(\n\t\t\t\t(\"evaluation_entitlements\".\"scope\" = 'instance' AND \"evaluation_entitlements\".\"organization_id\" IS NULL)\n\t\t\t\tOR (\"evaluation_entitlements\".\"scope\" = 'organization' AND \"evaluation_entitlements\".\"organization_id\" IS NOT NULL)\n\t\t\t)"
+				},
+				"evaluation_entitlements_limits_check": {
+					"name": "evaluation_entitlements_limits_check",
+					"value": "(\"evaluation_entitlements\".\"max_configured_targets\" IS NULL OR \"evaluation_entitlements\".\"max_configured_targets\" >= 0)\n\t\t\t\tAND (\"evaluation_entitlements\".\"max_configured_targets_per_brand\" IS NULL OR \"evaluation_entitlements\".\"max_configured_targets_per_brand\" >= 0)\n\t\t\t\tAND (\"evaluation_entitlements\".\"max_configured_targets_per_prompt\" IS NULL OR \"evaluation_entitlements\".\"max_configured_targets_per_prompt\" >= 0)\n\t\t\t\tAND (\"evaluation_entitlements\".\"max_samples_per_dispatch\" IS NULL OR \"evaluation_entitlements\".\"max_samples_per_dispatch\" >= 0)\n\t\t\t\tAND (\"evaluation_entitlements\".\"max_runs_per_day\" IS NULL OR \"evaluation_entitlements\".\"max_runs_per_day\" >= 0)"
+				}
+			},
+			"isRLSEnabled": true
+		},
+		"public.evaluation_target_scope_configs": {
+			"name": "evaluation_target_scope_configs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "evaluation_config_scope",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"brand_id": {
+					"name": "brand_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"prompt_id": {
+					"name": "prompt_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cadence_hours": {
+					"name": "cadence_hours",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"samples_per_dispatch": {
+					"name": "samples_per_dispatch",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"evaluation_target_scope_configs_org_target_uidx": {
+					"name": "evaluation_target_scope_configs_org_target_uidx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "target_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"evaluation_target_scope_configs\".\"scope\" = 'organization' AND \"evaluation_target_scope_configs\".\"target_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"evaluation_target_scope_configs_org_default_uidx": {
+					"name": "evaluation_target_scope_configs_org_default_uidx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"evaluation_target_scope_configs\".\"scope\" = 'organization' AND \"evaluation_target_scope_configs\".\"target_id\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"evaluation_target_scope_configs_brand_target_uidx": {
+					"name": "evaluation_target_scope_configs_brand_target_uidx",
+					"columns": [
+						{
+							"expression": "brand_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "target_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"evaluation_target_scope_configs\".\"scope\" = 'brand' AND \"evaluation_target_scope_configs\".\"target_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"evaluation_target_scope_configs_brand_default_uidx": {
+					"name": "evaluation_target_scope_configs_brand_default_uidx",
+					"columns": [
+						{
+							"expression": "brand_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"evaluation_target_scope_configs\".\"scope\" = 'brand' AND \"evaluation_target_scope_configs\".\"target_id\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"evaluation_target_scope_configs_prompt_target_uidx": {
+					"name": "evaluation_target_scope_configs_prompt_target_uidx",
+					"columns": [
+						{
+							"expression": "prompt_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "target_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"evaluation_target_scope_configs\".\"scope\" = 'prompt' AND \"evaluation_target_scope_configs\".\"target_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"evaluation_target_scope_configs_prompt_default_uidx": {
+					"name": "evaluation_target_scope_configs_prompt_default_uidx",
+					"columns": [
+						{
+							"expression": "prompt_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"evaluation_target_scope_configs\".\"scope\" = 'prompt' AND \"evaluation_target_scope_configs\".\"target_id\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"evaluation_target_scope_configs_organization_id_idx": {
+					"name": "evaluation_target_scope_configs_organization_id_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"evaluation_target_scope_configs_brand_id_idx": {
+					"name": "evaluation_target_scope_configs_brand_id_idx",
+					"columns": [
+						{
+							"expression": "brand_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"evaluation_target_scope_configs_prompt_id_idx": {
+					"name": "evaluation_target_scope_configs_prompt_id_idx",
+					"columns": [
+						{
+							"expression": "prompt_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"evaluation_target_scope_configs_target_id_evaluation_targets_id_fk": {
+					"name": "evaluation_target_scope_configs_target_id_evaluation_targets_id_fk",
+					"tableFrom": "evaluation_target_scope_configs",
+					"tableTo": "evaluation_targets",
+					"columnsFrom": ["target_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"evaluation_target_scope_configs_organization_id_organization_id_fk": {
+					"name": "evaluation_target_scope_configs_organization_id_organization_id_fk",
+					"tableFrom": "evaluation_target_scope_configs",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"evaluation_target_scope_configs_brand_id_brands_id_fk": {
+					"name": "evaluation_target_scope_configs_brand_id_brands_id_fk",
+					"tableFrom": "evaluation_target_scope_configs",
+					"tableTo": "brands",
+					"columnsFrom": ["brand_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"evaluation_target_scope_configs_prompt_id_prompts_id_fk": {
+					"name": "evaluation_target_scope_configs_prompt_id_prompts_id_fk",
+					"tableFrom": "evaluation_target_scope_configs",
+					"tableTo": "prompts",
+					"columnsFrom": ["prompt_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"evaluation_target_scope_configs_scope_owner_check": {
+					"name": "evaluation_target_scope_configs_scope_owner_check",
+					"value": "(\n\t\t\t\t(\"evaluation_target_scope_configs\".\"scope\" = 'organization' AND \"evaluation_target_scope_configs\".\"organization_id\" IS NOT NULL AND \"evaluation_target_scope_configs\".\"brand_id\" IS NULL AND \"evaluation_target_scope_configs\".\"prompt_id\" IS NULL)\n\t\t\t\tOR (\"evaluation_target_scope_configs\".\"scope\" = 'brand' AND \"evaluation_target_scope_configs\".\"organization_id\" IS NULL AND \"evaluation_target_scope_configs\".\"brand_id\" IS NOT NULL AND \"evaluation_target_scope_configs\".\"prompt_id\" IS NULL)\n\t\t\t\tOR (\"evaluation_target_scope_configs\".\"scope\" = 'prompt' AND \"evaluation_target_scope_configs\".\"organization_id\" IS NULL AND \"evaluation_target_scope_configs\".\"brand_id\" IS NULL AND \"evaluation_target_scope_configs\".\"prompt_id\" IS NOT NULL)\n\t\t\t)"
+				},
+				"evaluation_target_scope_configs_cadence_check": {
+					"name": "evaluation_target_scope_configs_cadence_check",
+					"value": "\"evaluation_target_scope_configs\".\"cadence_hours\" IS NULL OR \"evaluation_target_scope_configs\".\"cadence_hours\" > 0"
+				},
+				"evaluation_target_scope_configs_samples_check": {
+					"name": "evaluation_target_scope_configs_samples_check",
+					"value": "\"evaluation_target_scope_configs\".\"samples_per_dispatch\" IS NULL OR \"evaluation_target_scope_configs\".\"samples_per_dispatch\" > 0"
+				}
+			},
+			"isRLSEnabled": true
+		},
+		"public.evaluation_targets": {
+			"name": "evaluation_targets",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_connection_id": {
+					"name": "provider_connection_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version": {
+					"name": "version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"web_search": {
+					"name": "web_search",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"requires_prompt_assignment": {
+					"name": "requires_prompt_assignment",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"default_cadence_hours": {
+					"name": "default_cadence_hours",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"default_samples_per_dispatch": {
+					"name": "default_samples_per_dispatch",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"evaluation_targets_key_uidx": {
+					"name": "evaluation_targets_key_uidx",
+					"columns": [
+						{
+							"expression": "key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"evaluation_targets_provider_connection_id_idx": {
+					"name": "evaluation_targets_provider_connection_id_idx",
+					"columns": [
+						{
+							"expression": "provider_connection_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"evaluation_targets_model_idx": {
+					"name": "evaluation_targets_model_idx",
+					"columns": [
+						{
+							"expression": "model",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"evaluation_targets_provider_connection_id_provider_connections_id_fk": {
+					"name": "evaluation_targets_provider_connection_id_provider_connections_id_fk",
+					"tableFrom": "evaluation_targets",
+					"tableTo": "provider_connections",
+					"columnsFrom": ["provider_connection_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"evaluation_targets_defaults_check": {
+					"name": "evaluation_targets_defaults_check",
+					"value": "\"evaluation_targets\".\"default_cadence_hours\" > 0 AND \"evaluation_targets\".\"default_samples_per_dispatch\" > 0"
+				}
+			},
+			"isRLSEnabled": true
+		},
+		"public.instance_settings": {
+			"name": "instance_settings",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "'default'"
+				},
+				"configuration_version": {
+					"name": "configuration_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"legacy_bootstrap_at": {
+					"name": "legacy_bootstrap_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.prompt_runs": {
+			"name": "prompt_runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"prompt_id": {
+					"name": "prompt_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"brand_id": {
+					"name": "brand_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"evaluation_target_id": {
+					"name": "evaluation_target_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"version": {
+					"name": "version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"web_search_enabled": {
+					"name": "web_search_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_output": {
+					"name": "raw_output",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"web_queries": {
+					"name": "web_queries",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				},
+				"brand_mentioned": {
+					"name": "brand_mentioned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"competitors_mentioned": {
+					"name": "competitors_mentioned",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"prompt_runs_prompt_id_created_at_idx": {
+					"name": "prompt_runs_prompt_id_created_at_idx",
+					"columns": [
+						{
+							"expression": "prompt_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"prompt_runs_created_at_idx": {
+					"name": "prompt_runs_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"prompt_runs_web_search_created_at_idx": {
+					"name": "prompt_runs_web_search_created_at_idx",
+					"columns": [
+						{
+							"expression": "web_search_enabled",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"prompt_runs_web_search_model_created_at_idx": {
+					"name": "prompt_runs_web_search_model_created_at_idx",
+					"columns": [
+						{
+							"expression": "web_search_enabled",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "model",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"prompt_runs_provider_idx": {
+					"name": "prompt_runs_provider_idx",
+					"columns": [
+						{
+							"expression": "provider",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"prompt_runs_evaluation_target_id_idx": {
+					"name": "prompt_runs_evaluation_target_id_idx",
+					"columns": [
+						{
+							"expression": "evaluation_target_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"prompt_runs_model_created_at_idx": {
+					"name": "prompt_runs_model_created_at_idx",
+					"columns": [
+						{
+							"expression": "model",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"prompt_runs_prompt_id_prompts_id_fk": {
+					"name": "prompt_runs_prompt_id_prompts_id_fk",
+					"tableFrom": "prompt_runs",
+					"tableTo": "prompts",
+					"columnsFrom": ["prompt_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"prompt_runs_brand_id_brands_id_fk": {
+					"name": "prompt_runs_brand_id_brands_id_fk",
+					"tableFrom": "prompt_runs",
+					"tableTo": "brands",
+					"columnsFrom": ["brand_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"prompt_runs_evaluation_target_id_evaluation_targets_id_fk": {
+					"name": "prompt_runs_evaluation_target_id_evaluation_targets_id_fk",
+					"tableFrom": "prompt_runs",
+					"tableTo": "evaluation_targets",
+					"columnsFrom": ["evaluation_target_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.prompts": {
+			"name": "prompts",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"brand_id": {
+					"name": "brand_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				},
+				"system_tags": {
+					"name": "system_tags",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"prompts_brand_id_idx": {
+					"name": "prompts_brand_id_idx",
+					"columns": [
+						{
+							"expression": "brand_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"prompts_brand_id_enabled_idx": {
+					"name": "prompts_brand_id_enabled_idx",
+					"columns": [
+						{
+							"expression": "brand_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "enabled",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"prompts_brand_id_brands_id_fk": {
+					"name": "prompts_brand_id_brands_id_fk",
+					"tableFrom": "prompts",
+					"tableTo": "brands",
+					"columnsFrom": ["brand_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.provider_connections": {
+			"name": "provider_connections",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_source": {
+					"name": "credential_source",
+					"type": "provider_credential_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_reference": {
+					"name": "credential_reference",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_connections_key_uidx": {
+					"name": "provider_connections_key_uidx",
+					"columns": [
+						{
+							"expression": "key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_connections_provider_idx": {
+					"name": "provider_connections_provider_idx",
+					"columns": [
+						{
+							"expression": "provider",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.reports": {
+			"name": "reports",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"brand_name": {
+					"name": "brand_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"brand_website": {
+					"name": "brand_website",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "report_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"progress": {
+					"name": "progress",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"raw_output": {
+					"name": "raw_output",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"reports_created_at_idx": {
+					"name": "reports_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.invitation": {
+			"name": "invitation",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"inviter_id": {
+					"name": "inviter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"invitation_organizationId_idx": {
+					"name": "invitation_organizationId_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"invitation_email_idx": {
+					"name": "invitation_email_idx",
+					"columns": [
+						{
+							"expression": "email",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"invitation_organization_id_organization_id_fk": {
+					"name": "invitation_organization_id_organization_id_fk",
+					"tableFrom": "invitation",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"invitation_inviter_id_user_id_fk": {
+					"name": "invitation_inviter_id_user_id_fk",
+					"tableFrom": "invitation",
+					"tableTo": "user",
+					"columnsFrom": ["inviter_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.member": {
+			"name": "member",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'member'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"member_organizationId_idx": {
+					"name": "member_organizationId_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"member_userId_idx": {
+					"name": "member_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"member_organization_id_organization_id_fk": {
+					"name": "member_organization_id_organization_id_fk",
+					"tableFrom": "member",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"member_user_id_user_id_fk": {
+					"name": "member_user_id_user_id_fk",
+					"tableFrom": "member",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.organization": {
+			"name": "organization",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"logo": {
+					"name": "logo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"organization_slug_uidx": {
+					"name": "organization_slug_uidx",
+					"columns": [
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"organization_slug_unique": {
+					"name": "organization_slug_unique",
+					"nullsNotDistinct": false,
+					"columns": ["slug"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"active_organization_id": {
+					"name": "active_organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.sso_provider": {
+			"name": "sso_provider",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"issuer": {
+					"name": "issuer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"oidc_config": {
+					"name": "oidc_config",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"saml_config": {
+					"name": "saml_config",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"sso_provider_user_id_user_id_fk": {
+					"name": "sso_provider_user_id_user_id_fk",
+					"tableFrom": "sso_provider",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"sso_provider_provider_id_unique": {
+					"name": "sso_provider_provider_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["provider_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"banned": {
+					"name": "banned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_report_generator_access": {
+					"name": "has_report_generator_access",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.evaluation_config_scope": {
+			"name": "evaluation_config_scope",
+			"schema": "public",
+			"values": ["organization", "brand", "prompt"]
+		},
+		"public.evaluation_entitlement_scope": {
+			"name": "evaluation_entitlement_scope",
+			"schema": "public",
+			"values": ["instance", "organization"]
+		},
+		"public.provider_credential_source": {
+			"name": "provider_credential_source",
+			"schema": "public",
+			"values": ["legacy_env", "encrypted_db", "external_reference"]
+		},
+		"public.report_status": {
+			"name": "report_status",
+			"schema": "public",
+			"values": ["pending", "processing", "completed", "failed"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/lib/src/db/migrations/meta/_journal.json
+++ b/packages/lib/src/db/migrations/meta/_journal.json
@@ -1,83 +1,90 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1770853000310,
-      "tag": "0000_hot_excalibur",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1771495206934,
-      "tag": "0001_sturdy_ares",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1773081311430,
-      "tag": "0002_legal_ultimatum",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1773081457906,
-      "tag": "0003_phase3-constraints-and-indices",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1773100369290,
-      "tag": "0004_nebulous_gunslinger",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1773125217919,
-      "tag": "0005_known_warhawk",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1773200000000,
-      "tag": "0006_multi_domain_aliases",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1775800000000,
-      "tag": "0007_report_progress",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1776000000000,
-      "tag": "0008_provider_engines",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1780782746840,
-      "tag": "0009_brand_opportunities",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1784000000000,
-      "tag": "0010_scope_brands_to_orgs",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1770853000310,
+			"tag": "0000_hot_excalibur",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1771495206934,
+			"tag": "0001_sturdy_ares",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1773081311430,
+			"tag": "0002_legal_ultimatum",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1773081457906,
+			"tag": "0003_phase3-constraints-and-indices",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1773100369290,
+			"tag": "0004_nebulous_gunslinger",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1773125217919,
+			"tag": "0005_known_warhawk",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1773200000000,
+			"tag": "0006_multi_domain_aliases",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1775800000000,
+			"tag": "0007_report_progress",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1776000000000,
+			"tag": "0008_provider_engines",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1780782746840,
+			"tag": "0009_brand_opportunities",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1784000000000,
+			"tag": "0010_scope_brands_to_orgs",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1784667329009,
+      "tag": "0011_evaluation_configuration",
+			"breakpoints": true
+		}
+	]
 }

--- a/packages/lib/src/db/schema.ts
+++ b/packages/lib/src/db/schema.ts
@@ -1,7 +1,21 @@
-import { pgEnum, pgTable, uuid, text, timestamp, boolean, json, index, integer, smallint } from "drizzle-orm/pg-core";
+import {
+	boolean,
+	check,
+	index,
+	integer,
+	json,
+	pgEnum,
+	pgTable,
+	smallint,
+	text,
+	timestamp,
+	uniqueIndex,
+	uuid,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 // `organization` is referenced by the brands FK below; the re-export makes it
 // (and the rest of the auth schema) visible to `import * as schema` consumers.
-import { organization } from "./schema-auth";
+import { organization, user } from "./schema-auth";
 
 // Better-auth tables & relations — re-exported so `import * as schema` sees everything.
 // Source file is auto-generated; run `pnpm run generate:auth-schema` to refresh.
@@ -12,6 +26,242 @@ export * from "./schema-auth";
 // ============================================================================
 
 export const reportStatusEnum = pgEnum("report_status", ["pending", "processing", "completed", "failed"]);
+
+/**
+ * Evaluation configuration is deliberately separate from the deployment
+ * environment. A provider connection describes how an instance reaches a
+ * provider; targets then describe the concrete model/surface that may run.
+ */
+export const providerCredentialSourceEnum = pgEnum("provider_credential_source", [
+	"legacy_env",
+	"encrypted_db",
+	"external_reference",
+]);
+
+export const evaluationConfigScopeEnum = pgEnum("evaluation_config_scope", ["organization", "brand", "prompt"]);
+
+export const evaluationEntitlementScopeEnum = pgEnum("evaluation_entitlement_scope", ["instance", "organization"]);
+
+/**
+ * Singleton instance-level evaluation settings. `id` is always "default";
+ * keeping a real table (instead of env defaults) makes its revision available
+ * to the worker and configuration UI.
+ */
+export const instanceSettings = pgTable("instance_settings", {
+	id: text("id").primaryKey().notNull().default("default"),
+	configurationVersion: integer("configuration_version").notNull().default(0),
+	legacyBootstrapAt: timestamp("legacy_bootstrap_at", { withTimezone: true }),
+	createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+	updatedAt: timestamp("updated_at", { withTimezone: true })
+		.defaultNow()
+		.$onUpdate(() => new Date())
+		.notNull(),
+}).enableRLS();
+
+/**
+ * Instance-owned provider account. Credentials remain outside this table for
+ * now: legacy env mappings are represented without copying a secret into the
+ * database, while encrypted/external sources have a place to land later.
+ */
+export const providerConnections = pgTable(
+	"provider_connections",
+	{
+		id: uuid("id").defaultRandom().primaryKey().notNull(),
+		key: text("key").notNull(),
+		provider: text("provider").notNull(),
+		credentialSource: providerCredentialSourceEnum("credential_source").notNull(),
+		/** Non-secret source metadata, e.g. { provider: "brightdata" }. */
+		credentialReference: json("credential_reference"),
+		enabled: boolean("enabled").notNull().default(true),
+		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+		updatedAt: timestamp("updated_at", { withTimezone: true })
+			.defaultNow()
+			.$onUpdate(() => new Date())
+			.notNull(),
+	},
+	(table) => ({
+		keyUnique: uniqueIndex("provider_connections_key_uidx").on(table.key),
+		providerIdx: index("provider_connections_provider_idx").on(table.provider),
+	}),
+).enableRLS();
+
+/**
+ * A stable evaluation target, such as ChatGPT via BrightData with web search.
+ * Scope rows can narrow this target but never change its provider identity or
+ * instance-level safety defaults.
+ */
+export const evaluationTargets = pgTable(
+	"evaluation_targets",
+	{
+		id: uuid("id").defaultRandom().primaryKey().notNull(),
+		key: text("key").notNull(),
+		model: text("model").notNull(),
+		providerConnectionId: uuid("provider_connection_id")
+			.references(() => providerConnections.id)
+			.notNull(),
+		version: text("version"),
+		webSearch: boolean("web_search").notNull().default(false),
+		enabled: boolean("enabled").notNull().default(true),
+		/** Targets like Claude can opt in only when a prompt explicitly assigns them. */
+		requiresPromptAssignment: boolean("requires_prompt_assignment").notNull().default(false),
+		defaultCadenceHours: integer("default_cadence_hours").notNull(),
+		defaultSamplesPerDispatch: integer("default_samples_per_dispatch").notNull(),
+		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+		updatedAt: timestamp("updated_at", { withTimezone: true })
+			.defaultNow()
+			.$onUpdate(() => new Date())
+			.notNull(),
+	},
+	(table) => ({
+		keyUnique: uniqueIndex("evaluation_targets_key_uidx").on(table.key),
+		defaultsCheck: check(
+			"evaluation_targets_defaults_check",
+			sql`${table.defaultCadenceHours} > 0 AND ${table.defaultSamplesPerDispatch} > 0`,
+		),
+		providerConnectionIdx: index("evaluation_targets_provider_connection_id_idx").on(table.providerConnectionId),
+		modelIdx: index("evaluation_targets_model_idx").on(table.model),
+	}),
+).enableRLS();
+
+/**
+ * Limits are kept apart from target selection so a plan can cap configuration
+ * separately from the number of executions the runtime may consume. The
+ * instance row supplies local defaults; cloud billing can add a row for each
+ * organization without changing the target-resolution query.
+ */
+export const evaluationEntitlements = pgTable(
+	"evaluation_entitlements",
+	{
+		id: uuid("id").defaultRandom().primaryKey().notNull(),
+		scope: evaluationEntitlementScopeEnum("scope").notNull(),
+		organizationId: text("organization_id").references(() => organization.id),
+		maxConfiguredTargets: integer("max_configured_targets"),
+		maxConfiguredTargetsPerBrand: integer("max_configured_targets_per_brand"),
+		maxConfiguredTargetsPerPrompt: integer("max_configured_targets_per_prompt"),
+		maxSamplesPerDispatch: integer("max_samples_per_dispatch"),
+		maxRunsPerDay: integer("max_runs_per_day"),
+		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+		updatedAt: timestamp("updated_at", { withTimezone: true })
+			.defaultNow()
+			.$onUpdate(() => new Date())
+			.notNull(),
+	},
+	(table) => ({
+		scopeOwnerCheck: check(
+			"evaluation_entitlements_scope_owner_check",
+			sql`(
+				(${table.scope} = 'instance' AND ${table.organizationId} IS NULL)
+				OR (${table.scope} = 'organization' AND ${table.organizationId} IS NOT NULL)
+			)`,
+		),
+		limitsCheck: check(
+			"evaluation_entitlements_limits_check",
+			sql`(${table.maxConfiguredTargets} IS NULL OR ${table.maxConfiguredTargets} >= 0)
+				AND (${table.maxConfiguredTargetsPerBrand} IS NULL OR ${table.maxConfiguredTargetsPerBrand} >= 0)
+				AND (${table.maxConfiguredTargetsPerPrompt} IS NULL OR ${table.maxConfiguredTargetsPerPrompt} >= 0)
+				AND (${table.maxSamplesPerDispatch} IS NULL OR ${table.maxSamplesPerDispatch} >= 0)
+				AND (${table.maxRunsPerDay} IS NULL OR ${table.maxRunsPerDay} >= 0)`,
+		),
+		instanceUnique: uniqueIndex("evaluation_entitlements_instance_uidx")
+			.on(table.scope)
+			.where(sql`${table.scope} = 'instance'`),
+		organizationUnique: uniqueIndex("evaluation_entitlements_organization_uidx")
+			.on(table.organizationId)
+			.where(sql`${table.scope} = 'organization'`),
+		organizationIdx: index("evaluation_entitlements_organization_id_idx").on(table.organizationId),
+	}),
+).enableRLS();
+
+/**
+ * One typed override table for organization, brand, and prompt scopes. A row
+ * with a null target is a scope default; a row with a target narrows that one
+ * target. The foreign-key/check combination is intentionally used instead of
+ * a polymorphic `scope_id`, so a configuration row cannot point at a resource
+ * that does not exist.
+ */
+export const evaluationTargetScopeConfigs = pgTable(
+	"evaluation_target_scope_configs",
+	{
+		id: uuid("id").defaultRandom().primaryKey().notNull(),
+		targetId: uuid("target_id").references(() => evaluationTargets.id),
+		scope: evaluationConfigScopeEnum("scope").notNull(),
+		organizationId: text("organization_id").references(() => organization.id),
+		brandId: text("brand_id").references(() => brands.id),
+		promptId: uuid("prompt_id").references(() => prompts.id),
+		/** null means inherit; false is a permanent narrowing at this scope. */
+		enabled: boolean("enabled"),
+		cadenceHours: integer("cadence_hours"),
+		samplesPerDispatch: integer("samples_per_dispatch"),
+		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+		updatedAt: timestamp("updated_at", { withTimezone: true })
+			.defaultNow()
+			.$onUpdate(() => new Date())
+			.notNull(),
+	},
+	(table) => ({
+		scopeOwnerCheck: check(
+			"evaluation_target_scope_configs_scope_owner_check",
+			sql`(
+				(${table.scope} = 'organization' AND ${table.organizationId} IS NOT NULL AND ${table.brandId} IS NULL AND ${table.promptId} IS NULL)
+				OR (${table.scope} = 'brand' AND ${table.organizationId} IS NULL AND ${table.brandId} IS NOT NULL AND ${table.promptId} IS NULL)
+				OR (${table.scope} = 'prompt' AND ${table.organizationId} IS NULL AND ${table.brandId} IS NULL AND ${table.promptId} IS NOT NULL)
+			)`,
+		),
+		cadenceCheck: check(
+			"evaluation_target_scope_configs_cadence_check",
+			sql`${table.cadenceHours} IS NULL OR ${table.cadenceHours} > 0`,
+		),
+		samplesCheck: check(
+			"evaluation_target_scope_configs_samples_check",
+			sql`${table.samplesPerDispatch} IS NULL OR ${table.samplesPerDispatch} > 0`,
+		),
+		organizationTargetUnique: uniqueIndex("evaluation_target_scope_configs_org_target_uidx")
+			.on(table.organizationId, table.targetId)
+			.where(sql`${table.scope} = 'organization' AND ${table.targetId} IS NOT NULL`),
+		organizationDefaultUnique: uniqueIndex("evaluation_target_scope_configs_org_default_uidx")
+			.on(table.organizationId)
+			.where(sql`${table.scope} = 'organization' AND ${table.targetId} IS NULL`),
+		brandTargetUnique: uniqueIndex("evaluation_target_scope_configs_brand_target_uidx")
+			.on(table.brandId, table.targetId)
+			.where(sql`${table.scope} = 'brand' AND ${table.targetId} IS NOT NULL`),
+		brandDefaultUnique: uniqueIndex("evaluation_target_scope_configs_brand_default_uidx")
+			.on(table.brandId)
+			.where(sql`${table.scope} = 'brand' AND ${table.targetId} IS NULL`),
+		promptTargetUnique: uniqueIndex("evaluation_target_scope_configs_prompt_target_uidx")
+			.on(table.promptId, table.targetId)
+			.where(sql`${table.scope} = 'prompt' AND ${table.targetId} IS NOT NULL`),
+		promptDefaultUnique: uniqueIndex("evaluation_target_scope_configs_prompt_default_uidx")
+			.on(table.promptId)
+			.where(sql`${table.scope} = 'prompt' AND ${table.targetId} IS NULL`),
+		organizationIdx: index("evaluation_target_scope_configs_organization_id_idx").on(table.organizationId),
+		brandIdx: index("evaluation_target_scope_configs_brand_id_idx").on(table.brandId),
+		promptIdx: index("evaluation_target_scope_configs_prompt_id_idx").on(table.promptId),
+	}),
+).enableRLS();
+
+/**
+ * Configuration audit records intentionally contain metadata/diffs only;
+ * provider credential material must never be stored in an audit log.
+ */
+export const evaluationConfigAuditLogs = pgTable(
+	"evaluation_config_audit_logs",
+	{
+		id: uuid("id").defaultRandom().primaryKey().notNull(),
+		actorUserId: text("actor_user_id").references(() => user.id),
+		action: text("action").notNull(),
+		scope: evaluationConfigScopeEnum("scope"),
+		organizationId: text("organization_id").references(() => organization.id),
+		brandId: text("brand_id").references(() => brands.id),
+		promptId: uuid("prompt_id").references(() => prompts.id),
+		diff: json("diff"),
+		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+	},
+	(table) => ({
+		createdAtIdx: index("evaluation_config_audit_logs_created_at_idx").on(table.createdAt),
+		organizationIdx: index("evaluation_config_audit_logs_organization_id_idx").on(table.organizationId),
+		brandIdx: index("evaluation_config_audit_logs_brand_id_idx").on(table.brandId),
+	}),
+).enableRLS();
 
 export const brands = pgTable(
 	"brands",
@@ -89,9 +339,13 @@ export const promptRuns = pgTable(
 		promptId: uuid("prompt_id")
 			.references(() => prompts.id)
 			.notNull(),
-		brandId: text("brand_id").references(() => brands.id).notNull(),
+		brandId: text("brand_id")
+			.references(() => brands.id)
+			.notNull(),
 		model: text("model").notNull(),
 		provider: text("provider"),
+		/** Null for historical rows created before database-backed targets existed. */
+		evaluationTargetId: uuid("evaluation_target_id").references(() => evaluationTargets.id),
 		version: text("version").notNull(),
 		webSearchEnabled: boolean("web_search_enabled").notNull(),
 		rawOutput: json("raw_output").notNull(),
@@ -104,8 +358,13 @@ export const promptRuns = pgTable(
 		promptIdCreatedAtIdx: index("prompt_runs_prompt_id_created_at_idx").on(table.promptId, table.createdAt),
 		createdAtIdx: index("prompt_runs_created_at_idx").on(table.createdAt),
 		webSearchCreatedAtIdx: index("prompt_runs_web_search_created_at_idx").on(table.webSearchEnabled, table.createdAt),
-		webSearchModelCreatedAtIdx: index("prompt_runs_web_search_model_created_at_idx").on(table.webSearchEnabled, table.model, table.createdAt),
+		webSearchModelCreatedAtIdx: index("prompt_runs_web_search_model_created_at_idx").on(
+			table.webSearchEnabled,
+			table.model,
+			table.createdAt,
+		),
 		providerIdx: index("prompt_runs_provider_idx").on(table.provider),
+		evaluationTargetIdx: index("prompt_runs_evaluation_target_id_idx").on(table.evaluationTargetId),
 		modelCreatedAtIdx: index("prompt_runs_model_created_at_idx").on(table.model, table.createdAt),
 	}),
 ).enableRLS();
@@ -131,7 +390,15 @@ export const citations = pgTable(
 		createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
 	},
 	(table) => ({
-		brandAnalyticsIdx: index("idx_citations_brand_analytics").on(table.brandId, table.createdAt, table.url, table.domain, table.title, table.promptId, table.model),
+		brandAnalyticsIdx: index("idx_citations_brand_analytics").on(
+			table.brandId,
+			table.createdAt,
+			table.url,
+			table.domain,
+			table.title,
+			table.promptId,
+			table.model,
+		),
 		promptCreatedIdx: index("citations_prompt_id_created_at_idx").on(table.promptId, table.createdAt),
 		domainIdx: index("citations_domain_idx").on(table.domain),
 	}),
@@ -184,6 +451,12 @@ export type NewBrandOpportunity = typeof brandOpportunities.$inferInsert;
 
 export type Brand = typeof brands.$inferSelect;
 export type NewBrand = typeof brands.$inferInsert;
+
+export type InstanceSettings = typeof instanceSettings.$inferSelect;
+export type ProviderConnection = typeof providerConnections.$inferSelect;
+export type EvaluationTarget = typeof evaluationTargets.$inferSelect;
+export type EvaluationEntitlement = typeof evaluationEntitlements.$inferSelect;
+export type EvaluationTargetScopeConfig = typeof evaluationTargetScopeConfigs.$inferSelect;
 
 export type Prompt = typeof prompts.$inferSelect;
 export type NewPrompt = typeof prompts.$inferInsert;

--- a/packages/lib/src/evaluation-config/db.ts
+++ b/packages/lib/src/evaluation-config/db.ts
@@ -1,0 +1,380 @@
+import { formatScrapeTarget, parseScrapeTargets, type ModelConfig } from "@workspace/config/scrape-targets";
+import { and, eq, inArray, or, sql } from "drizzle-orm";
+import { RUNS_PER_PROMPT, getDefaultDelayHours } from "../constants";
+import { db } from "../db/db";
+import {
+	brands,
+	evaluationTargetScopeConfigs,
+	evaluationTargets,
+	instanceSettings,
+	prompts,
+	providerConnections,
+} from "../db/schema";
+import { getProvider } from "../providers";
+import { minimumCadenceHours, resolveEffectiveEvaluationTargets } from "./resolver";
+import type {
+	EffectiveEvaluationTarget,
+	EvaluationTargetForResolution,
+	EvaluationTargetScopeConfigForResolution,
+} from "./types";
+
+export type LegacyBootstrapStatus =
+	| "bootstrapped"
+	| "already-bootstrapped"
+	| "no-legacy-config"
+	| "skipped-existing-config";
+
+export interface LegacyBootstrapResult {
+	status: LegacyBootstrapStatus;
+	targetCount: number;
+}
+
+export interface EnsureEvaluationConfigOptions {
+	env?: Record<string, string | undefined>;
+}
+
+interface PromptContext {
+	promptId: string;
+	brandId: string;
+	organizationId: string;
+}
+
+function legacyProviderConnectionKey(provider: string): string {
+	return `legacy-env:${provider}`;
+}
+
+function legacyTargetKey(config: ModelConfig): string {
+	return `legacy:${formatScrapeTarget(config)}`;
+}
+
+function getLegacyTargets(env: Record<string, string | undefined>): ModelConfig[] | null {
+	const raw = env.SCRAPE_TARGETS;
+	if (!raw || !raw.trim()) return null;
+	return parseScrapeTargets(raw);
+}
+
+function isReadOnlyDeployment(env: Record<string, string | undefined>): boolean {
+	return env.DEPLOYMENT_MODE === "demo" || env.READ_ONLY === "true";
+}
+
+async function ensureInstanceSettings(): Promise<void> {
+	await db.insert(instanceSettings).values({ id: "default" }).onConflictDoNothing();
+}
+
+/**
+ * Imports an existing SCRAPE_TARGETS deployment once, preserving the current
+ * brand-level enabled-model and cadence behavior as scoped rows. Once a real
+ * target exists, this importer deliberately stops: an environment variable can
+ * never overwrite configuration that an operator has edited in the database.
+ */
+export async function bootstrapLegacyEvaluationConfig(
+	options: EnsureEvaluationConfigOptions = {},
+): Promise<LegacyBootstrapResult> {
+	const env = options.env ?? process.env;
+	if (isReadOnlyDeployment(env)) return { status: "no-legacy-config", targetCount: 0 };
+	const legacyTargets = getLegacyTargets(env);
+
+	await ensureInstanceSettings();
+	if (!legacyTargets) return { status: "no-legacy-config", targetCount: 0 };
+
+	return db.transaction(async (tx) => {
+		await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext('elmo:evaluation-config:legacy-bootstrap'))`);
+
+		const [instance] = await tx
+			.select({ legacyBootstrapAt: instanceSettings.legacyBootstrapAt })
+			.from(instanceSettings)
+			.where(eq(instanceSettings.id, "default"))
+			.limit(1);
+
+		if (instance?.legacyBootstrapAt) {
+			const existing = await tx.select({ id: evaluationTargets.id }).from(evaluationTargets);
+			return { status: "already-bootstrapped", targetCount: existing.length };
+		}
+
+		const existingTargets = await tx.select({ id: evaluationTargets.id }).from(evaluationTargets).limit(1);
+		if (existingTargets.length > 0) {
+			await tx
+				.update(instanceSettings)
+				.set({ legacyBootstrapAt: new Date(), updatedAt: new Date() })
+				.where(eq(instanceSettings.id, "default"));
+			const allTargets = await tx.select({ id: evaluationTargets.id }).from(evaluationTargets);
+			return { status: "skipped-existing-config", targetCount: allTargets.length };
+		}
+
+		const providerKeys = [...new Set(legacyTargets.map((target) => target.provider))];
+		await tx
+			.insert(providerConnections)
+			.values(
+				providerKeys.map((provider) => ({
+					key: legacyProviderConnectionKey(provider),
+					provider,
+					credentialSource: "legacy_env" as const,
+					credentialReference: { source: "environment" },
+				})),
+			)
+			.onConflictDoNothing();
+
+		const connections = await tx
+			.select({ id: providerConnections.id, provider: providerConnections.provider })
+			.from(providerConnections)
+			.where(inArray(providerConnections.key, providerKeys.map(legacyProviderConnectionKey)));
+		const connectionIdByProvider = new Map(connections.map((connection) => [connection.provider, connection.id]));
+
+		const defaultCadenceHours = getDefaultDelayHours();
+		await tx
+			.insert(evaluationTargets)
+			.values(
+				legacyTargets.map((target) => {
+					const providerConnectionId = connectionIdByProvider.get(target.provider);
+					if (!providerConnectionId) {
+						throw new Error(`Could not create provider connection for ${target.provider}`);
+					}
+					return {
+						key: legacyTargetKey(target),
+						model: target.model,
+						providerConnectionId,
+						version: target.version,
+						webSearch: target.webSearch,
+						defaultCadenceHours,
+						defaultSamplesPerDispatch: RUNS_PER_PROMPT,
+					};
+				}),
+			)
+			.onConflictDoNothing();
+
+		const targets = await tx
+			.select({ id: evaluationTargets.id, model: evaluationTargets.model, key: evaluationTargets.key })
+			.from(evaluationTargets)
+			.where(inArray(evaluationTargets.key, legacyTargets.map(legacyTargetKey)));
+
+		const existingBrands = await tx
+			.select({ id: brands.id, delayOverrideHours: brands.delayOverrideHours, enabledModels: brands.enabledModels })
+			.from(brands);
+		const configuredModels = new Set(legacyTargets.map((target) => target.model));
+		for (const brand of existingBrands) {
+			const unknownModels = brand.enabledModels?.filter((model) => !configuredModels.has(model)) ?? [];
+			if (unknownModels.length > 0) {
+				throw new Error(
+					`brand.enabledModels references models not in SCRAPE_TARGETS: ${unknownModels.join(", ")}. ` +
+						`Configured models: ${[...configuredModels].join(", ") || "(none)"}.`,
+				);
+			}
+		}
+		const legacyScopeRows = existingBrands.flatMap((brand) => {
+			const rows: Array<typeof evaluationTargetScopeConfigs.$inferInsert> = [];
+			if (brand.delayOverrideHours !== null) {
+				rows.push({
+					scope: "brand",
+					brandId: brand.id,
+					cadenceHours: brand.delayOverrideHours,
+				});
+			}
+			if (brand.enabledModels !== null) {
+				for (const target of targets) {
+					rows.push({
+						scope: "brand",
+						brandId: brand.id,
+						targetId: target.id,
+						enabled: brand.enabledModels.includes(target.model),
+					});
+				}
+			}
+			return rows;
+		});
+
+		if (legacyScopeRows.length > 0) {
+			await tx.insert(evaluationTargetScopeConfigs).values(legacyScopeRows).onConflictDoNothing();
+		}
+
+		await tx
+			.update(instanceSettings)
+			.set({
+				legacyBootstrapAt: new Date(),
+				configurationVersion: sql`${instanceSettings.configurationVersion} + 1`,
+				updatedAt: new Date(),
+			})
+			.where(eq(instanceSettings.id, "default"));
+
+		return { status: "bootstrapped", targetCount: targets.length };
+	});
+}
+
+export async function ensureEvaluationConfig(
+	options: EnsureEvaluationConfigOptions = {},
+): Promise<LegacyBootstrapResult> {
+	const env = options.env ?? process.env;
+	if (isReadOnlyDeployment(env)) return { status: "no-legacy-config", targetCount: 0 };
+	await ensureInstanceSettings();
+	const [instance] = await db
+		.select({ legacyBootstrapAt: instanceSettings.legacyBootstrapAt })
+		.from(instanceSettings)
+		.where(eq(instanceSettings.id, "default"))
+		.limit(1);
+	if (instance?.legacyBootstrapAt) return { status: "already-bootstrapped", targetCount: 0 };
+	return bootstrapLegacyEvaluationConfig({ ...options, env });
+}
+
+async function getResolutionTargets(): Promise<EvaluationTargetForResolution[]> {
+	const rows = await db
+		.select({
+			id: evaluationTargets.id,
+			key: evaluationTargets.key,
+			model: evaluationTargets.model,
+			provider: providerConnections.provider,
+			providerConnectionId: evaluationTargets.providerConnectionId,
+			providerConnectionEnabled: providerConnections.enabled,
+			version: evaluationTargets.version,
+			webSearch: evaluationTargets.webSearch,
+			enabled: evaluationTargets.enabled,
+			requiresPromptAssignment: evaluationTargets.requiresPromptAssignment,
+			defaultCadenceHours: evaluationTargets.defaultCadenceHours,
+			defaultSamplesPerDispatch: evaluationTargets.defaultSamplesPerDispatch,
+		})
+		.from(evaluationTargets)
+		.innerJoin(providerConnections, eq(evaluationTargets.providerConnectionId, providerConnections.id));
+
+	return rows;
+}
+
+async function getScopeConfigsForContexts(
+	contexts: readonly PromptContext[],
+): Promise<EvaluationTargetScopeConfigForResolution[]> {
+	const organizationIds = [...new Set(contexts.map((context) => context.organizationId))];
+	const brandIds = [...new Set(contexts.map((context) => context.brandId))];
+	const promptIds = [...new Set(contexts.map((context) => context.promptId))];
+	const conditions = [
+		organizationIds.length > 0
+			? and(
+					eq(evaluationTargetScopeConfigs.scope, "organization"),
+					inArray(evaluationTargetScopeConfigs.organizationId, organizationIds),
+				)
+			: undefined,
+		brandIds.length > 0
+			? and(eq(evaluationTargetScopeConfigs.scope, "brand"), inArray(evaluationTargetScopeConfigs.brandId, brandIds))
+			: undefined,
+		promptIds.length > 0
+			? and(eq(evaluationTargetScopeConfigs.scope, "prompt"), inArray(evaluationTargetScopeConfigs.promptId, promptIds))
+			: undefined,
+	].filter((condition): condition is NonNullable<typeof condition> => condition !== undefined);
+
+	if (conditions.length === 0) return [];
+	return db
+		.select()
+		.from(evaluationTargetScopeConfigs)
+		.where(or(...conditions));
+}
+
+async function getPromptContexts(promptIds: readonly string[]): Promise<PromptContext[]> {
+	if (promptIds.length === 0) return [];
+	return db
+		.select({
+			promptId: prompts.id,
+			brandId: brands.id,
+			organizationId: brands.organizationId,
+		})
+		.from(prompts)
+		.innerJoin(brands, eq(prompts.brandId, brands.id))
+		.where(inArray(prompts.id, [...new Set(promptIds)]));
+}
+
+/**
+ * Single read path used by workers and UI: each prompt gets the fully resolved
+ * instance → organization → brand → prompt target list in one batch of queries.
+ */
+export async function getEffectiveEvaluationTargetsForPrompts(
+	promptIds: readonly string[],
+): Promise<Map<string, EffectiveEvaluationTarget[]>> {
+	await ensureEvaluationConfig();
+	const contexts = await getPromptContexts(promptIds);
+	const result = new Map<string, EffectiveEvaluationTarget[]>();
+	if (contexts.length === 0) return result;
+
+	const [targets, scopeConfigs] = await Promise.all([getResolutionTargets(), getScopeConfigsForContexts(contexts)]);
+	for (const context of contexts) {
+		result.set(context.promptId, resolveEffectiveEvaluationTargets(targets, scopeConfigs, context));
+	}
+	return result;
+}
+
+export async function getEffectiveEvaluationTargetsForPrompt(promptId: string): Promise<EffectiveEvaluationTarget[]> {
+	const targets = await getEffectiveEvaluationTargetsForPrompts([promptId]);
+	return targets.get(promptId) ?? [];
+}
+
+export async function getEffectiveEvaluationTargetsForBrand(brandId: string): Promise<EffectiveEvaluationTarget[]> {
+	await ensureEvaluationConfig();
+	const [brand] = await db
+		.select({ brandId: brands.id, organizationId: brands.organizationId })
+		.from(brands)
+		.where(eq(brands.id, brandId))
+		.limit(1);
+	if (!brand) return [];
+
+	const context: PromptContext = { ...brand, promptId: "" };
+	const [targets, scopeConfigs] = await Promise.all([getResolutionTargets(), getScopeConfigsForContexts([context])]);
+	return resolveEffectiveEvaluationTargets(targets, scopeConfigs, brand);
+}
+
+export async function getEffectiveEvaluationTargetsForInstance(): Promise<EffectiveEvaluationTarget[]> {
+	await ensureEvaluationConfig();
+	return resolveEffectiveEvaluationTargets(await getResolutionTargets(), [], {});
+}
+
+export async function getPromptCadenceHours(promptId: string): Promise<number | undefined> {
+	return minimumCadenceHours(await getEffectiveEvaluationTargetsForPrompt(promptId));
+}
+
+/**
+ * Validate only runnable database targets. Credentials backed by the legacy
+ * environment preserve the old provider checks; encrypted and external
+ * references fail closed until their runtime resolver is configured.
+ */
+export async function validateConfiguredEvaluationTargets(): Promise<void> {
+	await ensureEvaluationConfig();
+	const rows = await db
+		.select({
+			key: evaluationTargets.key,
+			model: evaluationTargets.model,
+			provider: providerConnections.provider,
+			credentialSource: providerConnections.credentialSource,
+			version: evaluationTargets.version,
+			webSearch: evaluationTargets.webSearch,
+			enabled: evaluationTargets.enabled,
+			connectionEnabled: providerConnections.enabled,
+		})
+		.from(evaluationTargets)
+		.innerJoin(providerConnections, eq(evaluationTargets.providerConnectionId, providerConnections.id))
+		.where(and(eq(evaluationTargets.enabled, true), eq(providerConnections.enabled, true)));
+
+	for (const target of rows) {
+		if (target.credentialSource !== "legacy_env") {
+			throw new Error(
+				`Evaluation target "${target.key}" uses ${target.credentialSource} credentials, but no runtime credential resolver is configured`,
+			);
+		}
+
+		const provider = getProvider(target.provider);
+		if (!provider.isConfigured()) {
+			throw new Error(`Evaluation target "${target.key}" requires credentials for provider "${target.provider}"`);
+		}
+
+		const config: ModelConfig = {
+			model: target.model,
+			provider: target.provider,
+			version: target.version ?? undefined,
+			webSearch: target.webSearch,
+		};
+		if (
+			(target.provider === "openai-api" ||
+				target.provider === "anthropic-api" ||
+				target.provider === "mistral-api" ||
+				target.provider === "openrouter") &&
+			!config.version
+		) {
+			throw new Error(`Evaluation target "${target.key}" requires a version`);
+		}
+
+		const targetError = provider.validateTarget?.(config);
+		if (targetError) throw new Error(`Evaluation target "${target.key}" is invalid: ${targetError}`);
+	}
+}

--- a/packages/lib/src/evaluation-config/db.ts
+++ b/packages/lib/src/evaluation-config/db.ts
@@ -46,7 +46,7 @@ function legacyProviderConnectionKey(provider: string): string {
 }
 
 function legacyTargetKey(config: ModelConfig): string {
-	return `legacy:${formatScrapeTarget(config)}`;
+	return `target:${formatScrapeTarget(config)}`;
 }
 
 function getLegacyTargets(env: Record<string, string | undefined>): ModelConfig[] | null {
@@ -270,6 +270,21 @@ export async function ensureEvaluationConfig(
 		.limit(1);
 	if (instance?.legacyBootstrapAt) return { status: "already-bootstrapped", targetCount: 0 };
 	return bootstrapLegacyEvaluationConfig({ ...options, env });
+}
+
+/**
+ * A monotonically increasing revision carried by scheduled jobs. It lets a
+ * job detect that its cadence or target selection changed after it was queued
+ * without forcing an extra due-history query on unchanged, uniform schedules.
+ */
+export async function getEvaluationConfigurationVersion(): Promise<number> {
+	await ensureEvaluationConfig();
+	const [instance] = await db
+		.select({ configurationVersion: instanceSettings.configurationVersion })
+		.from(instanceSettings)
+		.where(eq(instanceSettings.id, "default"))
+		.limit(1);
+	return instance?.configurationVersion ?? 0;
 }
 
 async function getResolutionTargets(): Promise<EvaluationTargetForResolution[]> {

--- a/packages/lib/src/evaluation-config/db.ts
+++ b/packages/lib/src/evaluation-config/db.ts
@@ -37,6 +37,8 @@ interface PromptContext {
 	promptId: string;
 	brandId: string;
 	organizationId: string;
+	enabledModels: string[] | null;
+	delayOverrideHours: number | null;
 }
 
 function legacyProviderConnectionKey(provider: string): string {
@@ -55,6 +57,62 @@ function getLegacyTargets(env: Record<string, string | undefined>): ModelConfig[
 
 function isReadOnlyDeployment(env: Record<string, string | undefined>): boolean {
 	return env.DEPLOYMENT_MODE === "demo" || env.READ_ONLY === "true";
+}
+
+function legacyResolutionTargets(env: Record<string, string | undefined>): EvaluationTargetForResolution[] {
+	return (getLegacyTargets(env) ?? []).map((target) => ({
+		id: legacyTargetKey(target),
+		key: legacyTargetKey(target),
+		model: target.model,
+		provider: target.provider,
+		providerConnectionId: legacyProviderConnectionKey(target.provider),
+		providerConnectionEnabled: true,
+		version: target.version ?? null,
+		webSearch: target.webSearch,
+		enabled: true,
+		requiresPromptAssignment: false,
+		defaultCadenceHours: getDefaultDelayHours(),
+		defaultSamplesPerDispatch: RUNS_PER_PROMPT,
+	}));
+}
+
+function legacyScopeConfigs(
+	contexts: readonly PromptContext[],
+	targets: readonly EvaluationTargetForResolution[],
+): EvaluationTargetScopeConfigForResolution[] {
+	const configs: EvaluationTargetScopeConfigForResolution[] = [];
+	const configuredBrands = new Set<string>();
+	for (const context of contexts) {
+		if (configuredBrands.has(context.brandId)) continue;
+		configuredBrands.add(context.brandId);
+		if (context.delayOverrideHours !== null) {
+			configs.push({
+				targetId: null,
+				scope: "brand",
+				organizationId: null,
+				brandId: context.brandId,
+				promptId: null,
+				enabled: null,
+				cadenceHours: context.delayOverrideHours,
+				samplesPerDispatch: null,
+			});
+		}
+		if (context.enabledModels !== null) {
+			for (const target of targets) {
+				configs.push({
+					targetId: target.id,
+					scope: "brand",
+					organizationId: null,
+					brandId: context.brandId,
+					promptId: null,
+					enabled: context.enabledModels.includes(target.model),
+					cadenceHours: null,
+					samplesPerDispatch: null,
+				});
+			}
+		}
+	}
+	return configs;
 }
 
 async function ensureInstanceSettings(): Promise<void> {
@@ -271,6 +329,8 @@ async function getPromptContexts(promptIds: readonly string[]): Promise<PromptCo
 			promptId: prompts.id,
 			brandId: brands.id,
 			organizationId: brands.organizationId,
+			enabledModels: brands.enabledModels,
+			delayOverrideHours: brands.delayOverrideHours,
 		})
 		.from(prompts)
 		.innerJoin(brands, eq(prompts.brandId, brands.id))
@@ -289,7 +349,15 @@ export async function getEffectiveEvaluationTargetsForPrompts(
 	const result = new Map<string, EffectiveEvaluationTarget[]>();
 	if (contexts.length === 0) return result;
 
-	const [targets, scopeConfigs] = await Promise.all([getResolutionTargets(), getScopeConfigsForContexts(contexts)]);
+	const [databaseTargets, databaseScopeConfigs] = await Promise.all([
+		getResolutionTargets(),
+		getScopeConfigsForContexts(contexts),
+	]);
+	const useReadOnlyLegacyFallback = databaseTargets.length === 0 && isReadOnlyDeployment(process.env);
+	const targets = useReadOnlyLegacyFallback ? legacyResolutionTargets(process.env) : databaseTargets;
+	const scopeConfigs = useReadOnlyLegacyFallback
+		? [...databaseScopeConfigs, ...legacyScopeConfigs(contexts, targets)]
+		: databaseScopeConfigs;
 	for (const context of contexts) {
 		result.set(context.promptId, resolveEffectiveEvaluationTargets(targets, scopeConfigs, context));
 	}
@@ -304,20 +372,38 @@ export async function getEffectiveEvaluationTargetsForPrompt(promptId: string): 
 export async function getEffectiveEvaluationTargetsForBrand(brandId: string): Promise<EffectiveEvaluationTarget[]> {
 	await ensureEvaluationConfig();
 	const [brand] = await db
-		.select({ brandId: brands.id, organizationId: brands.organizationId })
+		.select({
+			brandId: brands.id,
+			organizationId: brands.organizationId,
+			enabledModels: brands.enabledModels,
+			delayOverrideHours: brands.delayOverrideHours,
+		})
 		.from(brands)
 		.where(eq(brands.id, brandId))
 		.limit(1);
 	if (!brand) return [];
 
 	const context: PromptContext = { ...brand, promptId: "" };
-	const [targets, scopeConfigs] = await Promise.all([getResolutionTargets(), getScopeConfigsForContexts([context])]);
+	const [databaseTargets, databaseScopeConfigs] = await Promise.all([
+		getResolutionTargets(),
+		getScopeConfigsForContexts([context]),
+	]);
+	const useReadOnlyLegacyFallback = databaseTargets.length === 0 && isReadOnlyDeployment(process.env);
+	const targets = useReadOnlyLegacyFallback ? legacyResolutionTargets(process.env) : databaseTargets;
+	const scopeConfigs = useReadOnlyLegacyFallback
+		? [...databaseScopeConfigs, ...legacyScopeConfigs([context], targets)]
+		: databaseScopeConfigs;
 	return resolveEffectiveEvaluationTargets(targets, scopeConfigs, brand);
 }
 
 export async function getEffectiveEvaluationTargetsForInstance(): Promise<EffectiveEvaluationTarget[]> {
 	await ensureEvaluationConfig();
-	return resolveEffectiveEvaluationTargets(await getResolutionTargets(), [], {});
+	const databaseTargets = await getResolutionTargets();
+	const targets =
+		databaseTargets.length === 0 && isReadOnlyDeployment(process.env)
+			? legacyResolutionTargets(process.env)
+			: databaseTargets;
+	return resolveEffectiveEvaluationTargets(targets, [], {});
 }
 
 export async function getPromptCadenceHours(promptId: string): Promise<number | undefined> {

--- a/packages/lib/src/evaluation-config/index.ts
+++ b/packages/lib/src/evaluation-config/index.ts
@@ -1,6 +1,7 @@
 export {
 	bootstrapLegacyEvaluationConfig,
 	ensureEvaluationConfig,
+	getEvaluationConfigurationVersion,
 	getEffectiveEvaluationTargetsForBrand,
 	getEffectiveEvaluationTargetsForInstance,
 	getEffectiveEvaluationTargetsForPrompt,
@@ -11,7 +12,13 @@ export {
 	type LegacyBootstrapResult,
 	type LegacyBootstrapStatus,
 } from "./db";
-export { minimumCadenceHours, resolveEffectiveEvaluationTargets } from "./resolver";
+export {
+	isEffectiveEvaluationTargetOverdue,
+	mapLastRunsToEffectiveTargets,
+	minimumCadenceHours,
+	resolveEffectiveEvaluationTargets,
+	selectDueEvaluationTargets,
+} from "./resolver";
 export {
 	createEvaluationTarget,
 	getBrandOrganizationIdForEvaluation,

--- a/packages/lib/src/evaluation-config/index.ts
+++ b/packages/lib/src/evaluation-config/index.ts
@@ -1,0 +1,37 @@
+export {
+	bootstrapLegacyEvaluationConfig,
+	ensureEvaluationConfig,
+	getEffectiveEvaluationTargetsForBrand,
+	getEffectiveEvaluationTargetsForInstance,
+	getEffectiveEvaluationTargetsForPrompt,
+	getEffectiveEvaluationTargetsForPrompts,
+	getPromptCadenceHours,
+	validateConfiguredEvaluationTargets,
+	type EnsureEvaluationConfigOptions,
+	type LegacyBootstrapResult,
+	type LegacyBootstrapStatus,
+} from "./db";
+export { minimumCadenceHours, resolveEffectiveEvaluationTargets } from "./resolver";
+export {
+	createEvaluationTarget,
+	getBrandOrganizationIdForEvaluation,
+	getEvaluationEntitlementLimits,
+	listEvaluationScopeConfigsForBrand,
+	listEvaluationTargets,
+	updateEvaluationEntitlement,
+	updateEvaluationTarget,
+	updateEvaluationTargetScopeConfig,
+	type CreateEvaluationTargetInput,
+	type EntitlementPatch,
+	type EvaluationScopeOwner,
+	type ScopeConfigPatch,
+	type UpdateEvaluationTargetInput,
+} from "./management";
+export type {
+	EffectiveEvaluationTarget,
+	EvaluationConfigScope,
+	EvaluationEntitlementLimits,
+	EvaluationTargetForResolution,
+	EvaluationTargetResolutionContext,
+	EvaluationTargetScopeConfigForResolution,
+} from "./types";

--- a/packages/lib/src/evaluation-config/management.ts
+++ b/packages/lib/src/evaluation-config/management.ts
@@ -1,4 +1,4 @@
-import type { ModelConfig } from "@workspace/config/scrape-targets";
+import { formatScrapeTarget, type ModelConfig } from "@workspace/config/scrape-targets";
 import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import { db } from "../db/db";
 import {
@@ -8,10 +8,15 @@ import {
 	evaluationTargetScopeConfigs,
 	evaluationTargets,
 	instanceSettings,
+	prompts,
 	providerConnections,
 } from "../db/schema";
 import { getProvider } from "../providers";
-import type { EvaluationConfigScope, EvaluationEntitlementLimits } from "./types";
+import { assertEvaluationEntitlementLimits, resolveEffectiveEvaluationTargets } from "./resolver";
+import type { EvaluationEntitlementLimits } from "./types";
+
+type DatabaseTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+type EvaluationEntitlementRow = typeof evaluationEntitlements.$inferSelect;
 
 export interface CreateEvaluationTargetInput {
 	model: string;
@@ -49,13 +54,7 @@ export interface EntitlementPatch extends EvaluationEntitlementLimits {}
 function managedTargetKey(
 	input: Pick<CreateEvaluationTargetInput, "model" | "provider" | "version" | "webSearch">,
 ): string {
-	return [
-		"managed",
-		encodeURIComponent(input.provider),
-		encodeURIComponent(input.model),
-		encodeURIComponent(input.version ?? "default"),
-		input.webSearch ? "online" : "offline",
-	].join(":");
+	return `target:${formatScrapeTarget({ ...input, version: input.version ?? undefined })}`;
 }
 
 function legacyProviderConnectionKey(provider: string): string {
@@ -86,13 +85,11 @@ function validateTargetInput(input: CreateEvaluationTargetInput): void {
 	}
 }
 
-async function ensureInstanceSettingsInTransaction(
-	tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
-): Promise<void> {
+async function ensureInstanceSettingsInTransaction(tx: DatabaseTransaction): Promise<void> {
 	await tx.insert(instanceSettings).values({ id: "default" }).onConflictDoNothing();
 }
 
-async function bumpConfigurationVersion(tx: Parameters<Parameters<typeof db.transaction>[0]>[0]): Promise<void> {
+async function bumpConfigurationVersion(tx: DatabaseTransaction): Promise<void> {
 	await tx
 		.update(instanceSettings)
 		.set({
@@ -103,7 +100,7 @@ async function bumpConfigurationVersion(tx: Parameters<Parameters<typeof db.tran
 }
 
 async function addAuditLog(
-	tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+	tx: DatabaseTransaction,
 	input: {
 		actorUserId?: string;
 		action: string;
@@ -120,6 +117,172 @@ async function addAuditLog(
 		promptId: input.owner?.scope === "prompt" ? input.owner.promptId : undefined,
 		diff: input.diff,
 	});
+}
+
+async function lockEvaluationEntitlements(tx: DatabaseTransaction, scopeKey: string): Promise<void> {
+	await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`elmo:evaluation-entitlements:${scopeKey}`}))`);
+}
+
+function combineEvaluationEntitlementLimits(rows: readonly EvaluationEntitlementRow[]): EvaluationEntitlementLimits {
+	const instance = rows.find((row) => row.scope === "instance");
+	const organization = rows.find((row) => row.scope === "organization");
+	const constrained = (field: keyof EvaluationEntitlementLimits): number | null => {
+		const values = [instance?.[field], organization?.[field]].filter(
+			(value): value is number => value !== null && value !== undefined,
+		);
+		return values.length > 0 ? Math.min(...values) : null;
+	};
+	return {
+		maxConfiguredTargets: constrained("maxConfiguredTargets"),
+		maxConfiguredTargetsPerBrand: constrained("maxConfiguredTargetsPerBrand"),
+		maxConfiguredTargetsPerPrompt: constrained("maxConfiguredTargetsPerPrompt"),
+		maxSamplesPerDispatch: constrained("maxSamplesPerDispatch"),
+		maxRunsPerDay: constrained("maxRunsPerDay"),
+	};
+}
+
+async function getResolutionTargetsInTransaction(tx: DatabaseTransaction) {
+	return tx
+		.select({
+			id: evaluationTargets.id,
+			key: evaluationTargets.key,
+			model: evaluationTargets.model,
+			provider: providerConnections.provider,
+			providerConnectionId: evaluationTargets.providerConnectionId,
+			providerConnectionEnabled: providerConnections.enabled,
+			version: evaluationTargets.version,
+			webSearch: evaluationTargets.webSearch,
+			enabled: evaluationTargets.enabled,
+			requiresPromptAssignment: evaluationTargets.requiresPromptAssignment,
+			defaultCadenceHours: evaluationTargets.defaultCadenceHours,
+			defaultSamplesPerDispatch: evaluationTargets.defaultSamplesPerDispatch,
+		})
+		.from(evaluationTargets)
+		.innerJoin(providerConnections, eq(evaluationTargets.providerConnectionId, providerConnections.id));
+}
+
+async function getOrganizationIdForScopeOwnerInTransaction(
+	tx: DatabaseTransaction,
+	owner: EvaluationScopeOwner,
+): Promise<string> {
+	if (owner.scope === "organization") return owner.organizationId;
+	if (owner.scope === "brand") {
+		const [brand] = await tx
+			.select({ organizationId: brands.organizationId })
+			.from(brands)
+			.where(eq(brands.id, owner.brandId))
+			.limit(1);
+		if (!brand) throw new Error("Brand not found");
+		return brand.organizationId;
+	}
+
+	const [prompt] = await tx
+		.select({ organizationId: brands.organizationId })
+		.from(prompts)
+		.innerJoin(brands, eq(prompts.brandId, brands.id))
+		.where(eq(prompts.id, owner.promptId))
+		.limit(1);
+	if (!prompt) throw new Error("Prompt not found");
+	return prompt.organizationId;
+}
+
+async function enforceOrganizationEvaluationEntitlements(
+	tx: DatabaseTransaction,
+	organizationId: string,
+): Promise<void> {
+	const [organizationBrands, targets, entitlementRows] = await Promise.all([
+		tx.select({ id: brands.id }).from(brands).where(eq(brands.organizationId, organizationId)),
+		getResolutionTargetsInTransaction(tx),
+		tx
+			.select()
+			.from(evaluationEntitlements)
+			.where(
+				or(
+					eq(evaluationEntitlements.scope, "instance"),
+					and(
+						eq(evaluationEntitlements.scope, "organization"),
+						eq(evaluationEntitlements.organizationId, organizationId),
+					),
+				),
+			),
+	]);
+	const brandIds = organizationBrands.map((brand) => brand.id);
+	const organizationPrompts =
+		brandIds.length === 0
+			? []
+			: await tx
+					.select({ id: prompts.id, brandId: prompts.brandId })
+					.from(prompts)
+					.where(inArray(prompts.brandId, brandIds));
+	const promptIds = organizationPrompts.map((prompt) => prompt.id);
+	const scopeConditions = [
+		and(
+			eq(evaluationTargetScopeConfigs.scope, "organization"),
+			eq(evaluationTargetScopeConfigs.organizationId, organizationId),
+		),
+		...(brandIds.length > 0
+			? [and(eq(evaluationTargetScopeConfigs.scope, "brand"), inArray(evaluationTargetScopeConfigs.brandId, brandIds))]
+			: []),
+		...(promptIds.length > 0
+			? [
+					and(
+						eq(evaluationTargetScopeConfigs.scope, "prompt"),
+						inArray(evaluationTargetScopeConfigs.promptId, promptIds),
+					),
+				]
+			: []),
+	];
+	const scopeConfigs = await tx
+		.select()
+		.from(evaluationTargetScopeConfigs)
+		.where(or(...scopeConditions));
+	const limits = combineEvaluationEntitlementLimits(entitlementRows);
+	const configuredTargets = resolveEffectiveEvaluationTargets(targets, scopeConfigs, { organizationId });
+	const brandTargets = organizationBrands.map((brand) => ({
+		label: brand.id,
+		targets: resolveEffectiveEvaluationTargets(targets, scopeConfigs, {
+			organizationId,
+			brandId: brand.id,
+		}),
+	}));
+	const promptTargets = organizationPrompts.map((prompt) => ({
+		label: prompt.id,
+		targets: resolveEffectiveEvaluationTargets(targets, scopeConfigs, {
+			organizationId,
+			brandId: prompt.brandId,
+			promptId: prompt.id,
+		}),
+	}));
+	assertEvaluationEntitlementLimits({ limits, configuredTargets, brandTargets, promptTargets });
+}
+
+async function enforceAllEvaluationEntitlements(tx: DatabaseTransaction): Promise<void> {
+	const [targets, entitlementRows, brandRows] = await Promise.all([
+		getResolutionTargetsInTransaction(tx),
+		tx.select().from(evaluationEntitlements).where(eq(evaluationEntitlements.scope, "instance")),
+		tx.select({ organizationId: brands.organizationId }).from(brands),
+	]);
+	assertEvaluationEntitlementLimits({
+		limits: combineEvaluationEntitlementLimits(entitlementRows),
+		configuredTargets: resolveEffectiveEvaluationTargets(targets, [], {}),
+	});
+
+	const organizationEntitlements = await tx
+		.select({ organizationId: evaluationEntitlements.organizationId })
+		.from(evaluationEntitlements)
+		.where(eq(evaluationEntitlements.scope, "organization"));
+	const organizationIds = [
+		...new Set(
+			[
+				...brandRows.map((brand) => brand.organizationId),
+				...organizationEntitlements.map((row) => row.organizationId),
+			].filter((id): id is string => id !== null),
+		),
+	].sort();
+	for (const organizationId of organizationIds) {
+		await lockEvaluationEntitlements(tx, organizationId);
+		await enforceOrganizationEvaluationEntitlements(tx, organizationId);
+	}
 }
 
 export async function listEvaluationTargets() {
@@ -151,6 +314,7 @@ export async function createEvaluationTarget(input: CreateEvaluationTargetInput,
 	return db.transaction(async (tx) => {
 		await ensureInstanceSettingsInTransaction(tx);
 		await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`elmo:evaluation-target:${key}`}))`);
+		await lockEvaluationEntitlements(tx, "instance");
 
 		await tx
 			.insert(providerConnections)
@@ -188,6 +352,7 @@ export async function createEvaluationTarget(input: CreateEvaluationTargetInput,
 		if (!target) throw new Error("Could not create evaluation target");
 
 		if (created) {
+			await enforceAllEvaluationEntitlements(tx);
 			await bumpConfigurationVersion(tx);
 			await addAuditLog(tx, {
 				actorUserId,
@@ -202,6 +367,8 @@ export async function createEvaluationTarget(input: CreateEvaluationTargetInput,
 export async function updateEvaluationTarget(input: UpdateEvaluationTargetInput, actorUserId?: string) {
 	return db.transaction(async (tx) => {
 		await ensureInstanceSettingsInTransaction(tx);
+		await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`elmo:evaluation-target:${input.targetId}`}))`);
+		await lockEvaluationEntitlements(tx, "instance");
 		const [target] = await tx.select().from(evaluationTargets).where(eq(evaluationTargets.id, input.targetId)).limit(1);
 		if (!target) throw new Error("Evaluation target not found");
 
@@ -222,6 +389,7 @@ export async function updateEvaluationTarget(input: UpdateEvaluationTargetInput,
 			.returning();
 		if (!updated) throw new Error("Could not update evaluation target");
 
+		await enforceAllEvaluationEntitlements(tx);
 		await bumpConfigurationVersion(tx);
 		await addAuditLog(tx, {
 			actorUserId,
@@ -272,6 +440,8 @@ export async function updateEvaluationTargetScopeConfig(
 ) {
 	return db.transaction(async (tx) => {
 		await ensureInstanceSettingsInTransaction(tx);
+		const organizationId = await getOrganizationIdForScopeOwnerInTransaction(tx, owner);
+		await lockEvaluationEntitlements(tx, organizationId);
 		await tx.execute(
 			sql`SELECT pg_advisory_xact_lock(hashtext(${`elmo:evaluation-scope:${owner.scope}:${scopeOwnerId(owner)}:${patch.targetId ?? "default"}`}))`,
 		);
@@ -295,6 +465,7 @@ export async function updateEvaluationTargetScopeConfig(
 		if (!hasOverrides) {
 			if (existing) {
 				await tx.delete(evaluationTargetScopeConfigs).where(eq(evaluationTargetScopeConfigs.id, existing.id));
+				await enforceOrganizationEvaluationEntitlements(tx, organizationId);
 				await bumpConfigurationVersion(tx);
 				await addAuditLog(tx, {
 					actorUserId,
@@ -318,6 +489,7 @@ export async function updateEvaluationTargetScopeConfig(
 					.returning();
 		if (!result) throw new Error("Could not update evaluation scope configuration");
 
+		await enforceOrganizationEvaluationEntitlements(tx, organizationId);
 		await bumpConfigurationVersion(tx);
 		await addAuditLog(tx, {
 			actorUserId,
@@ -345,21 +517,7 @@ export async function getEvaluationEntitlementLimits(organizationId?: string): P
 		.select()
 		.from(evaluationEntitlements)
 		.where(or(...conditions));
-	const instance = rows.find((row) => row.scope === "instance");
-	const organization = rows.find((row) => row.scope === "organization");
-	const constrained = (field: keyof EvaluationEntitlementLimits): number | null => {
-		const values = [instance?.[field], organization?.[field]].filter(
-			(value): value is number => value !== null && value !== undefined,
-		);
-		return values.length > 0 ? Math.min(...values) : null;
-	};
-	return {
-		maxConfiguredTargets: constrained("maxConfiguredTargets"),
-		maxConfiguredTargetsPerBrand: constrained("maxConfiguredTargetsPerBrand"),
-		maxConfiguredTargetsPerPrompt: constrained("maxConfiguredTargetsPerPrompt"),
-		maxSamplesPerDispatch: constrained("maxSamplesPerDispatch"),
-		maxRunsPerDay: constrained("maxRunsPerDay"),
-	};
+	return combineEvaluationEntitlementLimits(rows);
 }
 
 export async function updateEvaluationEntitlement(
@@ -373,6 +531,7 @@ export async function updateEvaluationEntitlement(
 
 	return db.transaction(async (tx) => {
 		await ensureInstanceSettingsInTransaction(tx);
+		await lockEvaluationEntitlements(tx, scope === "instance" ? "instance" : organizationId!);
 		const condition =
 			scope === "instance"
 				? eq(evaluationEntitlements.scope, "instance")
@@ -400,6 +559,11 @@ export async function updateEvaluationEntitlement(
 					.returning();
 		if (!result) throw new Error("Could not update evaluation entitlement");
 
+		if (scope === "instance") {
+			await enforceAllEvaluationEntitlements(tx);
+		} else {
+			await enforceOrganizationEvaluationEntitlements(tx, organizationId!);
+		}
 		await bumpConfigurationVersion(tx);
 		await addAuditLog(tx, {
 			actorUserId,

--- a/packages/lib/src/evaluation-config/management.ts
+++ b/packages/lib/src/evaluation-config/management.ts
@@ -1,0 +1,438 @@
+import type { ModelConfig } from "@workspace/config/scrape-targets";
+import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
+import { db } from "../db/db";
+import {
+	brands,
+	evaluationConfigAuditLogs,
+	evaluationEntitlements,
+	evaluationTargetScopeConfigs,
+	evaluationTargets,
+	instanceSettings,
+	providerConnections,
+} from "../db/schema";
+import { getProvider } from "../providers";
+import type { EvaluationConfigScope, EvaluationEntitlementLimits } from "./types";
+
+export interface CreateEvaluationTargetInput {
+	model: string;
+	provider: string;
+	version?: string | null;
+	webSearch: boolean;
+	requiresPromptAssignment?: boolean;
+	defaultCadenceHours: number;
+	defaultSamplesPerDispatch: number;
+	enabled?: boolean;
+}
+
+export interface UpdateEvaluationTargetInput {
+	targetId: string;
+	enabled?: boolean;
+	requiresPromptAssignment?: boolean;
+	defaultCadenceHours?: number;
+	defaultSamplesPerDispatch?: number;
+}
+
+export type EvaluationScopeOwner =
+	| { scope: "organization"; organizationId: string }
+	| { scope: "brand"; brandId: string }
+	| { scope: "prompt"; promptId: string };
+
+export interface ScopeConfigPatch {
+	targetId: string | null;
+	enabled?: boolean | null;
+	cadenceHours?: number | null;
+	samplesPerDispatch?: number | null;
+}
+
+export interface EntitlementPatch extends EvaluationEntitlementLimits {}
+
+function managedTargetKey(
+	input: Pick<CreateEvaluationTargetInput, "model" | "provider" | "version" | "webSearch">,
+): string {
+	return [
+		"managed",
+		encodeURIComponent(input.provider),
+		encodeURIComponent(input.model),
+		encodeURIComponent(input.version ?? "default"),
+		input.webSearch ? "online" : "offline",
+	].join(":");
+}
+
+function legacyProviderConnectionKey(provider: string): string {
+	return `legacy-env:${provider}`;
+}
+
+function validateTargetInput(input: CreateEvaluationTargetInput): void {
+	const config: ModelConfig = {
+		model: input.model,
+		provider: input.provider,
+		version: input.version ?? undefined,
+		webSearch: input.webSearch,
+	};
+	const provider = getProvider(config.provider);
+	if (
+		(config.provider === "openai-api" ||
+			config.provider === "anthropic-api" ||
+			config.provider === "mistral-api" ||
+			config.provider === "openrouter") &&
+		!config.version
+	) {
+		throw new Error(`Provider "${config.provider}" requires a version`);
+	}
+	const targetError = provider.validateTarget?.(config);
+	if (targetError) throw new Error(targetError);
+	if (input.enabled !== false && !provider.isConfigured()) {
+		throw new Error(`Provider "${config.provider}" credentials are not configured`);
+	}
+}
+
+async function ensureInstanceSettingsInTransaction(
+	tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+): Promise<void> {
+	await tx.insert(instanceSettings).values({ id: "default" }).onConflictDoNothing();
+}
+
+async function bumpConfigurationVersion(tx: Parameters<Parameters<typeof db.transaction>[0]>[0]): Promise<void> {
+	await tx
+		.update(instanceSettings)
+		.set({
+			configurationVersion: sql`${instanceSettings.configurationVersion} + 1`,
+			updatedAt: new Date(),
+		})
+		.where(eq(instanceSettings.id, "default"));
+}
+
+async function addAuditLog(
+	tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+	input: {
+		actorUserId?: string;
+		action: string;
+		owner?: EvaluationScopeOwner;
+		diff: Record<string, unknown>;
+	},
+): Promise<void> {
+	await tx.insert(evaluationConfigAuditLogs).values({
+		actorUserId: input.actorUserId,
+		action: input.action,
+		scope: input.owner?.scope,
+		organizationId: input.owner?.scope === "organization" ? input.owner.organizationId : undefined,
+		brandId: input.owner?.scope === "brand" ? input.owner.brandId : undefined,
+		promptId: input.owner?.scope === "prompt" ? input.owner.promptId : undefined,
+		diff: input.diff,
+	});
+}
+
+export async function listEvaluationTargets() {
+	return db
+		.select({
+			id: evaluationTargets.id,
+			key: evaluationTargets.key,
+			model: evaluationTargets.model,
+			provider: providerConnections.provider,
+			providerConnectionId: evaluationTargets.providerConnectionId,
+			credentialSource: providerConnections.credentialSource,
+			connectionEnabled: providerConnections.enabled,
+			version: evaluationTargets.version,
+			webSearch: evaluationTargets.webSearch,
+			enabled: evaluationTargets.enabled,
+			requiresPromptAssignment: evaluationTargets.requiresPromptAssignment,
+			defaultCadenceHours: evaluationTargets.defaultCadenceHours,
+			defaultSamplesPerDispatch: evaluationTargets.defaultSamplesPerDispatch,
+		})
+		.from(evaluationTargets)
+		.innerJoin(providerConnections, eq(evaluationTargets.providerConnectionId, providerConnections.id))
+		.orderBy(evaluationTargets.key);
+}
+
+export async function createEvaluationTarget(input: CreateEvaluationTargetInput, actorUserId?: string) {
+	validateTargetInput(input);
+	const key = managedTargetKey(input);
+
+	return db.transaction(async (tx) => {
+		await ensureInstanceSettingsInTransaction(tx);
+		await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`elmo:evaluation-target:${key}`}))`);
+
+		await tx
+			.insert(providerConnections)
+			.values({
+				key: legacyProviderConnectionKey(input.provider),
+				provider: input.provider,
+				credentialSource: "legacy_env",
+				credentialReference: { source: "environment" },
+			})
+			.onConflictDoNothing();
+		const [connection] = await tx
+			.select({ id: providerConnections.id })
+			.from(providerConnections)
+			.where(eq(providerConnections.key, legacyProviderConnectionKey(input.provider)))
+			.limit(1);
+		if (!connection) throw new Error(`Could not create provider connection for "${input.provider}"`);
+
+		const [created] = await tx
+			.insert(evaluationTargets)
+			.values({
+				key,
+				model: input.model,
+				providerConnectionId: connection.id,
+				version: input.version ?? null,
+				webSearch: input.webSearch,
+				enabled: input.enabled ?? true,
+				requiresPromptAssignment: input.requiresPromptAssignment ?? false,
+				defaultCadenceHours: input.defaultCadenceHours,
+				defaultSamplesPerDispatch: input.defaultSamplesPerDispatch,
+			})
+			.onConflictDoNothing()
+			.returning();
+		const target =
+			created ?? (await tx.select().from(evaluationTargets).where(eq(evaluationTargets.key, key)).limit(1))[0];
+		if (!target) throw new Error("Could not create evaluation target");
+
+		if (created) {
+			await bumpConfigurationVersion(tx);
+			await addAuditLog(tx, {
+				actorUserId,
+				action: "evaluation_target.created",
+				diff: { targetId: target.id, key: target.key },
+			});
+		}
+		return target;
+	});
+}
+
+export async function updateEvaluationTarget(input: UpdateEvaluationTargetInput, actorUserId?: string) {
+	return db.transaction(async (tx) => {
+		await ensureInstanceSettingsInTransaction(tx);
+		const [target] = await tx.select().from(evaluationTargets).where(eq(evaluationTargets.id, input.targetId)).limit(1);
+		if (!target) throw new Error("Evaluation target not found");
+
+		const [updated] = await tx
+			.update(evaluationTargets)
+			.set({
+				...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
+				...(input.requiresPromptAssignment !== undefined
+					? { requiresPromptAssignment: input.requiresPromptAssignment }
+					: {}),
+				...(input.defaultCadenceHours !== undefined ? { defaultCadenceHours: input.defaultCadenceHours } : {}),
+				...(input.defaultSamplesPerDispatch !== undefined
+					? { defaultSamplesPerDispatch: input.defaultSamplesPerDispatch }
+					: {}),
+				updatedAt: new Date(),
+			})
+			.where(eq(evaluationTargets.id, input.targetId))
+			.returning();
+		if (!updated) throw new Error("Could not update evaluation target");
+
+		await bumpConfigurationVersion(tx);
+		await addAuditLog(tx, {
+			actorUserId,
+			action: "evaluation_target.updated",
+			diff: { ...input, targetId: updated.id },
+		});
+		return updated;
+	});
+}
+
+function scopeOwnerId(owner: EvaluationScopeOwner): string {
+	switch (owner.scope) {
+		case "organization":
+			return owner.organizationId;
+		case "brand":
+			return owner.brandId;
+		case "prompt":
+			return owner.promptId;
+	}
+}
+
+function scopeOwnerValues(owner: EvaluationScopeOwner) {
+	switch (owner.scope) {
+		case "organization":
+			return { scope: owner.scope, organizationId: owner.organizationId } as const;
+		case "brand":
+			return { scope: owner.scope, brandId: owner.brandId } as const;
+		case "prompt":
+			return { scope: owner.scope, promptId: owner.promptId } as const;
+	}
+}
+
+function scopeOwnerCondition(owner: EvaluationScopeOwner) {
+	switch (owner.scope) {
+		case "organization":
+			return eq(evaluationTargetScopeConfigs.organizationId, owner.organizationId);
+		case "brand":
+			return eq(evaluationTargetScopeConfigs.brandId, owner.brandId);
+		case "prompt":
+			return eq(evaluationTargetScopeConfigs.promptId, owner.promptId);
+	}
+}
+
+export async function updateEvaluationTargetScopeConfig(
+	owner: EvaluationScopeOwner,
+	patch: ScopeConfigPatch,
+	actorUserId?: string,
+) {
+	return db.transaction(async (tx) => {
+		await ensureInstanceSettingsInTransaction(tx);
+		await tx.execute(
+			sql`SELECT pg_advisory_xact_lock(hashtext(${`elmo:evaluation-scope:${owner.scope}:${scopeOwnerId(owner)}:${patch.targetId ?? "default"}`}))`,
+		);
+		const targetCondition = patch.targetId
+			? eq(evaluationTargetScopeConfigs.targetId, patch.targetId)
+			: isNull(evaluationTargetScopeConfigs.targetId);
+		const [existing] = await tx
+			.select()
+			.from(evaluationTargetScopeConfigs)
+			.where(and(eq(evaluationTargetScopeConfigs.scope, owner.scope), scopeOwnerCondition(owner), targetCondition))
+			.limit(1);
+
+		const next = {
+			enabled: patch.enabled === undefined ? (existing?.enabled ?? null) : patch.enabled,
+			cadenceHours: patch.cadenceHours === undefined ? (existing?.cadenceHours ?? null) : patch.cadenceHours,
+			samplesPerDispatch:
+				patch.samplesPerDispatch === undefined ? (existing?.samplesPerDispatch ?? null) : patch.samplesPerDispatch,
+		};
+		const hasOverrides = Object.values(next).some((value) => value !== null);
+
+		if (!hasOverrides) {
+			if (existing) {
+				await tx.delete(evaluationTargetScopeConfigs).where(eq(evaluationTargetScopeConfigs.id, existing.id));
+				await bumpConfigurationVersion(tx);
+				await addAuditLog(tx, {
+					actorUserId,
+					action: "evaluation_scope_config.deleted",
+					owner,
+					diff: { targetId: patch.targetId },
+				});
+			}
+			return undefined;
+		}
+
+		const [result] = existing
+			? await tx
+					.update(evaluationTargetScopeConfigs)
+					.set({ ...next, updatedAt: new Date() })
+					.where(eq(evaluationTargetScopeConfigs.id, existing.id))
+					.returning()
+			: await tx
+					.insert(evaluationTargetScopeConfigs)
+					.values({ ...scopeOwnerValues(owner), targetId: patch.targetId, ...next })
+					.returning();
+		if (!result) throw new Error("Could not update evaluation scope configuration");
+
+		await bumpConfigurationVersion(tx);
+		await addAuditLog(tx, {
+			actorUserId,
+			action: "evaluation_scope_config.updated",
+			owner,
+			diff: { targetId: patch.targetId, ...next },
+		});
+		return result;
+	});
+}
+
+export async function getEvaluationEntitlementLimits(organizationId?: string): Promise<EvaluationEntitlementLimits> {
+	const conditions = [
+		eq(evaluationEntitlements.scope, "instance"),
+		...(organizationId
+			? [
+					and(
+						eq(evaluationEntitlements.scope, "organization"),
+						eq(evaluationEntitlements.organizationId, organizationId),
+					),
+				]
+			: []),
+	];
+	const rows = await db
+		.select()
+		.from(evaluationEntitlements)
+		.where(or(...conditions));
+	const instance = rows.find((row) => row.scope === "instance");
+	const organization = rows.find((row) => row.scope === "organization");
+	const constrained = (field: keyof EvaluationEntitlementLimits): number | null => {
+		const values = [instance?.[field], organization?.[field]].filter(
+			(value): value is number => value !== null && value !== undefined,
+		);
+		return values.length > 0 ? Math.min(...values) : null;
+	};
+	return {
+		maxConfiguredTargets: constrained("maxConfiguredTargets"),
+		maxConfiguredTargetsPerBrand: constrained("maxConfiguredTargetsPerBrand"),
+		maxConfiguredTargetsPerPrompt: constrained("maxConfiguredTargetsPerPrompt"),
+		maxSamplesPerDispatch: constrained("maxSamplesPerDispatch"),
+		maxRunsPerDay: constrained("maxRunsPerDay"),
+	};
+}
+
+export async function updateEvaluationEntitlement(
+	scope: "instance" | "organization",
+	limits: EntitlementPatch,
+	actorUserId?: string,
+	organizationId?: string,
+) {
+	if (scope === "organization" && !organizationId)
+		throw new Error("Organization entitlement requires an organization ID");
+
+	return db.transaction(async (tx) => {
+		await ensureInstanceSettingsInTransaction(tx);
+		const condition =
+			scope === "instance"
+				? eq(evaluationEntitlements.scope, "instance")
+				: and(
+						eq(evaluationEntitlements.scope, "organization"),
+						eq(evaluationEntitlements.organizationId, organizationId!),
+					);
+		const [existing] = await tx.select().from(evaluationEntitlements).where(condition).limit(1);
+		const values = {
+			maxConfiguredTargets: limits.maxConfiguredTargets,
+			maxConfiguredTargetsPerBrand: limits.maxConfiguredTargetsPerBrand,
+			maxConfiguredTargetsPerPrompt: limits.maxConfiguredTargetsPerPrompt,
+			maxSamplesPerDispatch: limits.maxSamplesPerDispatch,
+			maxRunsPerDay: limits.maxRunsPerDay,
+		};
+		const [result] = existing
+			? await tx
+					.update(evaluationEntitlements)
+					.set({ ...values, updatedAt: new Date() })
+					.where(eq(evaluationEntitlements.id, existing.id))
+					.returning()
+			: await tx
+					.insert(evaluationEntitlements)
+					.values({ scope, organizationId: scope === "organization" ? organizationId : null, ...values })
+					.returning();
+		if (!result) throw new Error("Could not update evaluation entitlement");
+
+		await bumpConfigurationVersion(tx);
+		await addAuditLog(tx, {
+			actorUserId,
+			action: "evaluation_entitlement.updated",
+			owner: scope === "organization" ? { scope: "organization", organizationId: organizationId! } : undefined,
+			diff: values,
+		});
+		return result;
+	});
+}
+
+export async function getBrandOrganizationIdForEvaluation(brandId: string): Promise<string | undefined> {
+	const [brand] = await db
+		.select({ organizationId: brands.organizationId })
+		.from(brands)
+		.where(eq(brands.id, brandId))
+		.limit(1);
+	return brand?.organizationId;
+}
+
+export async function listEvaluationScopeConfigsForBrand(brandId: string) {
+	const organizationId = await getBrandOrganizationIdForEvaluation(brandId);
+	if (!organizationId) return [];
+	return db
+		.select()
+		.from(evaluationTargetScopeConfigs)
+		.where(
+			or(
+				and(
+					eq(evaluationTargetScopeConfigs.scope, "organization"),
+					eq(evaluationTargetScopeConfigs.organizationId, organizationId),
+				),
+				and(eq(evaluationTargetScopeConfigs.scope, "brand"), eq(evaluationTargetScopeConfigs.brandId, brandId)),
+			),
+		);
+}

--- a/packages/lib/src/evaluation-config/resolver.test.ts
+++ b/packages/lib/src/evaluation-config/resolver.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { resolveEffectiveEvaluationTargets } from "./resolver";
+import type { EvaluationTargetForResolution, EvaluationTargetScopeConfigForResolution } from "./types";
+
+const baseTarget: EvaluationTargetForResolution = {
+	id: "target-chatgpt",
+	key: "chatgpt-brightdata-online",
+	model: "chatgpt",
+	provider: "brightdata",
+	providerConnectionId: "connection-brightdata",
+	providerConnectionEnabled: true,
+	version: null,
+	webSearch: true,
+	enabled: true,
+	requiresPromptAssignment: false,
+	defaultCadenceHours: 24,
+	defaultSamplesPerDispatch: 2,
+};
+
+function scopeConfig(
+	partial: Partial<EvaluationTargetScopeConfigForResolution>,
+): EvaluationTargetScopeConfigForResolution {
+	return {
+		targetId: null,
+		scope: "organization",
+		organizationId: "org-1",
+		brandId: null,
+		promptId: null,
+		enabled: null,
+		cadenceHours: null,
+		samplesPerDispatch: null,
+		...partial,
+	};
+}
+
+describe("resolveEffectiveEvaluationTargets", () => {
+	it("does not allow a child scope to restore a target disabled by an organization", () => {
+		const effective = resolveEffectiveEvaluationTargets(
+			[baseTarget],
+			[
+				scopeConfig({ targetId: baseTarget.id, enabled: false }),
+				scopeConfig({
+					scope: "brand",
+					organizationId: null,
+					brandId: "brand-1",
+					targetId: baseTarget.id,
+					enabled: true,
+				}),
+			],
+			{ organizationId: "org-1", brandId: "brand-1", promptId: "prompt-1" },
+		);
+
+		expect(effective).toEqual([]);
+	});
+
+	it("requires an explicit prompt assignment when a target opts into it", () => {
+		const target = { ...baseTarget, requiresPromptAssignment: true };
+
+		expect(
+			resolveEffectiveEvaluationTargets([target], [], {
+				organizationId: "org-1",
+				brandId: "brand-1",
+				promptId: "prompt-1",
+			}),
+		).toEqual([]);
+
+		const effective = resolveEffectiveEvaluationTargets(
+			[target],
+			[
+				scopeConfig({
+					scope: "prompt",
+					organizationId: null,
+					brandId: null,
+					promptId: "prompt-1",
+					targetId: target.id,
+					enabled: true,
+				}),
+			],
+			{ organizationId: "org-1", brandId: "brand-1", promptId: "prompt-1" },
+		);
+
+		expect(effective).toMatchObject([{ targetId: target.id }]);
+	});
+
+	it("uses target-specific values after scope defaults", () => {
+		const effective = resolveEffectiveEvaluationTargets(
+			[baseTarget],
+			[
+				scopeConfig({ cadenceHours: 12, samplesPerDispatch: 1 }),
+				scopeConfig({ targetId: baseTarget.id, cadenceHours: 6, samplesPerDispatch: 3 }),
+			],
+			{ organizationId: "org-1" },
+		);
+
+		expect(effective).toMatchObject([{ cadenceHours: 6, samplesPerDispatch: 3 }]);
+	});
+
+	it("allows an organization to select targets from a disabled organization default", () => {
+		const effective = resolveEffectiveEvaluationTargets(
+			[baseTarget],
+			[scopeConfig({ enabled: false }), scopeConfig({ targetId: baseTarget.id, enabled: true })],
+			{ organizationId: "org-1" },
+		);
+
+		expect(effective).toMatchObject([{ targetId: baseTarget.id }]);
+	});
+
+	it("excludes targets whose provider connection is disabled", () => {
+		const effective = resolveEffectiveEvaluationTargets([{ ...baseTarget, providerConnectionEnabled: false }], [], {
+			organizationId: "org-1",
+		});
+
+		expect(effective).toEqual([]);
+	});
+});

--- a/packages/lib/src/evaluation-config/resolver.test.ts
+++ b/packages/lib/src/evaluation-config/resolver.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { resolveEffectiveEvaluationTargets } from "./resolver";
-import type { EvaluationTargetForResolution, EvaluationTargetScopeConfigForResolution } from "./types";
+import {
+	assertEvaluationEntitlementLimits,
+	isEffectiveEvaluationTargetOverdue,
+	mapLastRunsToEffectiveTargets,
+	resolveEffectiveEvaluationTargets,
+	selectDueEvaluationTargets,
+} from "./resolver";
+import type {
+	EffectiveEvaluationTarget,
+	EvaluationTargetForResolution,
+	EvaluationTargetScopeConfigForResolution,
+} from "./types";
 
 const baseTarget: EvaluationTargetForResolution = {
 	id: "target-chatgpt",
@@ -16,6 +26,21 @@ const baseTarget: EvaluationTargetForResolution = {
 	defaultCadenceHours: 24,
 	defaultSamplesPerDispatch: 2,
 };
+
+function effectiveTarget(partial: Partial<EffectiveEvaluationTarget> = {}): EffectiveEvaluationTarget {
+	return {
+		targetId: baseTarget.id,
+		targetKey: baseTarget.key,
+		providerConnectionId: baseTarget.providerConnectionId,
+		model: baseTarget.model,
+		provider: baseTarget.provider,
+		version: baseTarget.version ?? undefined,
+		webSearch: baseTarget.webSearch,
+		cadenceHours: baseTarget.defaultCadenceHours,
+		samplesPerDispatch: baseTarget.defaultSamplesPerDispatch,
+		...partial,
+	};
+}
 
 function scopeConfig(
 	partial: Partial<EvaluationTargetScopeConfigForResolution>,
@@ -111,5 +136,79 @@ describe("resolveEffectiveEvaluationTargets", () => {
 		});
 
 		expect(effective).toEqual([]);
+	});
+
+	it("runs only targets that are due at their own cadence", () => {
+		const slowTarget = effectiveTarget({ targetId: "target-slow", targetKey: "target-slow", cadenceHours: 24 });
+		const fastTarget = effectiveTarget({ targetId: "target-fast", targetKey: "target-fast", cadenceHours: 6 });
+		const now = new Date("2026-07-21T12:00:00.000Z");
+		const due = selectDueEvaluationTargets(
+			[slowTarget, fastTarget],
+			new Map([
+				[slowTarget.targetId, new Date("2026-07-21T04:00:00.000Z")],
+				[fastTarget.targetId, new Date("2026-07-21T04:00:00.000Z")],
+			]),
+			now,
+		);
+
+		expect(due.map((target) => target.targetId)).toEqual([fastTarget.targetId]);
+	});
+
+	it("uses the latest direct or legacy run when bootstrapping target history", () => {
+		const target = effectiveTarget();
+		const lastRuns = mapLastRunsToEffectiveTargets(
+			[target],
+			[
+				{ evaluationTargetId: null, model: target.model, lastRunAt: new Date("2026-07-21T01:00:00.000Z") },
+				{ evaluationTargetId: target.targetId, model: target.model, lastRunAt: new Date("2026-07-21T02:00:00.000Z") },
+			],
+		);
+
+		expect(lastRuns.get(target.targetId)).toEqual(new Date("2026-07-21T02:00:00.000Z"));
+	});
+
+	it("evaluates overdue status against each target cadence", () => {
+		const now = new Date("2026-07-21T12:00:00.000Z").getTime();
+		expect(
+			isEffectiveEvaluationTargetOverdue({
+				target: effectiveTarget({ cadenceHours: 24 }),
+				lastRunAt: new Date("2026-07-21T04:00:00.000Z"),
+				promptCreatedAt: new Date("2026-07-20T00:00:00.000Z"),
+				now,
+			}),
+		).toBe(false);
+	});
+
+	it("enforces configured-target and sample limits after resolution", () => {
+		const firstTarget = effectiveTarget({ targetId: "target-one", samplesPerDispatch: 2 });
+		const secondTarget = effectiveTarget({ targetId: "target-two", samplesPerDispatch: 3 });
+
+		expect(() =>
+			assertEvaluationEntitlementLimits({
+				limits: {
+					maxConfiguredTargets: 2,
+					maxConfiguredTargetsPerBrand: 1,
+					maxConfiguredTargetsPerPrompt: null,
+					maxSamplesPerDispatch: 2,
+					maxRunsPerDay: 5,
+				},
+				configuredTargets: [firstTarget],
+				brandTargets: [{ label: "brand-1", targets: [firstTarget, secondTarget] }],
+			}),
+		).toThrow("Brand target limit exceeded");
+
+		expect(() =>
+			assertEvaluationEntitlementLimits({
+				limits: {
+					maxConfiguredTargets: 2,
+					maxConfiguredTargetsPerBrand: 2,
+					maxConfiguredTargetsPerPrompt: null,
+					maxSamplesPerDispatch: 2,
+					maxRunsPerDay: 5,
+				},
+				configuredTargets: [firstTarget],
+				brandTargets: [{ label: "brand-1", targets: [secondTarget] }],
+			}),
+		).toThrow("Samples per dispatch limit exceeded");
 	});
 });

--- a/packages/lib/src/evaluation-config/resolver.ts
+++ b/packages/lib/src/evaluation-config/resolver.ts
@@ -1,0 +1,115 @@
+import type {
+	EffectiveEvaluationTarget,
+	EvaluationConfigScope,
+	EvaluationTargetForResolution,
+	EvaluationTargetResolutionContext,
+	EvaluationTargetScopeConfigForResolution,
+} from "./types";
+
+interface ScopeContext {
+	scope: EvaluationConfigScope;
+	id: string | undefined;
+}
+
+function configBelongsToScope(config: EvaluationTargetScopeConfigForResolution, scope: ScopeContext): boolean {
+	if (!scope.id || config.scope !== scope.scope) return false;
+
+	switch (scope.scope) {
+		case "organization":
+			return config.organizationId === scope.id;
+		case "brand":
+			return config.brandId === scope.id;
+		case "prompt":
+			return config.promptId === scope.id;
+	}
+}
+
+function configAppliesToTarget(config: EvaluationTargetScopeConfigForResolution, targetId: string): boolean {
+	return config.targetId === null || config.targetId === targetId;
+}
+
+function hasPromptAssignment(
+	configs: readonly EvaluationTargetScopeConfigForResolution[],
+	promptId: string | undefined,
+	targetId: string,
+): boolean {
+	return configs.some(
+		(config) =>
+			config.scope === "prompt" &&
+			config.promptId === promptId &&
+			config.targetId === targetId &&
+			config.enabled === true,
+	);
+}
+
+/**
+ * Resolve the targets a prompt may execute without joining through every scope
+ * at each call site. Scope defaults are applied before target-specific rows;
+ * a false enabled value only narrows access, so a child scope cannot restore a
+ * provider or model that its parent has disabled.
+ */
+export function resolveEffectiveEvaluationTargets(
+	targets: readonly EvaluationTargetForResolution[],
+	configs: readonly EvaluationTargetScopeConfigForResolution[],
+	context: EvaluationTargetResolutionContext,
+): EffectiveEvaluationTarget[] {
+	const scopes: ScopeContext[] = [
+		{ scope: "organization", id: context.organizationId },
+		{ scope: "brand", id: context.brandId },
+		{ scope: "prompt", id: context.promptId },
+	];
+
+	const effective: EffectiveEvaluationTarget[] = [];
+	for (const target of targets) {
+		let enabled = target.enabled && target.providerConnectionEnabled;
+		let disabledByAncestor = !enabled;
+		let cadenceHours = target.defaultCadenceHours;
+		let samplesPerDispatch = target.defaultSamplesPerDispatch;
+
+		for (const scope of scopes) {
+			const scopeConfigs = configs.filter(
+				(config) => configBelongsToScope(config, scope) && configAppliesToTarget(config, target.id),
+			);
+			const defaultConfig = scopeConfigs.find((config) => config.targetId === null);
+			const targetConfig = scopeConfigs.find((config) => config.targetId === target.id);
+			const enabledOverride = targetConfig?.enabled ?? defaultConfig?.enabled;
+			if (enabledOverride === false) {
+				enabled = false;
+				disabledByAncestor = true;
+			} else if (enabledOverride === true && !disabledByAncestor) {
+				enabled = true;
+			}
+
+			// Defaults establish the scope's baseline; a target row refines it.
+			scopeConfigs.sort((a, b) => Number(a.targetId !== null) - Number(b.targetId !== null));
+			for (const config of scopeConfigs) {
+				if (config.cadenceHours !== null) cadenceHours = config.cadenceHours;
+				if (config.samplesPerDispatch !== null) samplesPerDispatch = config.samplesPerDispatch;
+			}
+		}
+
+		if (!enabled) continue;
+		if (target.requiresPromptAssignment && !hasPromptAssignment(configs, context.promptId, target.id)) {
+			continue;
+		}
+
+		effective.push({
+			targetId: target.id,
+			targetKey: target.key,
+			providerConnectionId: target.providerConnectionId,
+			model: target.model,
+			provider: target.provider,
+			version: target.version ?? undefined,
+			webSearch: target.webSearch,
+			cadenceHours,
+			samplesPerDispatch,
+		});
+	}
+
+	return effective.sort((a, b) => a.targetKey.localeCompare(b.targetKey));
+}
+
+export function minimumCadenceHours(targets: readonly EffectiveEvaluationTarget[]): number | undefined {
+	if (targets.length === 0) return undefined;
+	return Math.min(...targets.map((target) => target.cadenceHours));
+}

--- a/packages/lib/src/evaluation-config/resolver.ts
+++ b/packages/lib/src/evaluation-config/resolver.ts
@@ -1,10 +1,63 @@
 import type {
+	EvaluationEntitlementLimits,
 	EffectiveEvaluationTarget,
 	EvaluationConfigScope,
 	EvaluationTargetForResolution,
 	EvaluationTargetResolutionContext,
 	EvaluationTargetScopeConfigForResolution,
 } from "./types";
+
+export interface EvaluationEntitlementTargetUsage {
+	label: string;
+	targets: readonly EffectiveEvaluationTarget[];
+}
+
+/**
+ * Validates configuration-time limits after scope inheritance has been
+ * resolved. Runtime quotas deliberately live elsewhere: changing a target
+ * selection must not create extra allowance for executions already metered.
+ */
+export function assertEvaluationEntitlementLimits(input: {
+	limits: EvaluationEntitlementLimits;
+	configuredTargets: readonly EffectiveEvaluationTarget[];
+	brandTargets?: readonly EvaluationEntitlementTargetUsage[];
+	promptTargets?: readonly EvaluationEntitlementTargetUsage[];
+}): void {
+	const { limits, configuredTargets, brandTargets = [], promptTargets = [] } = input;
+	if (limits.maxConfiguredTargets !== null && configuredTargets.length > limits.maxConfiguredTargets) {
+		throw new Error(
+			`Configured target limit exceeded: ${configuredTargets.length} configured, maximum ${limits.maxConfiguredTargets}`,
+		);
+	}
+
+	const assertCountLimit = (
+		usages: readonly EvaluationEntitlementTargetUsage[],
+		limit: number | null,
+		label: string,
+	) => {
+		if (limit === null) return;
+		for (const usage of usages) {
+			if (usage.targets.length > limit) {
+				throw new Error(
+					`${label} target limit exceeded for ${usage.label}: ${usage.targets.length} configured, maximum ${limit}`,
+				);
+			}
+		}
+	};
+	assertCountLimit(brandTargets, limits.maxConfiguredTargetsPerBrand, "Brand");
+	assertCountLimit(promptTargets, limits.maxConfiguredTargetsPerPrompt, "Prompt");
+
+	if (limits.maxSamplesPerDispatch === null) return;
+	for (const usage of [{ label: "configuration", targets: configuredTargets }, ...brandTargets, ...promptTargets]) {
+		for (const target of usage.targets) {
+			if (target.samplesPerDispatch > limits.maxSamplesPerDispatch) {
+				throw new Error(
+					`Samples per dispatch limit exceeded for ${usage.label}: ${target.samplesPerDispatch} configured, maximum ${limits.maxSamplesPerDispatch}`,
+				);
+			}
+		}
+	}
+}
 
 interface ScopeContext {
 	scope: EvaluationConfigScope;
@@ -112,4 +165,56 @@ export function resolveEffectiveEvaluationTargets(
 export function minimumCadenceHours(targets: readonly EffectiveEvaluationTarget[]): number | undefined {
 	if (targets.length === 0) return undefined;
 	return Math.min(...targets.map((target) => target.cadenceHours));
+}
+
+/**
+ * Fold direct target history and pre-migration model-only history into the
+ * stable target IDs used by the scheduler. The model fallback is intentionally
+ * conservative: during the first cadence after migration it can delay a new
+ * target, but cannot create an unexpected extra provider call.
+ */
+export function mapLastRunsToEffectiveTargets(
+	targets: readonly EffectiveEvaluationTarget[],
+	history: readonly { evaluationTargetId: string | null; model: string; lastRunAt: Date }[],
+): Map<string, Date> {
+	const directRuns = new Map<string, Date>();
+	const legacyModelRuns = new Map<string, Date>();
+	for (const run of history) {
+		const runs = run.evaluationTargetId ? directRuns : legacyModelRuns;
+		const key = run.evaluationTargetId ?? run.model;
+		const previous = runs.get(key);
+		if (!previous || run.lastRunAt > previous) runs.set(key, run.lastRunAt);
+	}
+
+	const result = new Map<string, Date>();
+	for (const target of targets) {
+		const direct = directRuns.get(target.targetId);
+		const legacy = legacyModelRuns.get(target.model);
+		const latest = direct && legacy ? (direct > legacy ? direct : legacy) : (direct ?? legacy);
+		if (latest) result.set(target.targetId, latest);
+	}
+	return result;
+}
+
+/** A target is due only after its own cadence has fully elapsed. */
+export function selectDueEvaluationTargets(
+	targets: readonly EffectiveEvaluationTarget[],
+	lastRunAtByTargetId: ReadonlyMap<string, Date>,
+	now = new Date(),
+): EffectiveEvaluationTarget[] {
+	return targets.filter((target) => {
+		const lastRunAt = lastRunAtByTargetId.get(target.targetId);
+		return !lastRunAt || now.getTime() - lastRunAt.getTime() >= target.cadenceHours * 60 * 60 * 1000;
+	});
+}
+
+export function isEffectiveEvaluationTargetOverdue(input: {
+	target: EffectiveEvaluationTarget;
+	lastRunAt?: Date;
+	promptCreatedAt: Date;
+	now: number;
+	graceMs?: number;
+}): boolean {
+	const reference = input.lastRunAt ?? input.promptCreatedAt;
+	return input.now - reference.getTime() > input.target.cadenceHours * 60 * 60 * 1000 + (input.graceMs ?? 0);
 }

--- a/packages/lib/src/evaluation-config/types.ts
+++ b/packages/lib/src/evaluation-config/types.ts
@@ -1,0 +1,51 @@
+import type { ModelConfig } from "@workspace/config/scrape-targets";
+
+export type EvaluationConfigScope = "organization" | "brand" | "prompt";
+
+export interface EvaluationTargetForResolution {
+	id: string;
+	key: string;
+	model: string;
+	provider: string;
+	providerConnectionId: string;
+	providerConnectionEnabled: boolean;
+	version: string | null;
+	webSearch: boolean;
+	enabled: boolean;
+	requiresPromptAssignment: boolean;
+	defaultCadenceHours: number;
+	defaultSamplesPerDispatch: number;
+}
+
+export interface EvaluationTargetScopeConfigForResolution {
+	targetId: string | null;
+	scope: EvaluationConfigScope;
+	organizationId: string | null;
+	brandId: string | null;
+	promptId: string | null;
+	enabled: boolean | null;
+	cadenceHours: number | null;
+	samplesPerDispatch: number | null;
+}
+
+export interface EvaluationTargetResolutionContext {
+	organizationId?: string;
+	brandId?: string;
+	promptId?: string;
+}
+
+export interface EffectiveEvaluationTarget extends ModelConfig {
+	targetId: string;
+	targetKey: string;
+	providerConnectionId: string;
+	cadenceHours: number;
+	samplesPerDispatch: number;
+}
+
+export interface EvaluationEntitlementLimits {
+	maxConfiguredTargets: number | null;
+	maxConfiguredTargetsPerBrand: number | null;
+	maxConfiguredTargetsPerPrompt: number | null;
+	maxSamplesPerDispatch: number | null;
+	maxRunsPerDay: number | null;
+}


### PR DESCRIPTION
## Summary

- add database-backed evaluation targets, scoped overrides, provider connections, audit records, and configuration entitlements
- resolve targets through instance → organization → brand → prompt and run workers from that result
- preserve legacy `SCRAPE_TARGETS` as a one-time migration path and keep demo/whitelabel behavior guarded
- add scoped server-side authorization and local LLM configuration UI
- enforce configuration-time target and sampling caps after inheritance resolves

## Validation

- `pnpm --filter @workspace/lib test`
- `pnpm --filter @workspace/config test`
- `pnpm --filter @workspace/web test`
- `pnpm --filter @workspace/web check-types`
- `pnpm --filter @workspace/worker check-types`
- `pnpm --filter @workspace/worker build`
- `pnpm --filter @workspace/web build`

## Follow-up boundary

Provider-secret UI/external secret-store integration and runtime daily-quota metering remain separate from this configuration migration.