### PR TITLE
call out the Oxylabs Realtime deprecation deadline

### DIFF
--- a/.changeset/calm-oxylabs-jobs.md
+++ b/.changeset/calm-oxylabs-jobs.md
@@ -2,4 +2,4 @@
 "@elmohq/cli": patch
 ---
 
-Oxylabs requests now use asynchronous jobs to avoid realtime connection timeouts.
+Oxylabs requests now use the asynchronous Push-Pull API instead of the Realtime API, which Oxylabs is deprecating. If you have any `:oxylabs` targets in `SCRAPE_TARGETS`, upgrade before August 31, 2026 to avoid losing those runs.

--- a/.changeset/calm-oxylabs-jobs.md
+++ b/.changeset/calm-oxylabs-jobs.md
@@ -2,4 +2,4 @@
 "@elmohq/cli": patch
 ---
 
-Oxylabs requests now use the asynchronous Push-Pull API instead of the Realtime API, which Oxylabs is deprecating. If you have any `:oxylabs` targets in `SCRAPE_TARGETS`, upgrade before August 31, 2026 to avoid losing those runs.
+Oxylabs requests now use the asynchronous jobs API instead of the Realtime API, which Oxylabs is deprecating. If you have any `:oxylabs` targets in `SCRAPE_TARGETS`, upgrade before August 31, 2026 to avoid failures.


### PR DESCRIPTION
Oxylabs is deprecating the Realtime integration for LLM scraping (ChatGPT, Perplexity, Gemini) on **August 31, 2026**, and is emailing customers to move to Push-Pull.

We already made that move in #482 — `packages/lib/src/providers/registry/oxylabs.ts` posts to `https://data.oxylabs.io/v1/queries` and polls, so `main` is fine. But that changeset is still unconsumed: npm latest for `@elmohq/cli` is 0.2.17, which is pinned to `https://realtime.oxylabs.io/v1/queries`. Every self-hosted deployment on 0.2.17 or earlier is pointed at the endpoint that goes away.

This rewrites the pending changeset so the eventual release note tells that reader what to do, rather than describing an internal change they can't act on:

> Oxylabs requests now use the asynchronous Push-Pull API instead of the Realtime API, which Oxylabs is deprecating. If you have any `:oxylabs` targets in `SCRAPE_TARGETS`, upgrade before August 31, 2026 to avoid losing those runs.

No code change — the entry now names Push-Pull/Realtime so it lines up with the email Oxylabs is sending, and gives a scope test (`:oxylabs` in `SCRAPE_TARGETS`) readers can check themselves.

### Follow-ups this doesn't cover

- **A release has to actually go out before Aug 31.** The fix is merged but unreleased; the changeset is inert until then.
- **A changeset only reaches people who upgrade.** Anyone sitting on 0.2.17 who never checks npm still goes dark. That needs a different channel — status-page note or direct outreach to self-hosted users.
- Gemini is called out in the Oxylabs email but isn't relevant to us; our Oxylabs source map only covers ChatGPT, Perplexity, Google AI Mode, and Google AI Overview.