### PR TITLE
Resend email verification link on unverified cloud sign-in

### DIFF
--- a/.changeset/resend-verification-on-signin.md
+++ b/.changeset/resend-verification-on-signin.md
@@ -1,0 +1,5 @@
+---
+"@workspace/cloud": patch
+---
+
+Signing in to Elmo Cloud with an unverified email now resends the verification link, so the "we just sent you a new verification link" message on the login page is accurate and unverified users can get unstuck.

--- a/.changeset/resend-verification-on-signin.md
+++ b/.changeset/resend-verification-on-signin.md
@@ -1,5 +1,0 @@
----
-"@workspace/cloud": patch
----
-
-Signing in to Elmo Cloud with an unverified email now resends the verification link, so the "we just sent you a new verification link" message on the login page is accurate and unverified users can get unstuck.

--- a/packages/cloud/src/auth-hooks.test.ts
+++ b/packages/cloud/src/auth-hooks.test.ts
@@ -21,10 +21,11 @@ describe("getCloudAuthOptions", () => {
 		vi.stubEnv("RESEND_API_KEY", "re_test_x");
 	});
 
-	it("requires email verification and sends it on signup", () => {
+	it("requires email verification and sends it on signup and unverified sign-in", () => {
 		const options = getCloudAuthOptions();
 		expect(options.requireEmailVerification).toBe(true);
 		expect(options.emailVerification?.sendOnSignUp).toBe(true);
+		expect(options.emailVerification?.sendOnSignIn).toBe(true);
 	});
 
 	it("configures Google OAuth from env", () => {

--- a/packages/cloud/src/auth-hooks.ts
+++ b/packages/cloud/src/auth-hooks.ts
@@ -17,6 +17,11 @@ export function getCloudAuthOptions(): CreateAuthOptions {
 		requireEmailVerification: true,
 		emailVerification: {
 			sendOnSignUp: true,
+			// Resend the link when an unverified user signs in — otherwise the
+			// login page's "we just sent you a new verification link" is a lie and
+			// they can never get unstuck. Runs only after a valid password, so it
+			// isn't an open email-bombing vector.
+			sendOnSignIn: true,
 			autoSignInAfterVerification: true,
 			sendVerificationEmail: async ({ user, url }) => {
 				await sendEmail(user.email, verificationEmail({ url }));

--- a/packages/cloud/src/auth-hooks.ts
+++ b/packages/cloud/src/auth-hooks.ts
@@ -17,10 +17,6 @@ export function getCloudAuthOptions(): CreateAuthOptions {
 		requireEmailVerification: true,
 		emailVerification: {
 			sendOnSignUp: true,
-			// Resend the link when an unverified user signs in — otherwise the
-			// login page's "we just sent you a new verification link" is a lie and
-			// they can never get unstuck. Runs only after a valid password, so it
-			// isn't an open email-bombing vector.
 			sendOnSignIn: true,
 			autoSignInAfterVerification: true,
 			sendVerificationEmail: async ({ user, url }) => {


### PR DESCRIPTION
## Problem

Logging into Elmo Cloud with an unverified email shows *"Please verify your email first — we just sent you a new verification link,"* but no email is ever sent — the Vercel request trace shows `403` with **No outgoing requests**. Unverified users are permanently locked out: the login page promises a resend that never happens.

## Root cause

The cloud auth config set `requireEmailVerification: true` and `sendOnSignUp: true`, but not `sendOnSignIn`. In better-auth 1.6.23, `/sign-in/email` only resends the verification link on an unverified login when `emailVerification.sendOnSignIn` is set; otherwise it throws `403 EMAIL_NOT_VERIFIED` and sends nothing:

```js
if (requireEmailVerification && !user.emailVerified) {
  if (!sendVerificationEmail) throw 403 EMAIL_NOT_VERIFIED;
  if (emailVerification?.sendOnSignIn) { /* create token + send */ }  // ← was skipped
  throw 403 EMAIL_NOT_VERIFIED;
}
```

The login page shows the "we just sent you a new link" copy on any cloud 403, so the message was inaccurate.

## Fix

Enable `sendOnSignIn: true` in the cloud config. better-auth validates the password *before* this block, so the resend only fires for a correct-credential login — not an open email-bombing vector. `autoSignInAfterVerification: true` (already set) logs the user in once they click the link.

## Testing

- `tsc --noEmit` passes for `@workspace/cloud`
- `vitest run` — 18/18 pass (added a `sendOnSignIn` assertion)
- Biome-formatted

## Note

Already-locked-out users get a link on their next login attempt after deploy; to unblock someone immediately, use the register page's **Resend verification email** button.
