### PR TITLE
use async jobs for Oxylabs

### DIFF
--- a/.changeset/calm-oxylabs-jobs.md
+++ b/.changeset/calm-oxylabs-jobs.md
@@ -1,0 +1,5 @@
+---
+"@elmohq/cli": patch
+---
+
+Oxylabs requests now use asynchronous jobs to avoid realtime connection timeouts.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -432,7 +432,7 @@ async function configureProvidersInteractive(env: EnvMap): Promise<"recommended"
 			"",
 			pc.bold("1. A scraper") + " — to track ChatGPT and Google AI Mode (no public APIs):",
 			`     • ${pc.cyan("BrightData")} — cheap solid option, ~$0.45/mo per prompt`,
-			`     • ${pc.cyan("Oxylabs")}    — sync realtime API, pay-as-you-go`,
+			`     • ${pc.cyan("Oxylabs")}    — async job API, pay-as-you-go`,
 			`     • ${pc.cyan("Olostep")}    — premium option, powers Peec/AirOps, ~$2.25/mo per prompt`,
 			"",
 			pc.bold("2. A direct LLM API") + " — for low-latency tasks (onboarding analysis, sentiment scoring,",
@@ -471,7 +471,7 @@ async function configureProvidersRecommended(env: EnvMap): Promise<void> {
 		message: "Scraper (tracks ChatGPT + Google AI Mode)",
 		options: [
 			{ value: "brightdata" as const, label: "BrightData — ~$0.45/mo per prompt (cheaper)" },
-			{ value: "oxylabs" as const, label: "Oxylabs — sync realtime API, pay-as-you-go" },
+			{ value: "oxylabs" as const, label: "Oxylabs — async job API, pay-as-you-go" },
 			{ value: "olostep" as const, label: "Olostep — ~$2.25/mo per prompt (premium)" },
 		],
 		initialValue: "brightdata" as const,
@@ -649,7 +649,7 @@ async function collectOlostep(env: EnvMap, targets: string[]): Promise<void> {
 
 async function collectOxylabs(env: EnvMap, targets: string[]): Promise<void> {
 	const enable = await p.confirm({
-		message: `Configure ${pc.bold("Oxylabs")}? (sync realtime API, pay-as-you-go)`,
+		message: `Configure ${pc.bold("Oxylabs")}? (async job API, pay-as-you-go)`,
 		initialValue: false,
 	});
 	assertNotCancelled(enable);

--- a/packages/docs/content/docs/user-guide/providers.mdx
+++ b/packages/docs/content/docs/user-guide/providers.mdx
@@ -12,7 +12,7 @@ These cover the ChatGPT + Google AI Mode experiences that drive the bulk of AI r
 | Provider | Why | Rough cost per prompt/month* | Sign up |
 |---|---|---|---|
 | **BrightData** | Cheapest solid option. Battle-tested dataset collectors for each major AI surface. | ~$0.45 | [get.brightdata.com](https://get.brightdata.com/67h1b7h0shcn) |
-| **Oxylabs** | Synchronous realtime API — no snapshot polling. Good for ChatGPT, Perplexity, Google AI Mode. | pay-as-you-go | [oxylabs.io](https://oxylabs.go2cloud.org/aff_c?offer_id=7&aff_id=2263&url_id=32) |
+| **Oxylabs** | Asynchronous Push-Pull API. Good for ChatGPT, Perplexity, Google AI Mode. | pay-as-you-go | [oxylabs.io](https://oxylabs.go2cloud.org/aff_c?offer_id=7&aff_id=2263&url_id=32) |
 | **Olostep** | Powers most large-scale AI visibility trackers today. Good reliability at scale. | ~$2.25 | [olostep.com](https://olostep.com/?ref=elmo) |
 
 <Callout>
@@ -57,7 +57,7 @@ google-ai-mode:oxylabs:online
 google-ai-overview:oxylabs:online
 ```
 
-Oxylabs uses HTTP Basic auth (Web Scraper API username + password) and a synchronous realtime endpoint, so requests block until the answer is ready — no snapshot polling. `:online` toggles in-product web search for ChatGPT; Perplexity, Google AI Mode, and Google AI Overview always search.
+Oxylabs uses HTTP Basic auth (Web Scraper API username + password). Elmo submits each request through the asynchronous Push-Pull API and polls until the result is ready, avoiding the Realtime API's connection timeout. `:online` toggles in-product web search for ChatGPT; Perplexity, Google AI Mode, and Google AI Overview always search.
 
 ### Olostep
 

--- a/packages/lib/src/providers/registry/oxylabs.test.ts
+++ b/packages/lib/src/providers/registry/oxylabs.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { oxylabs } from "./oxylabs";
+
+const RESULT_PAYLOAD = {
+	results: [
+		{
+			content: {
+				markdown_text: "The Sonos Era 300 is a well-reviewed speaker released recently.",
+				citations: [{ url: "https://www.whathifi.com/reviews/sonos-era-300", title: "Sonos Era 300 review" }],
+				search_queries: ["recent speaker reviews"],
+				llm_model: "gpt-5",
+			},
+		},
+	],
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+beforeEach(() => {
+	vi.stubEnv("OXYLABS_USERNAME", "test-user");
+	vi.stubEnv("OXYLABS_PASSWORD", "test-password");
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+	vi.unstubAllEnvs();
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+describe("oxylabs provider", () => {
+	it("submits a Push-Pull job, polls it, and retrieves parsed results", async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse({ id: "job-123", status: "pending" }, 202))
+			.mockResolvedValueOnce(jsonResponse({ id: "job-123", status: "pending" }))
+			.mockResolvedValueOnce(jsonResponse({ id: "job-123", status: "done" }))
+			.mockResolvedValueOnce(jsonResponse(RESULT_PAYLOAD));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const promise = oxylabs.run("chatgpt", "What is a well-reviewed speaker?", { webSearch: true });
+		await vi.runAllTimersAsync();
+		const result = await promise;
+
+		expect(fetchMock).toHaveBeenCalledTimes(4);
+		expect(fetchMock.mock.calls[0][0]).toBe("https://data.oxylabs.io/v1/queries");
+		expect(fetchMock.mock.calls[0][1]).toMatchObject({
+			method: "POST",
+			headers: {
+				Authorization: "Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=",
+				"Content-Type": "application/json",
+			},
+		});
+		expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+			source: "chatgpt",
+			prompt: "What is a well-reviewed speaker?",
+			parse: true,
+			search: true,
+		});
+		expect(fetchMock.mock.calls[1][0]).toBe("https://data.oxylabs.io/v1/queries/job-123");
+		expect(fetchMock.mock.calls[3][0]).toBe("https://data.oxylabs.io/v1/queries/job-123/results");
+		expect(result.textContent).toContain("Sonos Era 300");
+		expect(result.citations).toHaveLength(1);
+		expect(result.webQueries).toEqual(["recent speaker reviews"]);
+		expect(result.modelVersion).toBe("gpt-5");
+	});
+
+	it("uses the same asynchronous flow for Google AI Mode", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse({ id: "job-google", status: "done" }, 202))
+			.mockResolvedValueOnce(jsonResponse(RESULT_PAYLOAD));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await oxylabs.run("google-ai-mode", "What are the best speakers?", { webSearch: true });
+
+		expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+			source: "google_ai_mode",
+			query: "What are the best speakers?",
+			parse: true,
+			render: "html",
+		});
+		expect(fetchMock.mock.calls[1][0]).toBe("https://data.oxylabs.io/v1/queries/job-google/results");
+	});
+
+	it("keeps polling through transient status and result responses", async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse({ id: "job-transient", status: "pending" }, 202))
+			.mockResolvedValueOnce(jsonResponse({ message: "temporary error" }, 500))
+			.mockResolvedValueOnce(jsonResponse({ id: "job-transient", status: "done" }))
+			.mockResolvedValueOnce(new Response(null, { status: 204 }))
+			.mockResolvedValueOnce(jsonResponse(RESULT_PAYLOAD));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const promise = oxylabs.run("chatgpt", "What is a well-reviewed speaker?", { webSearch: false });
+		await vi.runAllTimersAsync();
+		const result = await promise;
+
+		expect(fetchMock).toHaveBeenCalledTimes(5);
+		expect(result.textContent).toContain("Sonos Era 300");
+	});
+
+	it("fails a faulted asynchronous job without requesting results", async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse({ id: "job-faulted", status: "pending" }, 202))
+			.mockResolvedValueOnce(jsonResponse({ id: "job-faulted", status: "faulted", statuses: [{ status_code: 613 }] }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const promise = oxylabs.run("chatgpt", "What is a well-reviewed speaker?", { webSearch: true });
+		const assertion = expect(promise).rejects.toThrow("Oxylabs job job-faulted faulted");
+		await vi.runAllTimersAsync();
+		await assertion;
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("surfaces job submission errors", async () => {
+		const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ message: "invalid credentials" }, 401));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(oxylabs.run("chatgpt", "What is a well-reviewed speaker?", { webSearch: true })).rejects.toThrow(
+			'Oxylabs job submission failed (401: {"message":"invalid credentials"})',
+		);
+	});
+});

--- a/packages/lib/src/providers/registry/oxylabs.ts
+++ b/packages/lib/src/providers/registry/oxylabs.ts
@@ -1,29 +1,144 @@
 import type { Provider, ScrapeResult, ProviderOptions, ModelConfig } from "../types";
-import {
-	extractTextFromOxylabs,
-	extractCitationsFromOxylabs,
-	type Citation,
-} from "../../text-extraction";
+import { extractTextFromOxylabs, extractCitationsFromOxylabs, type Citation } from "../../text-extraction";
 
 // Oxylabs Web Scraper API sources for AI surfaces.
 // ChatGPT and Perplexity use `prompt`; the Google surfaces use `query` and
 // require `render: html` — AI Mode via the `google_ai_mode` source, AI Overview
 // via a `google_search` SERP whose parsed result carries the overview block.
-const OXYLABS_SOURCES: Record<
-	string,
-	{ source: string; field: "prompt" | "query"; render?: string }
-> = {
+const OXYLABS_SOURCES: Record<string, { source: string; field: "prompt" | "query"; render?: string }> = {
 	chatgpt: { source: "chatgpt", field: "prompt" },
 	perplexity: { source: "perplexity", field: "prompt" },
 	"google-ai-mode": { source: "google_ai_mode", field: "query", render: "html" },
 	"google-ai-overview": { source: "google_search", field: "query", render: "html" },
 };
 
-const OXYLABS_REALTIME_URL = "https://realtime.oxylabs.io/v1/queries";
+// AI answers can outlive the Realtime API's connection TTL. Use single-job
+// Push-Pull for every source; ChatGPT and Perplexity do not support batch jobs.
+const OXYLABS_JOBS_URL = "https://data.oxylabs.io/v1/queries";
+const OXYLABS_JOB_TIMEOUT_MS = 10 * 60 * 1000;
+const OXYLABS_POLL_BASE_DELAY_MS = 2000;
+const OXYLABS_POLL_MAX_DELAY_MS = 10_000;
+
+interface OxylabsJob {
+	id?: string;
+	status?: string;
+	statuses?: unknown;
+}
+
+interface OxylabsPayload {
+	results?: Array<{ content?: Record<string, any> }>;
+}
 
 function basicAuthHeader(): string {
 	const token = btoa(`${process.env.OXYLABS_USERNAME}:${process.env.OXYLABS_PASSWORD}`);
 	return `Basic ${token}`;
+}
+
+function requestHeaders(): Record<string, string> {
+	return {
+		Authorization: basicAuthHeader(),
+		"Content-Type": "application/json",
+	};
+}
+
+function pollDelay(attempt: number): number {
+	return Math.min(OXYLABS_POLL_BASE_DELAY_MS * Math.pow(2, Math.floor(attempt / 5)), OXYLABS_POLL_MAX_DELAY_MS);
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isTransientStatus(status: number): boolean {
+	return status === 408 || status === 429 || status >= 500;
+}
+
+async function responseError(res: Response): Promise<string> {
+	return `${res.status}: ${(await res.text()).slice(0, 500)}`.trim();
+}
+
+function faultDetails(job: OxylabsJob): string {
+	if (job.statuses === undefined || job.statuses === null) return "";
+	const serialized = typeof job.statuses === "string" ? job.statuses : JSON.stringify(job.statuses);
+	return serialized ? ` (${serialized.slice(0, 500)})` : "";
+}
+
+async function submitJob(body: Record<string, any>): Promise<OxylabsJob> {
+	const res = await fetch(OXYLABS_JOBS_URL, {
+		method: "POST",
+		headers: requestHeaders(),
+		body: JSON.stringify(body),
+	});
+
+	if (!res.ok) {
+		throw new Error(`Oxylabs job submission failed (${await responseError(res)})`);
+	}
+
+	const job = (await res.json()) as OxylabsJob;
+	if (!job.id) throw new Error("Oxylabs job submission returned no job id");
+	return job;
+}
+
+async function getJob(jobId: string): Promise<OxylabsJob | null> {
+	try {
+		const res = await fetch(`${OXYLABS_JOBS_URL}/${jobId}`, {
+			headers: requestHeaders(),
+		});
+		if (res.status === 204 || isTransientStatus(res.status)) return null;
+		if (!res.ok) {
+			throw new Error(`Oxylabs job status request failed (${await responseError(res)})`);
+		}
+		return (await res.json()) as OxylabsJob;
+	} catch (error) {
+		if (error instanceof Error && error.message.startsWith("Oxylabs job status request failed")) throw error;
+		return null;
+	}
+}
+
+async function waitForJob(initialJob: OxylabsJob, deadline: number): Promise<void> {
+	let job = initialJob;
+	let attempt = 0;
+
+	while (Date.now() < deadline) {
+		const status = job.status?.toLowerCase();
+		if (status === "done") return;
+		if (status === "faulted") {
+			throw new Error(`Oxylabs job ${job.id} faulted${faultDetails(job)}`);
+		}
+
+		await sleep(Math.min(pollDelay(attempt++), deadline - Date.now()));
+		job = (await getJob(job.id!)) ?? job;
+	}
+
+	throw new Error(`Oxylabs job ${initialJob.id} timed out after ${OXYLABS_JOB_TIMEOUT_MS / 1000}s`);
+}
+
+async function fetchResults(jobId: string, deadline: number): Promise<OxylabsPayload> {
+	let attempt = 0;
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(`${OXYLABS_JOBS_URL}/${jobId}/results`, {
+				headers: requestHeaders(),
+			});
+			if (res.ok) return (await res.json()) as OxylabsPayload;
+			if (res.status !== 204 && !isTransientStatus(res.status)) {
+				throw new Error(`Oxylabs results request failed (${await responseError(res)})`);
+			}
+		} catch (error) {
+			if (error instanceof Error && error.message.startsWith("Oxylabs results request failed")) throw error;
+		}
+
+		await sleep(Math.min(pollDelay(attempt++), deadline - Date.now()));
+	}
+
+	throw new Error(`Oxylabs results for job ${jobId} were not ready before the job timeout`);
+}
+
+async function runAsyncQuery(body: Record<string, any>): Promise<OxylabsPayload> {
+	const deadline = Date.now() + OXYLABS_JOB_TIMEOUT_MS;
+	const job = await submitJob(body);
+	await waitForJob(job, deadline);
+	return fetchResults(job.id!, deadline);
 }
 
 function extractWebQueries(content: Record<string, any>): string[] {
@@ -61,8 +176,7 @@ export const oxylabs: Provider = {
 		const sourceConfig = OXYLABS_SOURCES[model];
 		if (!sourceConfig) {
 			throw new Error(
-				`Oxylabs: no source mapping for model "${model}". ` +
-				`Supported: ${Object.keys(OXYLABS_SOURCES).join(", ")}`,
+				`Oxylabs: no source mapping for model "${model}". Supported: ${Object.keys(OXYLABS_SOURCES).join(", ")}`,
 			);
 		}
 
@@ -76,22 +190,7 @@ export const oxylabs: Provider = {
 		// always search, so we don't send the flag for them.
 		if (model === "chatgpt") body.search = options?.webSearch ?? false;
 
-		const res = await fetch(OXYLABS_REALTIME_URL, {
-			method: "POST",
-			headers: {
-				Authorization: basicAuthHeader(),
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify(body),
-		});
-
-		if (!res.ok) {
-			throw new Error(`Oxylabs realtime query failed (${res.status}): ${await res.text()}`);
-		}
-
-		const payload = (await res.json()) as {
-			results?: Array<{ content?: Record<string, any> }>;
-		};
+		const payload = await runAsyncQuery(body);
 		const content = payload.results?.[0]?.content ?? {};
 
 		const textContent = extractTextFromOxylabs(payload);


### PR DESCRIPTION
## Summary

- submit Oxylabs searches through asynchronous jobs for every Oxylabs-backed provider
- poll jobs through completion with consistent timeout and failure handling
- make the realtime and online variants comparable with other asynchronous scraping providers

## Testing

- library tests: 236 passed
- CLI tests: 24 passed
- library and CLI typechecks