### PR TITLE
Preload the logo font to stop the first-load flicker

### DIFF
--- a/.changeset/preload-logo-font.md
+++ b/.changeset/preload-logo-font.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Fixed the logo briefly rendering in a fallback font before swapping on the first page load.

--- a/apps/web/src/components/logo.tsx
+++ b/apps/web/src/components/logo.tsx
@@ -9,14 +9,19 @@ interface LogoProps extends ComponentPropsWithoutRef<"div"> {
 	textClassName?: string;
 }
 
-export function Logo({ className, iconClassName, textClassName, ...props }: LogoProps) {
-	const context = useRouteContext({ strict: false }) as { clientConfig?: ClientConfig };
-	const branding = context.clientConfig?.branding;
+/** Whether the Titan One wordmark renders — drives the font preload in `__root.tsx`. */
+export function usesWordmarkFont(branding: { icon?: string; name?: string } | undefined) {
 	const hasCustomBranding =
 		Boolean(branding?.icon && branding?.name) &&
 		(branding?.icon !== DEFAULT_APP_ICON || branding?.name !== DEFAULT_APP_NAME);
+	return !hasCustomBranding;
+}
 
-	if (!hasCustomBranding) {
+export function Logo({ className, iconClassName, textClassName, ...props }: LogoProps) {
+	const context = useRouteContext({ strict: false }) as { clientConfig?: ClientConfig };
+	const branding = context.clientConfig?.branding;
+
+	if (usesWordmarkFont(branding)) {
 		return (
 			<div {...props} className={cn("flex items-center gap-2", className)}>
 				<span className={cn("font-titan-one text-3xl font-normal lowercase text-blue-600", textClassName)}>elmo</span>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -116,7 +116,9 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 								as: "font",
 								type: "font/woff2",
 								href: titanOneFont,
-								crossOrigin: "anonymous",
+								// Inside a conditional spread the literal widens to `string`,
+								// which doesn't satisfy React's `CrossOrigin` union.
+								crossOrigin: "anonymous" as const,
 							},
 						]
 					: []),

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -9,9 +9,13 @@ import type { DeploymentMode } from "@workspace/config/types";
 import type { MissingEnvVar } from "@workspace/config/env";
 import { getClientConfig, getEnvValidationStateFn, type PublicClientConfig } from "@/server/config";
 import MissingEnvPage from "@/components/missing-env-page";
+import { usesWordmarkFont } from "@/components/logo";
 import queryDevtools from "@/integrations/tanstack-query/devtools";
 import { initPostHog } from "@/lib/posthog";
 import appCss from "../styles.css?url";
+// Preloaded so the wordmark font downloads in parallel with the CSS rather than
+// after it. Must resolve to the same emitted asset as the @font-face src.
+import titanOneFont from "@fontsource/titan-one/files/titan-one-latin-400-normal.woff2?url";
 
 interface RouterContext {
 	queryClient: QueryClient;
@@ -103,6 +107,19 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 				{ name: "twitter:image", content: ogImage },
 			],
 			links: [
+				// Whitelabel deployments render an icon + system-font name instead,
+				// so the wordmark font is never used there.
+				...(usesWordmarkFont(branding)
+					? [
+							{
+								rel: "preload",
+								as: "font",
+								type: "font/woff2",
+								href: titanOneFont,
+								crossOrigin: "anonymous",
+							},
+						]
+					: []),
 				{ rel: "stylesheet", href: appCss },
 				{ rel: "manifest", href: "/api/manifest" },
 				// Whitelabel uses its own icon URL for both favicon and iOS touch;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,5 +1,4 @@
 @import "tailwindcss" source(none);
-@import "@fontsource/titan-one";
 
 @import "tw-animate-css";
 
@@ -54,6 +53,17 @@
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);
 	--radius-xl: calc(var(--radius) + 4px);
+}
+
+/* font-display: block (not swap) so the wordmark never flashes the cursive
+   fallback before swapping; __root.tsx preloads this exact file to keep the
+   block window imperceptible. */
+@font-face {
+	font-family: "Titan One";
+	font-style: normal;
+	font-weight: 400;
+	src: url("@fontsource/titan-one/files/titan-one-latin-400-normal.woff2") format("woff2");
+	font-display: block;
 }
 
 :root {


### PR DESCRIPTION
## The problem

On a cold load of `apps/web`, the `elmo` wordmark paints in a fallback font and then visibly swaps to Titan One.

`apps/web/src/styles.css` pulled the font in with `@import "@fontsource/titan-one"`. Fontsource's `index.css` declares its faces with `font-display: swap`, and nothing preloaded the file — so the browser only discovered the `.woff2` after parsing the stylesheet (HTML → CSS → font waterfall), painted the logo in the `cursive` fallback in the meantime, and re-rendered the moment the font arrived. `cursive` has very different metrics from Titan One, which is why the correction is so noticeable.

`apps/www` already handles this correctly; `apps/web` never got the same treatment.

## The fix

Ported the `apps/www` pattern:

- **`styles.css`** — replaced the fontsource `@import` with an explicit `@font-face` against the single `latin` file, and set `font-display: block`. `block` is what actually removes the flicker: the wordmark is held invisible during the load window instead of being painted wrong and corrected. For a four-character logo that's strictly better than a visible font change, and it still falls back after ~3s if the font never loads. The wordmark is ASCII, so dropping the `latin-ext` subset costs nothing.
- **`__root.tsx`** — added a `rel="preload"` link ahead of the stylesheet so the ~10.5 KB font downloads in parallel with the CSS rather than after it, which collapses the block window to nothing in practice. Declaring the face explicitly is what makes this work: a preload only helps if its URL matches what the CSS requests, and both now resolve through Vite from the same source path to the same emitted asset.
- **`logo.tsx`** — extracted the whitelabel check as `usesWordmarkFont` so the preload and the component can't drift. Whitelabel deployments render an icon plus a system-font name and never touch Titan One, so preloading there would be a wasted request and a devtools warning.

## Noticed but not touched

`apps/web/src/styles.css` sets `--font-sans: var(--font-geist-sans)` and `--font-mono: var(--font-geist-mono)`, but neither variable is defined anywhere in `apps/web` — no `@font-face` for Geist, no `@fontsource/geist-sans` CSS import, and the app doesn't import `packages/ui`'s `globals.css` (which only references them too). Only `apps/www` defines them.

So `@fontsource/geist-sans` is a dependency the web app never loads, and `font-sans` falls through to the system sans stack via Tailwind's preflight fallback. It looks fine, which is presumably why it went unnoticed — but the dashboard isn't rendering in Geist while the marketing site is. Fixing it would restyle the app's whole typography, so it's left for a separate change.

## Testing

Formatting verified with Biome. No behavior is covered by tests here — this is a paint-timing fix, best confirmed by a hard-refresh on a throttled connection.