### PR TITLE
Keep prompt settings order stable

### DIFF
--- a/.changeset/stable-prompt-order.md
+++ b/.changeset/stable-prompt-order.md
@@ -2,4 +2,4 @@
 "@workspace/web": patch
 ---
 
-Keep prompts in a stable order when their settings change.
+Sort prompts alphabetically on the prompt settings page.

--- a/.changeset/stable-prompt-order.md
+++ b/.changeset/stable-prompt-order.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Keep prompts in a stable order when their settings change.

--- a/apps/web/src/routes/_authed/app/$brand/settings/prompts.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/settings/prompts.tsx
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
 import { db } from "@workspace/lib/db/db";
 import { prompts } from "@workspace/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { PromptsEditor } from "@/components/prompts-editor";
 import { Skeleton } from "@workspace/ui/components/skeleton";
 
@@ -25,7 +25,7 @@ const getPromptsForEditing = createServerFn({ method: "GET" })
 			.select()
 			.from(prompts)
 			.where(eq(prompts.brandId, data.brandId))
-			.orderBy(prompts.createdAt, prompts.id);
+			.orderBy(prompts.value, desc(prompts.enabled), prompts.id);
 
 		return brandPrompts;
 	});

--- a/apps/web/src/routes/_authed/app/$brand/settings/prompts.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/settings/prompts.tsx
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
 import { db } from "@workspace/lib/db/db";
 import { prompts } from "@workspace/lib/db/schema";
-import { eq, desc } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { PromptsEditor } from "@/components/prompts-editor";
 import { Skeleton } from "@workspace/ui/components/skeleton";
 
@@ -25,7 +25,7 @@ const getPromptsForEditing = createServerFn({ method: "GET" })
 			.select()
 			.from(prompts)
 			.where(eq(prompts.brandId, data.brandId))
-			.orderBy(desc(prompts.enabled), prompts.createdAt);
+			.orderBy(prompts.createdAt, prompts.id);
 
 		return brandPrompts;
 	});


### PR DESCRIPTION
## Summary

- keep prompts in creation order on the prompt settings page
- use prompt IDs as a deterministic tie-breaker
- add a patch changeset for the user-facing fix

## Validation

- `pnpm --filter @workspace/web check-types`
- `pnpm --filter @workspace/web test` (222 tests passed)