### PR TITLE
tell a workspace it is out of brands before it fills in the form

### DIFF
--- a/apps/web/src/routes/_authed/app/new.tsx
+++ b/apps/web/src/routes/_authed/app/new.tsx
@@ -9,14 +9,22 @@
  * Where the plan meters platforms, a second step asks which ones to track:
  * this is the flow every cloud brand goes through, so accepting the defaults
  * silently would mean a brand's first cycle runs on platforms nobody chose.
+ *
+ * A workspace that has spent its plan's brands is told so here, before anything
+ * is filled in — the write guard would otherwise reject the finished form, and
+ * a limit is not something to discover at the end of a wizard.
  */
 
-import { createFileRoute, redirect, useNavigate, useRouter } from "@tanstack/react-router";
+import { createFileRoute, Link, redirect, useNavigate, useRouter } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
+import { db } from "@workspace/lib/db/db";
+import { brands } from "@workspace/lib/db/schema";
+import { checkBrandCreate, type EntitlementDenialCode } from "@workspace/lib/entitlements";
 import { Button } from "@workspace/ui/components/button";
 import { Input } from "@workspace/ui/components/input";
 import { Label } from "@workspace/ui/components/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@workspace/ui/components/select";
+import { inArray } from "drizzle-orm";
 import { useState } from "react";
 import FullPageCard from "@/components/full-page-card";
 import { PlatformSelectionStep } from "@/components/platform-selection-step";
@@ -27,18 +35,56 @@ import { trackEvent } from "@/lib/posthog";
 import { createBrandInOrgFn } from "@/server/brands";
 import { getOnboardingPlatformStateFn, type OnboardingPlatformState } from "@/server/platform-picks";
 
+type NewBrandOrganization = {
+	id: string;
+	name: string;
+	/** Why this workspace can't take another brand; null when it can. */
+	blocked: { code: EntitlementDenialCode; message: string } | null;
+	/** A brand to hang the (brand-scoped) billing link on; null when the org has none. */
+	billingBrandId: string | null;
+};
+
+/** The oldest brand of each org, which is as good a billing entry point as any. */
+async function billingBrandByOrg(orgIds: string[]): Promise<Map<string, string>> {
+	if (orgIds.length === 0) return new Map();
+	const rows = await db
+		.select({ id: brands.id, organizationId: brands.organizationId })
+		.from(brands)
+		.where(inArray(brands.organizationId, orgIds))
+		.orderBy(brands.createdAt);
+	const byOrg = new Map<string, string>();
+	for (const row of rows) if (!byOrg.has(row.organizationId)) byOrg.set(row.organizationId, row.id);
+	return byOrg;
+}
+
 const getNewBrandOptions = createServerFn({ method: "GET" }).handler(
-	async (): Promise<{ canCreateBrands: boolean; organizations: { id: string; name: string }[] }> => {
+	async (): Promise<{ canCreateBrands: boolean; organizations: NewBrandOrganization[] }> => {
 		if (!getDeployment().features.canCreateBrands) {
 			return { canCreateBrands: false, organizations: [] };
 		}
 		const session = await requireAuthSession();
-		return { canCreateBrands: true, organizations: await listUserOrganizations(session.user.id) };
+		const orgs = await listUserOrganizations(session.user.id);
+		const decisions = await checkBrandCreate(orgs.map((org) => org.id));
+		const blocked = orgs.filter((org) => decisions.get(org.id)?.allowed === false);
+		const billingBrands = await billingBrandByOrg(blocked.map((org) => org.id));
+
+		return {
+			canCreateBrands: true,
+			organizations: orgs.map((org) => {
+				const decision = decisions.get(org.id);
+				return {
+					id: org.id,
+					name: org.name,
+					blocked: decision && !decision.allowed ? { code: decision.code, message: decision.message } : null,
+					billingBrandId: billingBrands.get(org.id) ?? null,
+				};
+			}),
+		};
 	},
 );
 
 export const Route = createFileRoute("/_authed/app/new")({
-	loader: async (): Promise<{ organizations: { id: string; name: string }[] }> => {
+	loader: async (): Promise<{ organizations: NewBrandOrganization[] }> => {
 		const { canCreateBrands, organizations } = await getNewBrandOptions();
 		if (!canCreateBrands) {
 			throw redirect({ to: "/app" });
@@ -48,6 +94,35 @@ export const Route = createFileRoute("/_authed/app/new")({
 	component: NewBrandPage,
 });
 
+interface WorkspaceSelectProps {
+	organizations: NewBrandOrganization[];
+	value: string;
+	onChange: (organizationId: string) => void;
+	disabled?: boolean;
+}
+
+/** One workspace is the norm; only ask when the answer isn't already decided. */
+function WorkspaceSelect({ organizations, value, onChange, disabled }: WorkspaceSelectProps) {
+	if (organizations.length <= 1) return null;
+	return (
+		<div className="space-y-2">
+			<Label htmlFor="organization">Workspace</Label>
+			<Select value={value} onValueChange={onChange} disabled={disabled}>
+				<SelectTrigger id="organization" className="w-full">
+					<SelectValue />
+				</SelectTrigger>
+				<SelectContent>
+					{organizations.map((org) => (
+						<SelectItem key={org.id} value={org.id}>
+							{org.name}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+		</div>
+	);
+}
+
 function NewBrandPage() {
 	const { organizations } = Route.useLoaderData();
 	const [step, setStep] = useState<"details" | "platforms">("details");
@@ -56,9 +131,14 @@ function NewBrandPage() {
 	const [selected, setSelected] = useState<Set<string>>(new Set());
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState("");
-	const [organizationId, setOrganizationId] = useState(organizations[0]?.id ?? "");
+	// Start on a workspace that can actually take a brand, so a user who belongs
+	// to a full one and an empty one isn't shown a wall they can walk around.
+	const [organizationId, setOrganizationId] = useState(
+		(organizations.find((org) => !org.blocked) ?? organizations[0])?.id ?? "",
+	);
 	const navigate = useNavigate();
 	const router = useRouter();
+	const activeOrg = organizations.find((org) => org.id === organizationId);
 
 	const createBrand = async (brandName: string, website: string, enabledModels: string[] | null) => {
 		setIsLoading(true);
@@ -115,6 +195,32 @@ function NewBrandPage() {
 		}
 	};
 
+	if (activeOrg?.blocked) {
+		const { code, message } = activeOrg.blocked;
+		return (
+			<FullPageCard
+				title={code === "no-active-plan" ? "This workspace has no plan" : "You've used every brand on your plan"}
+				subtitle={message}
+				showBackButton
+			>
+				<div className="space-y-4">
+					<WorkspaceSelect organizations={organizations} value={organizationId} onChange={setOrganizationId} />
+					<Button asChild className="w-full">
+						{activeOrg.billingBrandId ? (
+							<Link to="/app/$brand/settings/billing" params={{ brand: activeOrg.billingBrandId }}>
+								Go to billing
+							</Link>
+						) : (
+							<Link to="/choose-plan" search={{ org: activeOrg.id }}>
+								Choose a plan
+							</Link>
+						)}
+					</Button>
+				</div>
+			</FullPageCard>
+		);
+	}
+
 	if (step === "platforms" && platformState) {
 		return (
 			<FullPageCard title={`Create ${details.brandName}`} subtitle="Choose which AI platforms to track">
@@ -161,24 +267,12 @@ function NewBrandPage() {
 					/>
 				</div>
 
-				{/* One workspace is the norm; only ask when the answer isn't already decided. */}
-				{organizations.length > 1 && (
-					<div className="space-y-2">
-						<Label htmlFor="organization">Workspace</Label>
-						<Select value={organizationId} onValueChange={setOrganizationId} disabled={isLoading}>
-							<SelectTrigger id="organization" className="w-full">
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								{organizations.map((org) => (
-									<SelectItem key={org.id} value={org.id}>
-										{org.name}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</div>
-				)}
+				<WorkspaceSelect
+					organizations={organizations}
+					value={organizationId}
+					onChange={setOrganizationId}
+					disabled={isLoading}
+				/>
 
 				{error && <p className="text-sm text-destructive">{error}</p>}
 

--- a/packages/lib/src/entitlements/guards.ts
+++ b/packages/lib/src/entitlements/guards.ts
@@ -15,10 +15,10 @@
 
 import type { Entitlements } from "@workspace/config/entitlements";
 import { MAX_SELF_SERVE_BRANDS, premiumPairings } from "@workspace/config/plans";
-import { and, count, eq, sql } from "drizzle-orm";
+import { and, count, eq, inArray, sql } from "drizzle-orm";
 import { db } from "../db/db";
 import { brands, prompts } from "../db/schema";
-import { getOrgEntitlements } from "./service";
+import { getOrgEntitlements, getOrgEntitlementsMap } from "./service";
 
 export type EntitlementDenialCode =
 	| "no-active-plan"
@@ -188,9 +188,18 @@ export function assertAllowed(decision: EntitlementDecision): void {
 // Usage counts (cloud-only paths; every assert below skips them when unlimited)
 // ---------------------------------------------------------------------------
 
+export async function countBrandsByOrg(orgIds: string[]): Promise<Map<string, number>> {
+	if (orgIds.length === 0) return new Map();
+	const rows = await db
+		.select({ organizationId: brands.organizationId, value: count() })
+		.from(brands)
+		.where(inArray(brands.organizationId, orgIds))
+		.groupBy(brands.organizationId);
+	return new Map(rows.map((row) => [row.organizationId, row.value]));
+}
+
 export async function countOrgBrands(organizationId: string): Promise<number> {
-	const [row] = await db.select({ value: count() }).from(brands).where(eq(brands.organizationId, organizationId));
-	return row?.value ?? 0;
+	return (await countBrandsByOrg([organizationId])).get(organizationId) ?? 0;
 }
 
 export async function countOrgEnabledPrompts(organizationId: string): Promise<number> {
@@ -238,6 +247,25 @@ export async function assertCanCreateBrand(organizationId: string): Promise<void
 	await withEntitlements(organizationId, async (entitlements) => [
 		decideBrandCreate(entitlements, await countOrgBrands(organizationId)),
 	]);
+}
+
+/**
+ * The same verdict assertCanCreateBrand raises, returned instead of thrown, for
+ * any number of orgs at once. UI that offers brand creation asks this first so a
+ * customer meets the limit before filling in a form, rather than as an error on
+ * the last step of one.
+ */
+export async function checkBrandCreate(orgIds: string[]): Promise<Map<string, EntitlementDecision>> {
+	const entitlementsByOrg = await getOrgEntitlementsMap(orgIds);
+	const limited = orgIds.filter((orgId) => !entitlementsByOrg.get(orgId)?.unlimited);
+	const counts = await countBrandsByOrg(limited);
+	const decisions = new Map<string, EntitlementDecision>();
+	for (const orgId of orgIds) {
+		const entitlements = entitlementsByOrg.get(orgId);
+		// getOrgEntitlementsMap answers for every requested id; the fallback narrows.
+		decisions.set(orgId, entitlements ? decideBrandCreate(entitlements, counts.get(orgId) ?? 0) : ALLOWED);
+	}
+	return decisions;
 }
 
 /** Guard creating `adding` new enabled prompts (or re-enabling that many). */

--- a/packages/lib/src/entitlements/index.ts
+++ b/packages/lib/src/entitlements/index.ts
@@ -7,6 +7,8 @@ export {
 	assertCanCreateBrand,
 	assertEnabledModelsAllowed,
 	assertPromptSaveAllowed,
+	checkBrandCreate,
+	countBrandsByOrg,
 	countOrgAssignedPremiumSlots,
 	countOrgBrands,
 	countOrgEnabledPrompts,


### PR DESCRIPTION
## Problem

The plan's brand limit was only enforced in `createBrandInOrgFn` (`assertCanCreateBrand`), which runs after the brand name, website, workspace and platform picks have all been entered. Since #555 routes creation through the platform step, that denial rendered in `PlatformSelectionStep`'s error slot — directly under the picker — so `Your plan includes 2 brands. Upgrade to add more.` looked like a rejected platform selection, and picking more platforms did nothing to clear it.

Nothing before the write consulted entitlements: `/app/new`'s loader checked only the `canCreateBrands` deployment feature, and the switcher's `+ Create new brand` link is unconditional.

## Change

- `checkBrandCreate(orgIds)` in `packages/lib/src/entitlements/guards.ts` — the verdict `assertCanCreateBrand` raises, returned instead of thrown, for any number of orgs at once. It short-circuits on unlimited entitlements, so non-cloud deployments still issue no queries.
- `countBrandsByOrg(orgIds)` groups the count in one query; `countOrgBrands` delegates to it.
- `/app/new`'s loader resolves per workspace whether it can take another brand, and a brand id to route the (brand-scoped) billing page through. A blocked workspace gets a card — the guard's own message as the subtitle, **Go to billing**, and the usual back link — instead of the form. Orgs with no brand at all fall back to **Choose a plan**.
- The workspace select moved into a shared `WorkspaceSelect` used by both the form and the card, so a user in several workspaces can switch to one that has room; the initial selection is now the first workspace that can create a brand rather than whichever is oldest.

The switcher link stays visible — clicking it now explains why creation is unavailable, which hiding it would not.

## Notes

- The write guard is unchanged and still authoritative; its error can still surface under the picker if the limit is reached in another tab mid-wizard. That is now a race rather than the normal path.
- No changeset: like the picker in #555, this only exists in cloud mode.