### PR TITLE
Stop counting Perplexity's follow-up suggestions as Oxylabs searches

### DIFF
--- a/.changeset/oxylabs-perplexity-fanout.md
+++ b/.changeset/oxylabs-perplexity-fanout.md
@@ -1,0 +1,5 @@
+---
+"@workspace/lib": patch
+---
+
+Query Fan-Out no longer counts Perplexity's suggested follow-up questions as searches on `:oxylabs` targets, which inflated fan-out with searches that never ran.

--- a/.changeset/oxylabs-perplexity-fanout.md
+++ b/.changeset/oxylabs-perplexity-fanout.md
@@ -2,4 +2,4 @@
 "@workspace/lib": patch
 ---
 
-Query Fan-Out no longer counts Perplexity's suggested follow-up questions as searches on `:oxylabs` targets, which inflated fan-out with searches that never ran.
+Fix Oxylabs Perplexity query fan-out which incorrectly included follow-up questions.

--- a/packages/lib/src/providers/registry/oxylabs.test.ts
+++ b/packages/lib/src/providers/registry/oxylabs.test.ts
@@ -14,6 +14,20 @@ const RESULT_PAYLOAD = {
 	],
 };
 
+// Perplexity exposes no searches of its own, only the follow-up questions it
+// suggests below an answer.
+const PERPLEXITY_PAYLOAD = {
+	results: [
+		{
+			content: {
+				markdown_text: "The Sonos Era 300 is a well-reviewed speaker released recently.",
+				citations: [{ url: "https://www.whathifi.com/reviews/sonos-era-300", title: "Sonos Era 300 review" }],
+				related_queries: ["What about the JBL Charge 6", "Which is better for a pool party"],
+			},
+		},
+	],
+};
+
 function jsonResponse(body: unknown, status = 200): Response {
 	return new Response(JSON.stringify(body), {
 		status,
@@ -69,6 +83,24 @@ describe("oxylabs provider", () => {
 		expect(result.citations).toHaveLength(1);
 		expect(result.webQueries).toEqual(["recent speaker reviews"]);
 		expect(result.modelVersion).toBe("gpt-5");
+	});
+
+	it("does not count Perplexity's suggested follow-ups as searches", async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse({ id: "job-pplx", status: "pending" }, 202))
+			.mockResolvedValueOnce(jsonResponse({ id: "job-pplx", status: "done" }))
+			.mockResolvedValueOnce(jsonResponse(PERPLEXITY_PAYLOAD));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const promise = oxylabs.run("perplexity", "What is a well-reviewed speaker?", { webSearch: true });
+		await vi.runAllTimersAsync();
+		const result = await promise;
+
+		// Citations prove a search ran, but Oxylabs never reports what was searched.
+		expect(result.citations).toHaveLength(1);
+		expect(result.webQueries).toEqual(["unavailable"]);
 	});
 
 	it("uses the same asynchronous flow for Google AI Mode", async () => {

--- a/packages/lib/src/providers/registry/oxylabs.ts
+++ b/packages/lib/src/providers/registry/oxylabs.ts
@@ -144,7 +144,10 @@ async function runAsyncQuery(body: Record<string, any>): Promise<OxylabsPayload>
 
 function extractWebQueries(content: Record<string, any>): string[] {
 	// Oxylabs exposes search queries under different keys depending on the source.
-	for (const key of ["search_queries", "related_queries", "web_search_queries"]) {
+	// `related_queries` is not one of them: Oxylabs documents it as the follow-up
+	// questions Perplexity suggests below an answer, so counting it would report
+	// searches that never ran.
+	for (const key of ["search_queries", "web_search_queries"]) {
 		const arr = content[key];
 		if (Array.isArray(arr)) {
 			const queries = arr.filter((q: any) => typeof q === "string" && q.trim());


### PR DESCRIPTION
Oxylabs' Perplexity extractor reads `related_queries` as web search queries. [Oxylabs' own docs](https://developers.oxylabs.io/api-targets/llms-and-ai/perplexity) describe that field as:

> `related_queries` – Suggested follow-up questions by Perplexity.

Those are the recommendations rendered *below* an answer for further exploration, not the searches Perplexity ran to produce it — the same concept Perplexity's API calls `related_questions`. Their parsed response exposes no field holding the actual searches.

So every `perplexity:oxylabs:online` run has been filling `web_queries` with searches that never happened, and Query Fan-Out counted them as real. This is the same fabrication #324 removed from DataForSEO, which now writes the `unavailable` sentinel instead.

## Change

Drop `related_queries` from the key list. Perplexity via Oxylabs now falls back to the `unavailable` sentinel when citations prove a search ran but the query strings aren't exposed — consistent with DataForSEO's Google AI Mode and BrightData's SERP path.

`search_queries` and `web_search_queries` are left in place for the other Oxylabs sources.

## Effect on existing data

Historical rows keep the fabricated queries. They'll age out of the lookback windows; no migration here.

## How this surfaced

Found while integration-testing the Cloro provider (#498). Cloro's Perplexity payload has the same split — a `related_queries` follow-up block and a `search_model_queries` field that only ever echoes the prompt — and checking whether the other Perplexity scrapers were consistent turned this up. Olostep and BrightData both read `search_model_queries` and were unaffected.