### PR TITLE
ask for platform picks at brand creation, and apply run-config changes immediately

### DIFF
--- a/.changeset/brand-platform-picks-at-creation.md
+++ b/.changeset/brand-platform-picks-at-creation.md
@@ -1,5 +1,0 @@
----
-"@workspace/web": patch
----
-
-Creating a brand now asks which AI platforms to track, and adding a platform or premium model starts tracking it right away instead of at the next scheduled run.

--- a/.changeset/brand-platform-picks-at-creation.md
+++ b/.changeset/brand-platform-picks-at-creation.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Creating a brand now asks which AI platforms to track, and adding a platform or premium model starts tracking it right away instead of at the next scheduled run.

--- a/apps/web/src/components/brand-onboarding.tsx
+++ b/apps/web/src/components/brand-onboarding.tsx
@@ -1,11 +1,10 @@
 import { useNavigate, useRouter } from "@tanstack/react-router";
-import { getModelMeta } from "@workspace/config/models";
 import { Button } from "@workspace/ui/components/button";
 import { Input } from "@workspace/ui/components/input";
 import { Label } from "@workspace/ui/components/label";
 import { useState } from "react";
 import FullPageCard from "@/components/full-page-card";
-import { PlatformPicker } from "@/components/platform-picker";
+import { PlatformSelectionStep } from "@/components/platform-selection-step";
 import { validateWebsiteUrl } from "@/lib/brand-website";
 import { trackEvent } from "@/lib/posthog";
 import { createBrandFn } from "@/server/brands";
@@ -17,11 +16,7 @@ interface BrandOnboardingProps {
 	platformState: OnboardingPlatformState;
 }
 
-export default function BrandOnboarding({
-	brandId,
-	brandName,
-	platformState,
-}: BrandOnboardingProps) {
+export default function BrandOnboarding({ brandId, brandName, platformState }: BrandOnboardingProps) {
 	const [step, setStep] = useState<"website" | "platforms">("website");
 	const [website, setWebsite] = useState("");
 	const [selected, setSelected] = useState<Set<string>>(
@@ -73,50 +68,18 @@ export default function BrandOnboarding({
 	};
 
 	if (step === "platforms" && platformState) {
-		const limit = platformState.platformPicks;
-		const locked = platformState.available.length === 1;
-		const onlyOption = platformState.available[0];
-
 		return (
 			<FullPageCard title={`Setup ${brandName}`} subtitle="Choose which AI platforms to track">
-				<div className="space-y-4">
-					<p className="text-sm text-muted-foreground">
-						{locked && onlyOption
-							? `Your plan includes ${getModelMeta(onlyOption.model).label} tracking. You can change platforms anytime in settings.`
-							: `Your plan tracks up to ${limit} platform${limit === 1 ? "" : "s"} for this brand. You can change these anytime in settings.`}
-					</p>
-
-					<PlatformPicker
-						options={platformState.available}
-						selected={selected}
-						onSelectedChange={setSelected}
-						limit={limit}
-						disabled={isLoading || locked}
-						className="sm:grid-cols-1 lg:grid-cols-1"
-					/>
-
-					{!locked && (
-						<p className="text-xs text-muted-foreground">
-							{selected.size === 0 ? "Pick at least one platform." : `${selected.size} of ${limit} selected`}
-						</p>
-					)}
-
-					{error && <p className="text-sm text-destructive">{error}</p>}
-
-					<div className="flex gap-2">
-						<Button type="button" variant="outline" onClick={() => setStep("website")} disabled={isLoading}>
-							Back
-						</Button>
-						<Button
-							type="button"
-							className="flex-1"
-							onClick={() => createBrand([...selected])}
-							disabled={isLoading || selected.size === 0}
-						>
-							{isLoading ? "Setting up..." : "Complete Setup"}
-						</Button>
-					</div>
-				</div>
+				<PlatformSelectionStep
+					state={platformState}
+					selected={selected}
+					onSelectedChange={setSelected}
+					disabled={isLoading}
+					error={error}
+					onBack={() => setStep("website")}
+					onSubmit={() => createBrand([...selected])}
+					submitLabel={isLoading ? "Setting up..." : "Complete Setup"}
+				/>
 			</FullPageCard>
 		);
 	}

--- a/apps/web/src/components/platform-selection-step.tsx
+++ b/apps/web/src/components/platform-selection-step.tsx
@@ -1,0 +1,72 @@
+import { getModelMeta } from "@workspace/config/models";
+import { Button } from "@workspace/ui/components/button";
+import { PlatformPicker } from "@/components/platform-picker";
+import type { OnboardingPlatformState } from "@/server/platform-picks";
+
+interface PlatformSelectionStepProps {
+	state: NonNullable<OnboardingPlatformState>;
+	selected: Set<string>;
+	onSelectedChange: (next: Set<string>) => void;
+	disabled: boolean;
+	error?: string;
+	onBack: () => void;
+	onSubmit: () => void;
+	submitLabel: string;
+}
+
+/**
+ * The platform step every brand-creation flow shares: which platforms the new
+ * brand is tracked on, within what the plan sells. Picking here rather than
+ * accepting the plan defaults matters because the first cycle starts as soon as
+ * the brand exists — a set corrected afterwards has already been paid for.
+ */
+export function PlatformSelectionStep({
+	state,
+	selected,
+	onSelectedChange,
+	disabled,
+	error,
+	onBack,
+	onSubmit,
+	submitLabel,
+}: PlatformSelectionStepProps) {
+	const limit = state.platformPicks;
+	const locked = state.available.length === 1;
+	const onlyOption = state.available[0];
+
+	return (
+		<div className="space-y-4">
+			<p className="text-sm text-muted-foreground">
+				{locked && onlyOption
+					? `Your plan includes ${getModelMeta(onlyOption.model).label} tracking. You can change platforms anytime in settings.`
+					: `Your plan tracks up to ${limit} platform${limit === 1 ? "" : "s"} for this brand. You can change these anytime in settings.`}
+			</p>
+
+			<PlatformPicker
+				options={state.available}
+				selected={selected}
+				onSelectedChange={onSelectedChange}
+				limit={limit}
+				disabled={disabled || locked}
+				className="sm:grid-cols-1 lg:grid-cols-1"
+			/>
+
+			{!locked && (
+				<p className="text-xs text-muted-foreground">
+					{selected.size === 0 ? "Pick at least one platform." : `${selected.size} of ${limit} selected`}
+				</p>
+			)}
+
+			{error && <p className="text-sm text-destructive">{error}</p>}
+
+			<div className="flex gap-2">
+				<Button type="button" variant="outline" onClick={onBack} disabled={disabled}>
+					Back
+				</Button>
+				<Button type="button" className="flex-1" onClick={onSubmit} disabled={disabled || selected.size === 0}>
+					{submitLabel}
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/lib/__tests__/run-config-changes.test.ts
+++ b/apps/web/src/lib/__tests__/run-config-changes.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { addedPlatforms, promptsGainingPremium } from "@/lib/run-config-changes";
+
+const CONFIGURED = ["chatgpt", "perplexity", "gemini"];
+
+describe("addedPlatforms", () => {
+	it("reports a newly picked platform", () => {
+		expect(addedPlatforms(["chatgpt"], ["chatgpt", "gemini"], CONFIGURED)).toEqual(["gemini"]);
+	});
+
+	it("reports nothing when a platform is dropped", () => {
+		expect(addedPlatforms(["chatgpt", "gemini"], ["chatgpt"], CONFIGURED)).toEqual([]);
+	});
+
+	it("reports nothing when the selection is unchanged", () => {
+		expect(addedPlatforms(["chatgpt", "gemini"], ["gemini", "chatgpt"], CONFIGURED)).toEqual([]);
+	});
+
+	it("treats null as every configured target, so narrowing adds nothing", () => {
+		expect(addedPlatforms(null, ["chatgpt"], CONFIGURED)).toEqual([]);
+	});
+
+	it("treats null as every configured target, so widening adds the rest", () => {
+		expect(addedPlatforms(["chatgpt"], null, CONFIGURED)).toEqual(["perplexity", "gemini"]);
+	});
+});
+
+describe("promptsGainingPremium", () => {
+	const before = new Map([
+		["kept", { premiumModels: ["claude"] }],
+		["grew", { premiumModels: ["claude"] }],
+		["shrank", { premiumModels: ["claude", "grok"] }],
+	]);
+
+	it("reports only the prompts that gained a model", () => {
+		const after = [
+			{ id: "kept", premiumModels: ["claude"] },
+			{ id: "grew", premiumModels: ["claude", "grok"] },
+			{ id: "shrank", premiumModels: ["claude"] },
+		];
+		expect(promptsGainingPremium(before, after)).toEqual(["grew"]);
+	});
+
+	it("ignores prompts created by the same save", () => {
+		expect(promptsGainingPremium(before, [{ id: "fresh", premiumModels: ["claude"] }])).toEqual([]);
+	});
+});

--- a/apps/web/src/lib/expedite-prompts.ts
+++ b/apps/web/src/lib/expedite-prompts.ts
@@ -1,0 +1,50 @@
+import { db } from "@workspace/lib/db/db";
+import { sql } from "drizzle-orm";
+import { createMultiplePromptJobSchedulers } from "@/lib/job-scheduler";
+
+/**
+ * Bring prompts' next cycle forward after a configuration change — platforms
+ * added to a brand, a premium model added to a prompt — so the change takes
+ * effect now rather than whenever the current cadence happens to come around.
+ *
+ * Dragging the queued row forward is the only thing that works here: the
+ * `prompt-${id}` singleton swallows a fresh send while a future job exists, so
+ * `boss.send` would silently do nothing. Same UPDATE the worker's
+ * schedule-maintenance uses to revive stalled chains.
+ *
+ * Safe to call on any save, and cheap: the cycle it triggers runs only the
+ * targets that are actually due, so platforms that ran recently are skipped
+ * rather than paid for a second time.
+ *
+ * Best-effort by design. A prompt whose cycle is mid-flight has no queued row
+ * to move and holds the singleton against a new one, so its added target waits
+ * for maintenance to expedite the job that cycle queues on its way out.
+ */
+export async function expeditePromptRuns(promptIds: string[]): Promise<void> {
+	if (promptIds.length === 0) return;
+
+	try {
+		const idList = sql.join(
+			promptIds.map((id) => sql`${id}`),
+			sql`, `,
+		);
+		const result = await db.execute(sql`
+			UPDATE pgboss.job
+			SET start_after = now()
+			WHERE name = 'process-prompt'
+			  AND state = 'created'
+			  AND (data->>'promptId') IN (${idList})
+			RETURNING (data->>'promptId') AS prompt_id
+		`);
+
+		const moved = new Set((result.rows as { prompt_id: string }[]).map((row) => row.prompt_id));
+		const unqueued = promptIds.filter((id) => !moved.has(id));
+		if (unqueued.length > 0) {
+			await createMultiplePromptJobSchedulers(unqueued);
+		}
+	} catch (error) {
+		// Never fail the save over this: maintenance reaches the same state on its
+		// own, just an hour later.
+		console.error("Failed to expedite prompt runs:", error);
+	}
+}

--- a/apps/web/src/lib/run-config-changes.ts
+++ b/apps/web/src/lib/run-config-changes.ts
@@ -1,0 +1,35 @@
+/**
+ * Which saves have earned an immediate run.
+ *
+ * A platform or premium model that was just added has no run history, so its
+ * target is due the moment it is saved — waiting out the cadence leaves the
+ * customer looking at a setting that hasn't taken effect. Dropping one, or
+ * saving with nothing changed, earns nothing: the cycle it would trigger is
+ * paid provider calls for answers already on file.
+ */
+
+/**
+ * Platforms `next` adds over `previous`. Null on either side means "every
+ * configured target", which is what a brand with no explicit picks follows.
+ */
+export function addedPlatforms(previous: string[] | null, next: string[] | null, configured: string[]): string[] {
+	const before = new Set(previous ?? configured);
+	return (next ?? configured).filter((model) => !before.has(model));
+}
+
+/**
+ * Prompts that gained a premium model in a save. Prompts created by the same
+ * save are excluded — their chain starts immediately anyway, and expediting a
+ * job that doesn't exist yet would race it.
+ */
+export function promptsGainingPremium(
+	before: Map<string, { premiumModels: string[] }>,
+	after: { id: string; premiumModels: string[] }[],
+): string[] {
+	return after
+		.filter((prompt) => {
+			const previous = before.get(prompt.id);
+			return previous !== undefined && prompt.premiumModels.some((model) => !previous.premiumModels.includes(model));
+		})
+		.map((prompt) => prompt.id);
+}

--- a/apps/web/src/routes/_authed/app/new.tsx
+++ b/apps/web/src/routes/_authed/app/new.tsx
@@ -5,19 +5,27 @@
  * the brand row with the supplied name + website. Gated by the
  * canCreateBrands deployment feature (local, cloud) at both the loader
  * (redirect to /app) and the server function.
+ *
+ * Where the plan meters platforms, a second step asks which ones to track:
+ * this is the flow every cloud brand goes through, so accepting the defaults
+ * silently would mean a brand's first cycle runs on platforms nobody chose.
  */
-import { useState } from "react";
+
 import { createFileRoute, redirect, useNavigate, useRouter } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { Button } from "@workspace/ui/components/button";
 import { Input } from "@workspace/ui/components/input";
 import { Label } from "@workspace/ui/components/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@workspace/ui/components/select";
+import { useState } from "react";
 import FullPageCard from "@/components/full-page-card";
+import { PlatformSelectionStep } from "@/components/platform-selection-step";
 import { listUserOrganizations, requireAuthSession } from "@/lib/auth/helpers";
+import { validateWebsiteUrl } from "@/lib/brand-website";
+import { getDeployment } from "@/lib/config/server";
 import { trackEvent } from "@/lib/posthog";
 import { createBrandInOrgFn } from "@/server/brands";
-import { getDeployment } from "@/lib/config/server";
+import { getOnboardingPlatformStateFn, type OnboardingPlatformState } from "@/server/platform-picks";
 
 const getNewBrandOptions = createServerFn({ method: "GET" }).handler(
 	async (): Promise<{ canCreateBrands: boolean; organizations: { id: string; name: string }[] }> => {
@@ -42,22 +50,28 @@ export const Route = createFileRoute("/_authed/app/new")({
 
 function NewBrandPage() {
 	const { organizations } = Route.useLoaderData();
+	const [step, setStep] = useState<"details" | "platforms">("details");
+	const [details, setDetails] = useState({ brandName: "", website: "" });
+	const [platformState, setPlatformState] = useState<NonNullable<OnboardingPlatformState> | null>(null);
+	const [selected, setSelected] = useState<Set<string>>(new Set());
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState("");
 	const [organizationId, setOrganizationId] = useState(organizations[0]?.id ?? "");
 	const navigate = useNavigate();
 	const router = useRouter();
 
-	const handleSubmit = async (formData: FormData) => {
+	const createBrand = async (brandName: string, website: string, enabledModels: string[] | null) => {
 		setIsLoading(true);
 		setError("");
 
 		try {
-			const brandName = (formData.get("brandName") as string)?.trim() ?? "";
-			const website = (formData.get("website") as string)?.trim() ?? "";
-
 			const { brandId } = await createBrandInOrgFn({
-				data: { brandName, website, organizationId: organizationId || undefined },
+				data: {
+					brandName,
+					website,
+					organizationId: organizationId || undefined,
+					...(enabledModels && enabledModels.length > 0 && { enabledModels }),
+				},
 			});
 			trackEvent("brand_created", { has_website: Boolean(website) });
 
@@ -70,17 +84,81 @@ function NewBrandPage() {
 		}
 	};
 
+	const handleDetailsSubmit = async (formData: FormData) => {
+		const brandName = (formData.get("brandName") as string)?.trim() ?? "";
+		const website = (formData.get("website") as string)?.trim() ?? "";
+		setError("");
+
+		// Checked before the platform step rather than after it, so a typo in the
+		// URL doesn't cost the user their platform picks.
+		const validation = validateWebsiteUrl(website);
+		if (!validation.isValid) {
+			setError(validation.error);
+			return;
+		}
+
+		setIsLoading(true);
+		try {
+			const state = organizationId ? await getOnboardingPlatformStateFn({ data: { organizationId } }) : null;
+			if (!state) {
+				await createBrand(brandName, website, null);
+				return;
+			}
+			setDetails({ brandName, website });
+			setPlatformState(state);
+			setSelected(new Set(state.defaultSelected));
+			setStep("platforms");
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "An error occurred");
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	if (step === "platforms" && platformState) {
+		return (
+			<FullPageCard title={`Create ${details.brandName}`} subtitle="Choose which AI platforms to track">
+				<PlatformSelectionStep
+					state={platformState}
+					selected={selected}
+					onSelectedChange={setSelected}
+					disabled={isLoading}
+					error={error}
+					onBack={() => setStep("details")}
+					onSubmit={() => createBrand(details.brandName, details.website, [...selected])}
+					submitLabel={isLoading ? "Creating..." : "Create brand"}
+				/>
+			</FullPageCard>
+		);
+	}
+
 	return (
 		<FullPageCard title="Create a new brand" subtitle="Set up a brand to start tracking" showBackButton>
-			<form action={handleSubmit} className="space-y-4">
+			<form action={handleDetailsSubmit} className="space-y-4">
 				<div className="space-y-2">
 					<Label htmlFor="brandName">Brand name</Label>
-					<Input id="brandName" name="brandName" type="text" placeholder="Acme" required disabled={isLoading} />
+					<Input
+						id="brandName"
+						name="brandName"
+						type="text"
+						placeholder="Acme"
+						required
+						disabled={isLoading}
+						defaultValue={details.brandName}
+					/>
 				</div>
 
 				<div className="space-y-2">
 					<Label htmlFor="website">Website</Label>
-					<Input id="website" name="website" type="text" placeholder="example.com" required disabled={isLoading} />
+					<Input
+						id="website"
+						name="website"
+						type="text"
+						placeholder="example.com"
+						required
+						disabled={isLoading}
+						defaultValue={details.website}
+					/>
 				</div>
 
 				{/* One workspace is the norm; only ask when the answer isn't already decided. */}
@@ -105,7 +183,7 @@ function NewBrandPage() {
 				{error && <p className="text-sm text-destructive">{error}</p>}
 
 				<Button type="submit" className="w-full" disabled={isLoading}>
-					{isLoading ? "Creating..." : "Create brand"}
+					{isLoading ? "Creating..." : "Continue"}
 				</Button>
 			</form>
 		</FullPageCard>

--- a/apps/web/src/server/brands.ts
+++ b/apps/web/src/server/brands.ts
@@ -302,6 +302,8 @@ export const createBrandInOrgFn = createServerFn({ method: "POST" })
 			brandName: z.string().min(1).max(100),
 			website: z.string().min(1),
 			organizationId: z.string().optional(),
+			/** Platform picks from the creation wizard; omitted → plan defaults. */
+			enabledModels: z.array(z.string().min(1)).max(50).optional(),
 		}),
 	)
 	.handler(async ({ data }) => {
@@ -340,7 +342,7 @@ export const createBrandInOrgFn = createServerFn({ method: "POST" })
 
 		const brandId = await findUniqueBrandId(slugify(trimmedName));
 		const defaultDomains = getDefaultBrandDomains();
-		const enabledModels = await initialEnabledModels(orgId);
+		const enabledModels = await resolveCreateEnabledModels(orgId, data.enabledModels);
 
 		await db.insert(brands).values({
 			id: brandId,

--- a/apps/web/src/server/platform-picks.ts
+++ b/apps/web/src/server/platform-picks.ts
@@ -23,6 +23,8 @@ import { and, count, eq } from "drizzle-orm";
 import { z } from "zod";
 import { requireAuthSession, requireBrandAccess, requireOrgAccess } from "@/lib/auth/helpers";
 import { getDeployment } from "@/lib/config/server";
+import { expeditePromptRuns } from "@/lib/expedite-prompts";
+import { addedPlatforms } from "@/lib/run-config-changes";
 
 export type PlatformOption = {
 	model: string;
@@ -288,5 +290,21 @@ export const updateEnabledModelsFn = createServerFn({ method: "POST" })
 			.where(eq(brands.id, data.brandId))
 			.returning({ id: brands.id, enabledModels: brands.enabledModels });
 		if (!updated) throw new Error("Brand not found");
+
+		// A newly picked platform is due immediately, but the prompts' next jobs
+		// are a whole cadence away — which is how long a new pick used to sit dark.
+		const added = addedPlatforms(
+			brand.enabledModels,
+			models,
+			configs.map((config) => config.model),
+		);
+		if (added.length > 0) {
+			const enabled = await db
+				.select({ id: prompts.id })
+				.from(prompts)
+				.where(and(eq(prompts.brandId, data.brandId), eq(prompts.enabled, true)));
+			await expeditePromptRuns(enabled.map((prompt) => prompt.id));
+		}
+
 		return updated;
 	});

--- a/apps/web/src/server/prompts.ts
+++ b/apps/web/src/server/prompts.ts
@@ -17,6 +17,7 @@ import { generateDateRange } from "@/lib/chart-utils";
 import { rollUpCitationDomains, rollUpCitationUrls, tallyCitations } from "@/lib/citation-rollup";
 import { extractDomain } from "@/lib/domain-categories";
 import { classifyUrl } from "@/lib/domain-categories.server";
+import { expeditePromptRuns } from "@/lib/expedite-prompts";
 import { buildGoogleModule } from "@/lib/google-module";
 import { createMultiplePromptJobSchedulers } from "@/lib/job-scheduler";
 import {
@@ -29,6 +30,7 @@ import {
 	getPromptWebQueriesForMapping,
 	getPromptWebQueryCounts,
 } from "@/lib/postgres-read";
+import { promptsGainingPremium } from "@/lib/run-config-changes";
 // Server Functions
 // ============================================================================
 
@@ -583,6 +585,11 @@ export const updatePromptsFn = createServerFn({ method: "POST" })
 				console.error("Failed to create job schedulers for new prompts:", err),
 			);
 		}
+
+		// A grounded target added to a prompt that already runs has no history of
+		// its own, so it is due immediately — but the prompt's next job is a whole
+		// cadence away, and the customer has just paid for the slot.
+		await expeditePromptRuns(promptsGainingPremium(existingById, saved));
 
 		return saved;
 	});


### PR DESCRIPTION
Two problems a new cloud account runs into, both reported from a real signup.

## The platform picker never rendered in cloud

`/app` computes `unprovisionedOrgs: canCreateBrands ? [] : …`, and cloud sets `canCreateBrands: true` — so nothing ever links to the `/app/$orgId` wizard where the picker lived. Every cloud brand, first or fifth, was created through `/app/new`, which silently applied `initialEnabledModels` (the first N of the plan menu). The brand's first cycle then ran on platforms nobody chose, and correcting them afterwards means the wrong ones have already been paid for.

The step moves to `/app/new`, which is the flow cloud actually routes to. Its markup is extracted into `PlatformSelectionStep` so the legacy wizard (still reachable by URL) and the new one can't drift apart. `createBrandInOrgFn` takes `enabledModels` and validates it through the same `resolveCreateEnabledModels` path as the legacy route, so plan enforcement is unchanged. Deployments without metered platforms get `null` from `getOnboardingPlatformStateFn` and keep the single-step form.

## Config changes waited out the cadence

Enabling a premium model on a prompt, or adding a platform to a brand, wrote the row and stopped there. `updatePromptsFn` only queued jobs for *newly created* prompts; `updateEnabledModelsFn` queued nothing at all. The added target has no run history, so it is due immediately — but the prompt's queued job sits a full cadence out, and `schedule-maintenance` only drags it forward once the prompt's last run is an hour old. A change made just after a cycle (exactly what a new account does while its first runs are landing) sat dark for that hour.

`expeditePromptRuns` moves the queued row's `start_after` to now, the same `UPDATE` maintenance uses. It has to be the update rather than a fresh `boss.send`: the `prompt-${id}` singleton swallows a send while a future job exists, which is why the immediate path in `createPromptJobScheduler` works for new prompts and would have silently no-opped here.

This does not double-run anything. `selectDueTargets` filters the cycle to targets that are actually due, so the platforms that just ran are skipped and only the new target costs a call; a cycle with nothing due reschedules without spending. Removing a platform triggers nothing, and the rules deciding that (`addedPlatforms`, `promptsGainingPremium`) are pure and unit-tested.

Worth noting what this deliberately does *not* do: relax maintenance's expedite floor for never-run targets. Failed runs write no `prompt_runs` row and `consecutiveFailures` only increments when the whole cycle fails, so one persistently-broken target among healthy ones would look never-run forever and re-expedite every five minutes — the v0.2.15 storm shape. A user-initiated, one-shot expedite has no such loop.

## Testing

`check-types` clean; new unit tests pass. The expedite path itself needs a live queue and was not exercised end to end.