### PR TITLE
fix the license check failing on wasm32-wasi bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.13",
   "private": true,
   "license": "MIT",
-  "packageManager": "pnpm@11.5.0",
+  "packageManager": "pnpm@11.18.0",
   "engines": {
     "node": "24.x"
   },

--- a/scripts/check-licenses.mjs
+++ b/scripts/check-licenses.mjs
@@ -113,7 +113,11 @@ function run() {
       maxBuffer: 50 * 1024 * 1024,
     });
   } catch (err) {
+    // pnpm reports its own failures (e.g. ERR_PNPM_MISSING_PACKAGE_INDEX_FILE)
+    // as JSON on stdout, which execSync captures rather than forwards.
     console.error("Failed to run pnpm licenses list:", err.message);
+    if (err.stdout) console.error(err.stdout.toString().trim());
+    if (err.stderr) console.error(err.stderr.toString().trim());
     process.exit(1);
   }
 


### PR DESCRIPTION
The License Check job fails on #528 (and would fail on any PR that pulls a
`*-wasm32-wasi` binding into the graph) with nothing but
`Command failed: pnpm licenses list --json`.

## What's actually happening

`pnpm licenses list` aborts before the audit runs:

```
ERR_PNPM_MISSING_PACKAGE_INDEX_FILE
Failed to find package index file for @tybys/wasm-util@0.10.3
```

It's not a license violation. `@napi-rs/wasm-runtime` 1.1.6 -> 1.2.2 widens its
peer range to `@emnapi/core: ^1.7.1 || ^2.0.0-alpha.3`, and
`@rolldown/binding-wasm32-wasi@1.2.1` now wants `@emnapi/core@2.0.0-alpha.3`.
That produces a peer-resolved `@napi-rs/wasm-runtime` variant which pnpm 11.5.0
materializes into the virtual store while skipping its own `@tybys/wasm-util`
dependency. The licenses walk descends into the installed runtime, finds no
store index for `wasm-util`, and exits 1.

pnpm 11.18.0 installs the dependency, so the walk completes.

## Changes

- **Upgrade pnpm to 11.18.0.** `packageManager` is the only pnpm pin in the
  repo and `pnpm/action-setup@v6` reads it, so every workflow follows.
- **Print pnpm's output when the license check fails.** pnpm reports its own
  errors as JSON on stdout, which `execSync` captures rather than forwards, so
  the real message was being dropped on the floor.

## Verification

- License check passes on this branch (1260 packages) and on #528 rebased onto
  it (1272), with no new `ALLOWED_LICENSES` or `PACKAGE_EXCEPTIONS` entries --
  the newly-visible `@tybys/wasm-util` and `@emnapi/*` are MIT.
- **No lockfile churn**: `pnpm install` under 11.18.0 leaves `pnpm-lock.yaml`
  byte-identical, on this branch and on #528. So #528 only needs a rebase.
- Reproduced the original failure against a cold store and confirmed the
  patched script now prints the `ERR_PNPM_MISSING_PACKAGE_INDEX_FILE` payload.
- 11.18.0 rather than the latest 11.20.0: 11.20.0 shipped 2026-08-03, inside
  our own 4-day `minimumReleaseAge`. Both fix the bug.
- Bonus: 11.6.0 carried a security fix -- pnpm no longer expands `${ENV_VAR}`
  from repository-controlled config files, which could leak env secrets to
  attacker-controlled registries. 11.5.0 predates it.

Alternatives considered and rejected: `--no-optional` (passes, but silently
drops the 10 shipped native bindings from the audit, including
`lightningcss-linux-x64-gnu` MPL-2.0 and `@sentry/cli-linux-x64` FSL);
`ignoredOptionalDependencies` (doesn't invalidate an existing lockfile, so it
needs a full re-resolve to take effect); pinning `@napi-rs/wasm-runtime` back
to 1.1.6 (fights dependabot, and its `^1.7.1` peer range rejects the
`@emnapi/core` prerelease rolldown now requires).

One gotcha for reviewers: the failure is store-state dependent. Once anything
populates `@tybys/wasm-util` into the local store, even 11.5.0 passes -- so a
local run on a warm store is a false negative.
