### PR TITLE
Allow Biome configuration in nested worktrees

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
-	"root": false,
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -8,12 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"includes": [
-			"apps/**",
-			"packages/**",
-			"!**/node_modules/**",
-			"!packages/ui/src/components/**"
-		]
+		"includes": ["apps/**", "packages/**", "!**/node_modules/**", "!packages/ui/src/components/**"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+	"root": false,
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -7,7 +8,12 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"includes": ["apps/**", "packages/**", "!**/node_modules/**", "!packages/ui/src/components/**"]
+		"includes": [
+			"apps/**",
+			"packages/**",
+			"!**/node_modules/**",
+			"!packages/ui/src/components/**"
+		]
 	},
 	"formatter": {
 		"enabled": true,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "turbo build",
     "lint": "turbo lint",
     "test": "turbo test",
-    "format": "biome format --write .",
+    "format": "biome format --write --config-path=biome.json .",
     "knip": "knip",
     "elmo": "tsx apps/cli/src/index.ts",
     "cli:link": "npm unlink -g @elmohq/cli || true && pnpm -C apps/cli build && (cd apps/cli && npm link)",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "lint": "turbo lint",
     "test": "turbo test",
     "format": "biome format --write --config-path=biome.json .",
+    "format-and-lint": "biome check --config-path=biome.json .",
+    "format-and-lint:fix": "biome check --write --config-path=biome.json .",
     "knip": "knip",
     "elmo": "tsx apps/cli/src/index.ts",
     "cli:link": "npm unlink -g @elmohq/cli || true && pnpm -C apps/cli build && (cd apps/cli && npm link)",

--- a/turbo.json
+++ b/turbo.json
@@ -61,6 +61,13 @@
     "RESEND_FROM_EMAIL"
   ],
   "tasks": {
+    "//#format": {
+      "cache": false
+    },
+    "//#format-and-lint": {},
+    "//#format-and-lint:fix": {
+      "cache": false
+    },
     "build": {
       "dependsOn": ["^build", "check-types"],
       "outputs": [".output/**", ".vercel/output/**", "dist/**"]


### PR DESCRIPTION
Marks the repository Biome configuration as non-root so it can be discovered from nested worktrees without a root-configuration conflict.