### PR TITLE
allow adding prompts in bulk

### DIFF
--- a/.changeset/bulk-paste-prompts.md
+++ b/.changeset/bulk-paste-prompts.md
@@ -1,0 +1,6 @@
+---
+"@workspace/web": patch
+"@workspace/lib": patch
+---
+
+Prompts can now be added in bulk by pasting one per line.

--- a/.github/contributors.txt
+++ b/.github/contributors.txt
@@ -28,3 +28,4 @@ melalj
 mfa-g
 rodriguescarson
 dchaudhari7177
+nosey-dewdrop

--- a/apps/web/src/components/prompts-list-editor.tsx
+++ b/apps/web/src/components/prompts-list-editor.tsx
@@ -8,16 +8,19 @@
  * keeps it inline. The `showSystemTags` prop hides the System Tags column
  * in the wizard since onboarding hasn't yet computed any system tags.
  */
-import { useMemo, useState } from "react";
+
+import { IconInfoCircle } from "@tabler/icons-react";
+import { describeSkipped, parseBulkPrompts } from "@workspace/lib/bulk-prompts";
+import { MAX_PROMPTS } from "@workspace/lib/constants";
 import { Button } from "@workspace/ui/components/button";
-import { Input } from "@workspace/ui/components/input";
 import { Checkbox } from "@workspace/ui/components/checkbox";
+import { Input } from "@workspace/ui/components/input";
 import { Switch } from "@workspace/ui/components/switch";
 import { TagsInput } from "@workspace/ui/components/tags-input";
+import { Textarea } from "@workspace/ui/components/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
-import { Plus, Inbox } from "lucide-react";
-import { IconInfoCircle } from "@tabler/icons-react";
-import { MAX_PROMPTS } from "@workspace/lib/constants";
+import { Copy, Inbox, Plus } from "lucide-react";
+import { useMemo, useState } from "react";
 
 export interface EditablePrompt {
 	id?: string;
@@ -61,6 +64,28 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 	const add = () => {
 		if (prompts.length >= MAX_PROMPTS) return;
 		onChange([...prompts, newPromptEntry()]);
+	};
+
+	// Bulk paste. The parse is pure and lives in @workspace/lib so the rules
+	// (trim, dedupe, cap) are tested without a DOM, and it runs on every
+	// keystroke only to label the button and warn about what will be dropped.
+	const [bulkOpen, setBulkOpen] = useState(false);
+	const [bulkText, setBulkText] = useState("");
+
+	const bulkPreview = useMemo(
+		() => parseBulkPrompts(bulkText, { existing: prompts.map((p) => p.value), limit: MAX_PROMPTS }),
+		[bulkText, prompts],
+	);
+	const bulkNotice = bulkText.trim().length > 0 ? describeSkipped(bulkPreview.skipped) : null;
+
+	const closeBulk = () => {
+		setBulkOpen(false);
+		setBulkText("");
+	};
+	const addBulk = () => {
+		if (bulkPreview.added.length === 0) return;
+		onChange([...prompts, ...bulkPreview.added.map((value) => newPromptEntry({ value }))]);
+		closeBulk();
 	};
 
 	// Count selection against current prompts so stale keys (e.g. after the
@@ -256,15 +281,48 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 			)}
 
 			{prompts.length < MAX_PROMPTS && (
-				<Button
-					variant="outline"
-					size="sm"
-					type="button"
-					onClick={add}
-					className="flex items-center gap-2 cursor-pointer"
-				>
-					<Plus className="h-4 w-4" /> Add Prompt
-				</Button>
+				<div className="flex flex-wrap items-center gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						type="button"
+						onClick={add}
+						className="flex items-center gap-2 cursor-pointer"
+					>
+						<Plus className="h-4 w-4" /> Add Prompt
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						type="button"
+						onClick={() => setBulkOpen((open) => !open)}
+						className="flex items-center gap-2 cursor-pointer"
+					>
+						<Copy className="h-4 w-4" /> Paste in Bulk
+					</Button>
+				</div>
+			)}
+
+			{bulkOpen && prompts.length < MAX_PROMPTS && (
+				<div className="space-y-2 rounded-md border bg-muted/40 p-3">
+					<Textarea
+						value={bulkText}
+						onChange={(e) => setBulkText(e.target.value)}
+						placeholder={"One prompt per line\nbest running shoes for flat feet\nmost durable trail runners"}
+						rows={6}
+						aria-label="Prompts to add, one per line"
+					/>
+					<div className="flex flex-wrap items-center gap-2">
+						<Button size="sm" type="button" onClick={addBulk} disabled={bulkText.trim().length === 0}>
+							Add {bulkPreview.added.length > 0 ? `${bulkPreview.added.length} ` : ""}
+							{bulkPreview.added.length === 1 ? "Prompt" : "Prompts"}
+						</Button>
+						<Button variant="ghost" size="sm" type="button" onClick={closeBulk}>
+							Cancel
+						</Button>
+						{bulkNotice && <span className="text-xs text-muted-foreground">{bulkNotice}</span>}
+					</div>
+				</div>
 			)}
 
 			{prompts.length >= MAX_PROMPTS && (

--- a/apps/web/src/components/prompts-list-editor.tsx
+++ b/apps/web/src/components/prompts-list-editor.tsx
@@ -19,7 +19,7 @@ import { Switch } from "@workspace/ui/components/switch";
 import { TagsInput } from "@workspace/ui/components/tags-input";
 import { Textarea } from "@workspace/ui/components/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
-import { Copy, Inbox, Plus } from "lucide-react";
+import { Inbox, ListPlus, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 
 export interface EditablePrompt {
@@ -72,18 +72,32 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 	const [bulkOpen, setBulkOpen] = useState(false);
 	const [bulkText, setBulkText] = useState("");
 
+	// A row only takes a slot once it has text. Blank rows are how this editor
+	// stages a new prompt and they're dropped on save, so counting them against
+	// the cap would refuse prompts the list still has room for.
+	const filledValues = useMemo(() => prompts.map((p) => p.value).filter((v) => v.trim().length > 0), [prompts]);
+	const atCapacity = filledValues.length >= MAX_PROMPTS;
+
 	const bulkPreview = useMemo(
-		() => parseBulkPrompts(bulkText, { existing: prompts.map((p) => p.value), limit: MAX_PROMPTS }),
-		[bulkText, prompts],
+		() => parseBulkPrompts(bulkText, { existing: filledValues, limit: MAX_PROMPTS }),
+		[bulkText, filledValues],
 	);
 	const bulkNotice = bulkText.trim().length > 0 ? describeSkipped(bulkPreview.skipped) : null;
+
+	// Over capacity blocks the whole paste rather than quietly taking the lines
+	// that fit, so nobody submits a list believing all of it landed.
+	const overCapacity = bulkPreview.skipped.overCapacity.length;
+	const bulkError =
+		overCapacity > 0
+			? `This paste is ${overCapacity} prompt${overCapacity === 1 ? "" : "s"} over the ${MAX_PROMPTS} limit. Remove ${overCapacity === 1 ? "a line" : "some lines"} to continue.`
+			: null;
 
 	const closeBulk = () => {
 		setBulkOpen(false);
 		setBulkText("");
 	};
 	const addBulk = () => {
-		if (bulkPreview.added.length === 0) return;
+		if (bulkPreview.added.length === 0 || overCapacity > 0) return;
 		onChange([...prompts, ...bulkPreview.added.map((value) => newPromptEntry({ value }))]);
 		closeBulk();
 	};
@@ -280,17 +294,19 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 				</div>
 			)}
 
-			{prompts.length < MAX_PROMPTS && (
+			{!atCapacity && (
 				<div className="flex flex-wrap items-center gap-2">
-					<Button
-						variant="outline"
-						size="sm"
-						type="button"
-						onClick={add}
-						className="flex items-center gap-2 cursor-pointer"
-					>
-						<Plus className="h-4 w-4" /> Add Prompt
-					</Button>
+					{prompts.length < MAX_PROMPTS && (
+						<Button
+							variant="outline"
+							size="sm"
+							type="button"
+							onClick={add}
+							className="flex items-center gap-2 cursor-pointer"
+						>
+							<Plus className="h-4 w-4" /> Add Prompt
+						</Button>
+					)}
 					<Button
 						variant="outline"
 						size="sm"
@@ -298,22 +314,27 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 						onClick={() => setBulkOpen((open) => !open)}
 						className="flex items-center gap-2 cursor-pointer"
 					>
-						<Copy className="h-4 w-4" /> Paste in Bulk
+						<ListPlus className="h-4 w-4" /> Add Multiple
 					</Button>
 				</div>
 			)}
 
-			{bulkOpen && prompts.length < MAX_PROMPTS && (
+			{bulkOpen && !atCapacity && (
 				<div className="space-y-2 rounded-md border bg-muted/40 p-3">
 					<Textarea
 						value={bulkText}
 						onChange={(e) => setBulkText(e.target.value)}
-						placeholder={"One prompt per line\nbest running shoes for flat feet\nmost durable trail runners"}
+						placeholder="One prompt per line"
 						rows={6}
 						aria-label="Prompts to add, one per line"
 					/>
 					<div className="flex flex-wrap items-center gap-2">
-						<Button size="sm" type="button" onClick={addBulk} disabled={bulkText.trim().length === 0}>
+						<Button
+							size="sm"
+							type="button"
+							onClick={addBulk}
+							disabled={bulkPreview.added.length === 0 || overCapacity > 0}
+						>
 							Add {bulkPreview.added.length > 0 ? `${bulkPreview.added.length} ` : ""}
 							{bulkPreview.added.length === 1 ? "Prompt" : "Prompts"}
 						</Button>
@@ -322,10 +343,15 @@ export function PromptsListEditor({ prompts, onChange, showSystemTags = true }: 
 						</Button>
 						{bulkNotice && <span className="text-xs text-muted-foreground">{bulkNotice}</span>}
 					</div>
+					{bulkError && (
+						<p role="alert" className="text-xs text-destructive">
+							{bulkError}
+						</p>
+					)}
 				</div>
 			)}
 
-			{prompts.length >= MAX_PROMPTS && (
+			{atCapacity && (
 				<p className="text-xs text-muted-foreground">
 					Maximum of {MAX_PROMPTS} prompts allowed. Remove a prompt to add a new one.
 				</p>

--- a/apps/web/src/server/prompts.ts
+++ b/apps/web/src/server/prompts.ts
@@ -5,6 +5,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import { requireAuthSession, requireOrgAccess } from "@/lib/auth/helpers";
+import { MAX_PROMPTS } from "@workspace/lib/constants";
 import { db } from "@workspace/lib/db/db";
 import { prompts, promptRuns, brands, competitors, SYSTEM_TAGS } from "@workspace/lib/db/schema";
 import { eq, and, desc, gte, count, sql } from "drizzle-orm";
@@ -540,14 +541,16 @@ export const updatePromptsFn = createServerFn({ method: "POST" })
 	.validator(
 		z.object({
 			brandId: z.string(),
-			prompts: z.array(
-				z.object({
-					id: z.string().optional(),
-					value: z.string(),
-					enabled: z.boolean().optional().default(true),
-					tags: z.array(z.string()).optional(),
-				}),
-			),
+			prompts: z
+				.array(
+					z.object({
+						id: z.string().optional(),
+						value: z.string(),
+						enabled: z.boolean().optional().default(true),
+						tags: z.array(z.string()).optional(),
+					}),
+				)
+				.max(MAX_PROMPTS, `A brand may have at most ${MAX_PROMPTS} prompts.`),
 		}),
 	)
 	.handler(async ({ data }) => {

--- a/apps/web/src/stories/prompts-list-editor.stories.tsx
+++ b/apps/web/src/stories/prompts-list-editor.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { MAX_PROMPTS } from "@workspace/lib/constants";
+import { useState } from "react";
+import { expect, userEvent, within } from "storybook/test";
+import { type EditablePrompt, newPromptEntry, PromptsListEditor } from "@/components/prompts-list-editor";
+
+const meta = {
+	title: "Components/PromptsListEditor",
+} satisfies Meta;
+
+export default meta;
+
+/** The table layout is `hidden md:grid` — widen the canvas past 768px to see it. */
+function Harness({ initial, showSystemTags = true }: { initial: EditablePrompt[]; showSystemTags?: boolean }) {
+	const [prompts, setPrompts] = useState(initial);
+
+	return (
+		<div className="p-8">
+			<PromptsListEditor prompts={prompts} onChange={setPrompts} showSystemTags={showSystemTags} />
+		</div>
+	);
+}
+
+const entries = (values: string[], partial?: Partial<EditablePrompt>) =>
+	values.map((value) => newPromptEntry({ value, ...partial }));
+
+const filler = (count: number) => entries(Array.from({ length: count }, (_, i) => `best running shoes option ${i}`));
+
+/** Opens the bulk panel and pastes `text` into it. */
+const addMultiple =
+	(text: string) =>
+	async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: /add multiple/i }));
+		await userEvent.click(canvas.getByLabelText("Prompts to add, one per line"));
+		await userEvent.paste(text);
+	};
+
+export const Populated = () => (
+	<Harness
+		initial={[
+			...entries(["best running shoes for flat feet"], { tags: ["footwear"], systemTags: ["unbranded"] }),
+			...entries(["is nike better than adidas"], { tags: ["comparison"], systemTags: ["branded"] }),
+			...entries(["most durable trail runners"], { enabled: false, systemTags: ["unbranded"] }),
+		]}
+	/>
+);
+
+/**
+ * A paste into a non-empty list carrying every skip reason at once: two blank
+ * lines, a repeat of an existing prompt (differing only in case and spacing),
+ * and a line repeated within the paste. Two survive, and the notice accounts
+ * for all four dropped lines.
+ */
+export const AddMultiple: StoryObj = {
+	render: () => <Harness initial={entries(["best running shoes for flat feet", "most durable trail runners"])} />,
+	play: async (ctx) => {
+		await addMultiple(
+			"trail shoes for wide feet\n\nBest  Running   Shoes For Flat Feet\n   \nbest marathon racing flats\ntrail shoes for wide feet",
+		)(ctx);
+		const canvas = within(ctx.canvasElement);
+		await expect(canvas.getByRole("button", { name: /^add 2 prompts$/i })).toBeEnabled();
+		await expect(canvas.getByText("Skipped 2 duplicates and 2 blank lines.")).toBeVisible();
+	},
+};
+
+/**
+ * 95 filled prompts plus 5 blank rows, so there is room for exactly 5 more —
+ * blank rows fill the table but don't hold prompt slots. Pasting 6 lines puts
+ * the paste over the limit, which blocks it outright rather than taking the 5
+ * that fit.
+ */
+export const AddMultipleOverCapacity: StoryObj = {
+	render: () => (
+		<Harness showSystemTags={false} initial={[...filler(MAX_PROMPTS - 5), ...entries(["", "", "", "", ""])]} />
+	),
+	play: async (ctx) => {
+		await addMultiple(
+			"trail shoes for wide feet\nbest marathon racing flats\nlightweight gym trainers\nbest shoes for plantar fasciitis\ncushioned recovery runners\nzero drop road shoes",
+		)(ctx);
+		const canvas = within(ctx.canvasElement);
+		await expect(canvas.getByRole("button", { name: /^add 5 prompts$/i })).toBeDisabled();
+		await expect(canvas.getByRole("alert")).toHaveTextContent(
+			`This paste is 1 prompt over the ${MAX_PROMPTS} limit. Remove a line to continue.`,
+		);
+	},
+};
+
+/** At the cap: both toolbar buttons are hidden and the limit message shows. */
+export const AtCapacity = () => <Harness showSystemTags={false} initial={filler(MAX_PROMPTS)} />;

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -21,6 +21,7 @@
 		"./text-extraction": "./src/text-extraction.ts",
 		"./onboarding": "./src/onboarding/index.ts",
 		"./tag-utils": "./src/tag-utils.ts",
+		"./bulk-prompts": "./src/bulk-prompts.ts",
 		"./website-excerpt": "./src/website-excerpt.ts",
 		"./report-metrics": "./src/report-metrics.ts",
 		"./secrets": "./src/secrets/index.ts",

--- a/packages/lib/src/bulk-prompts.test.ts
+++ b/packages/lib/src/bulk-prompts.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { describeSkipped, parseBulkPrompts } from "./bulk-prompts";
+import { MAX_PROMPTS } from "./constants";
+
+describe("bulk-prompts", () => {
+	describe("parseBulkPrompts", () => {
+		it("should split on newlines and trim each line", () => {
+			const { added } = parseBulkPrompts("  best running shoes\nbest trail shoes  ");
+			expect(added).toEqual(["best running shoes", "best trail shoes"]);
+		});
+
+		it("should handle windows line endings", () => {
+			const { added } = parseBulkPrompts("one\r\ntwo\r\nthree");
+			expect(added).toEqual(["one", "two", "three"]);
+		});
+
+		it("should count blank lines without reporting them as an error", () => {
+			const { added, skipped } = parseBulkPrompts("one\n\n   \ntwo\n");
+			expect(added).toEqual(["one", "two"]);
+			expect(skipped.blank).toBe(3);
+			expect(describeSkipped(skipped)).toBeNull();
+		});
+
+		it("should drop lines already in the list", () => {
+			const { added, skipped } = parseBulkPrompts("one\ntwo", { existing: ["one"] });
+			expect(added).toEqual(["two"]);
+			expect(skipped.duplicateOfExisting).toEqual(["one"]);
+		});
+
+		it("should drop lines repeated inside the paste", () => {
+			const { added, skipped } = parseBulkPrompts("one\none\ntwo");
+			expect(added).toEqual(["one", "two"]);
+			expect(skipped.duplicateInPaste).toEqual(["one"]);
+		});
+
+		it("should treat case and internal spacing as the same prompt", () => {
+			const { added, skipped } = parseBulkPrompts("Best  Running   Shoes", {
+				existing: ["best running shoes"],
+			});
+			expect(added).toEqual([]);
+			expect(skipped.duplicateOfExisting).toEqual(["Best  Running   Shoes"]);
+		});
+
+		it("should keep the pasted casing of the line it accepts", () => {
+			const { added } = parseBulkPrompts("Best Running Shoes");
+			expect(added).toEqual(["Best Running Shoes"]);
+		});
+
+		it("should measure capacity against the whole list and not the paste", () => {
+			const { added, skipped } = parseBulkPrompts("c\nd\ne", {
+				existing: ["a", "b"],
+				limit: 4,
+			});
+			expect(added).toEqual(["c", "d"]);
+			expect(skipped.overCapacity).toEqual(["e"]);
+		});
+
+		it("should add nothing when the list is already full", () => {
+			const { added, skipped } = parseBulkPrompts("c", { existing: ["a", "b"], limit: 2 });
+			expect(added).toEqual([]);
+			expect(skipped.overCapacity).toEqual(["c"]);
+		});
+
+		it("should not blame the limit for a line a duplicate rule already dropped", () => {
+			const { added, skipped } = parseBulkPrompts("a\nb", { existing: ["a"], limit: 1 });
+			expect(added).toEqual([]);
+			expect(skipped.duplicateOfExisting).toEqual(["a"]);
+			expect(skipped.overCapacity).toEqual(["b"]);
+		});
+
+		it("should default the limit to MAX_PROMPTS", () => {
+			const text = Array.from({ length: MAX_PROMPTS + 5 }, (_, i) => `prompt ${i}`).join("\n");
+			const { added, skipped } = parseBulkPrompts(text);
+			expect(added).toHaveLength(MAX_PROMPTS);
+			expect(skipped.overCapacity).toHaveLength(5);
+		});
+
+		it("should return nothing for empty input", () => {
+			const { added, skipped } = parseBulkPrompts("");
+			expect(added).toEqual([]);
+			expect(skipped.blank).toBe(1);
+		});
+	});
+
+	describe("describeSkipped", () => {
+		it("should say nothing when only blank lines were dropped", () => {
+			expect(describeSkipped({ blank: 4, duplicateOfExisting: [], duplicateInPaste: [], overCapacity: [] })).toBeNull();
+		});
+
+		it("should count both kinds of duplicate together", () => {
+			expect(describeSkipped({ blank: 0, duplicateOfExisting: ["a"], duplicateInPaste: ["b"], overCapacity: [] })).toBe(
+				"Skipped 2 duplicates.",
+			);
+		});
+
+		it("should use the singular for one duplicate", () => {
+			expect(describeSkipped({ blank: 0, duplicateOfExisting: ["a"], duplicateInPaste: [], overCapacity: [] })).toBe(
+				"Skipped 1 duplicate.",
+			);
+		});
+
+		it("should name both reasons when both applied", () => {
+			expect(
+				describeSkipped({ blank: 0, duplicateOfExisting: ["a"], duplicateInPaste: [], overCapacity: ["b", "c"] }),
+			).toBe("Skipped 1 duplicate and 2 over the limit.");
+		});
+	});
+});

--- a/packages/lib/src/bulk-prompts.test.ts
+++ b/packages/lib/src/bulk-prompts.test.ts
@@ -14,11 +14,11 @@ describe("bulk-prompts", () => {
 			expect(added).toEqual(["one", "two", "three"]);
 		});
 
-		it("should count blank lines without reporting them as an error", () => {
+		it("should skip blank lines and say how many", () => {
 			const { added, skipped } = parseBulkPrompts("one\n\n   \ntwo\n");
 			expect(added).toEqual(["one", "two"]);
 			expect(skipped.blank).toBe(3);
-			expect(describeSkipped(skipped)).toBeNull();
+			expect(describeSkipped(skipped)).toBe("Skipped 3 blank lines.");
 		});
 
 		it("should drop lines already in the list", () => {
@@ -83,8 +83,20 @@ describe("bulk-prompts", () => {
 	});
 
 	describe("describeSkipped", () => {
-		it("should say nothing when only blank lines were dropped", () => {
-			expect(describeSkipped({ blank: 4, duplicateOfExisting: [], duplicateInPaste: [], overCapacity: [] })).toBeNull();
+		it("should say nothing when nothing was dropped", () => {
+			expect(describeSkipped({ blank: 0, duplicateOfExisting: [], duplicateInPaste: [], overCapacity: [] })).toBeNull();
+		});
+
+		it("should report blank lines", () => {
+			expect(describeSkipped({ blank: 4, duplicateOfExisting: [], duplicateInPaste: [], overCapacity: [] })).toBe(
+				"Skipped 4 blank lines.",
+			);
+		});
+
+		it("should use the singular for one blank line", () => {
+			expect(describeSkipped({ blank: 1, duplicateOfExisting: [], duplicateInPaste: [], overCapacity: [] })).toBe(
+				"Skipped 1 blank line.",
+			);
 		});
 
 		it("should count both kinds of duplicate together", () => {
@@ -99,10 +111,16 @@ describe("bulk-prompts", () => {
 			);
 		});
 
-		it("should name both reasons when both applied", () => {
+		it("should name duplicates and blank lines together", () => {
+			expect(describeSkipped({ blank: 2, duplicateOfExisting: ["a"], duplicateInPaste: [], overCapacity: [] })).toBe(
+				"Skipped 1 duplicate and 2 blank lines.",
+			);
+		});
+
+		it("should leave over-capacity lines out, since they block the paste instead", () => {
 			expect(
-				describeSkipped({ blank: 0, duplicateOfExisting: ["a"], duplicateInPaste: [], overCapacity: ["b", "c"] }),
-			).toBe("Skipped 1 duplicate and 2 over the limit.");
+				describeSkipped({ blank: 0, duplicateOfExisting: [], duplicateInPaste: [], overCapacity: ["b", "c"] }),
+			).toBeNull();
 		});
 	});
 });

--- a/packages/lib/src/bulk-prompts.ts
+++ b/packages/lib/src/bulk-prompts.ts
@@ -104,9 +104,10 @@ export function parseBulkPrompts(text: string, options: ParseBulkPromptsOptions 
 }
 
 /**
- * One sentence naming everything the parse dropped, or null when it dropped
- * nothing worth saying. Blank lines are counted but never mentioned, because
- * a trailing newline is not a mistake anyone needs told about.
+ * One sentence naming what the parse dropped, or null when it dropped nothing.
+ *
+ * Over-capacity lines are deliberately absent: they block the paste outright
+ * rather than being skipped, so the caller reports those as an error instead.
  */
 export function describeSkipped(skipped: SkippedLines): string | null {
 	const parts: string[] = [];
@@ -114,8 +115,8 @@ export function describeSkipped(skipped: SkippedLines): string | null {
 	if (duplicates > 0) {
 		parts.push(`${duplicates} duplicate${duplicates === 1 ? "" : "s"}`);
 	}
-	if (skipped.overCapacity.length > 0) {
-		parts.push(`${skipped.overCapacity.length} over the limit`);
+	if (skipped.blank > 0) {
+		parts.push(`${skipped.blank} blank line${skipped.blank === 1 ? "" : "s"}`);
 	}
 	if (parts.length === 0) return null;
 	return `Skipped ${parts.join(" and ")}.`;

--- a/packages/lib/src/bulk-prompts.ts
+++ b/packages/lib/src/bulk-prompts.ts
@@ -1,0 +1,122 @@
+import { MAX_PROMPTS } from "./constants";
+
+/**
+ * Why a pasted line did not become a prompt.
+ *
+ * Reported rather than dropped silently: pasting fifty lines and getting
+ * forty-one prompts with no explanation is the case this parser exists to
+ * avoid, since the nine that vanished are indistinguishable from a bug.
+ */
+export interface SkippedLines {
+	/** Lines that were empty or whitespace only. */
+	blank: number;
+	/** Lines matching a prompt already in the list. */
+	duplicateOfExisting: string[];
+	/** Lines repeated within the pasted text itself. */
+	duplicateInPaste: string[];
+	/** Lines dropped because the list is capped at `MAX_PROMPTS`. */
+	overCapacity: string[];
+}
+
+export interface BulkPromptParse {
+	/** Lines that became prompts, in the order they were pasted. */
+	added: string[];
+	skipped: SkippedLines;
+}
+
+export interface ParseBulkPromptsOptions {
+	/** Prompt values already in the list, used for duplicate detection. */
+	existing?: readonly string[];
+	/** Total prompts the list may hold. Defaults to `MAX_PROMPTS`. */
+	limit?: number;
+}
+
+/**
+ * Comparison key for two prompts being "the same".
+ *
+ * Case and surrounding whitespace are ignored, and runs of internal whitespace
+ * collapse to one space, so a line re-pasted from a wrapped document does not
+ * arrive as a second distinct prompt.
+ */
+function dedupeKey(value: string): string {
+	return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+/**
+ * Split pasted text into prompts, one per line.
+ *
+ * Everything this drops, it names. The caller gets the lines that became
+ * prompts and, separately, every line that did not along with the reason, so
+ * the screen can tell someone that three of their lines were already in the
+ * list rather than leaving them to count.
+ *
+ * Capacity is measured against the whole list, not the paste: `limit` is the
+ * total the list may hold, so a paste of ten lines into a list already holding
+ * `limit - 2` prompts contributes two and reports eight as over capacity.
+ */
+export function parseBulkPrompts(text: string, options: ParseBulkPromptsOptions = {}): BulkPromptParse {
+	const { existing = [], limit = MAX_PROMPTS } = options;
+
+	const seen = new Set(existing.map(dedupeKey));
+	const room = Math.max(0, limit - existing.length);
+
+	const added: string[] = [];
+	const skipped: SkippedLines = {
+		blank: 0,
+		duplicateOfExisting: [],
+		duplicateInPaste: [],
+		overCapacity: [],
+	};
+
+	const withinPaste = new Set<string>();
+
+	for (const raw of text.split(/\r?\n/)) {
+		const value = raw.trim();
+		if (value.length === 0) {
+			skipped.blank += 1;
+			continue;
+		}
+
+		const key = dedupeKey(value);
+		if (withinPaste.has(key)) {
+			skipped.duplicateInPaste.push(value);
+			continue;
+		}
+		if (seen.has(key)) {
+			skipped.duplicateOfExisting.push(value);
+			continue;
+		}
+
+		// Capacity is checked after the duplicate rules on purpose. A line that
+		// was never going to be added is not competing for a slot, so reporting
+		// it as over capacity would blame the limit for something the limit did
+		// not cause.
+		if (added.length >= room) {
+			skipped.overCapacity.push(value);
+			continue;
+		}
+
+		withinPaste.add(key);
+		added.push(value);
+	}
+
+	return { added, skipped };
+}
+
+/**
+ * One sentence naming everything the parse dropped, or null when it dropped
+ * nothing worth saying. Blank lines are counted but never mentioned, because
+ * a trailing newline is not a mistake anyone needs told about.
+ */
+export function describeSkipped(skipped: SkippedLines): string | null {
+	const parts: string[] = [];
+	const duplicates = skipped.duplicateOfExisting.length + skipped.duplicateInPaste.length;
+	if (duplicates > 0) {
+		parts.push(`${duplicates} duplicate${duplicates === 1 ? "" : "s"}`);
+	}
+	if (skipped.overCapacity.length > 0) {
+		parts.push(`${skipped.overCapacity.length} over the limit`);
+	}
+	if (parts.length === 0) return null;
+	return `Skipped ${parts.join(" and ")}.`;
+}


### PR DESCRIPTION
Closes #512.

Adds a "Paste in Bulk" control beside "Add Prompt" that takes a textarea of prompts, one per line.

### What it does with the lines

Parsing lives in `@workspace/lib/bulk-prompts` as a pure function, so the rules are tested without a DOM and the component only renders the result.

- trims each line, ignores blank ones
- skips a line already in the list, and a line repeated inside the paste itself
- comparison ignores case and collapses internal whitespace, so a line re-pasted from a wrapped document does not arrive as a second prompt
- respects `MAX_PROMPTS` against the **whole list**, not the paste, so ten lines pasted into a list holding 98 contributes two

Every dropped line is returned with its reason rather than disappearing. Pasting fifty lines and getting forty-one prompts with no explanation is the case this avoids, since the nine that vanished are otherwise indistinguishable from a bug. The button label counts what will be added, and a short note beside it names what will not (`Skipped 2 duplicates.`).

One deliberate ordering choice: capacity is checked **after** the duplicate rules. A line that was never going to be added is not competing for a slot, so reporting it as over the limit would blame the cap for something the cap did not cause.

### Checks

```
vitest run packages/lib   21 files, 301 tests passed  (16 new)
biome check               clean
tsc --noEmit packages/lib 0 errors
tsc --noEmit apps/web     0 errors
```

Happy to adjust the copy, the icon, or move the control if you would rather it live somewhere else.