### PR TITLE
set the required cache-key on the Blacksmith docker builder

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -113,6 +113,10 @@ jobs:
 
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v2
+        with:
+          # Scoped per arch: the two matrix jobs share no layers and commit
+          # concurrently, and cache commits are last-write-wins.
+          cache-key: docker/Dockerfile-${{ matrix.arch }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v4


### PR DESCRIPTION
`useblacksmith/setup-docker-builder@v2` made `cache-key` a required input. The release workflow wasn't passing one, so builder setup failed and fell back to a local builder — release image builds have been running with no Docker layer cache.

The builds still succeeded, which is why this went unnoticed. All 14 annotations on [the last release run](https://github.com/elmohq/elmo/actions/runs/31132642212) trace back to it:

| Warning | Cause |
| --- | --- |
| `Error in setupStickyDisk: 'cache-key' input is required` | the actual failure |
| `Error during Blacksmith builder setup ... Falling back to local builder` | fallback path |
| `Blacksmith builder setup skipped or failed` | fallback path |
| `Not using a Blacksmith builder (current builder: local)` ×3 | one per `build-push-action` step |
| `Expose ID not found in state, skipping sticky disk commit` | post-step, no sticky disk was ever mounted |

## On the key

Blacksmith's own multi-arch matrix example uses a single unscoped key across both arches, but this scopes it per arch on purpose: amd64 and arm64 share no layers (BuildKit keys cache by platform), the two matrix jobs run concurrently, and Blacksmith documents cache commits as last-write-wins under concurrency. A shared key would have the two arches clobbering each other every release for no upside.

The three image targets (web/worker/db-migrate) share one key — same Dockerfile behind one builder, so that's forced regardless.

## Notes

- The first release after this merges will still be slow; the new key starts on a cold sticky disk and the speedup lands on the run after.
- The action defaults to `nofallback: false`, which is why this degraded to warnings instead of failing. Left as-is so a Blacksmith hiccup can't break a release, but worth flipping to `true` if we'd rather catch the next regression immediately.

No changeset — CI-only, not user-facing.