### PR TITLE
Red tests for the prompt-job dedup collision

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -257,8 +257,26 @@ jobs:
           npx tsx e2e/scheduling/verify-scheduling.ts cloud
           kill "$(cat /tmp/worker.pid)" || true
 
+      - name: "Cloud mode: queue addressing + expedite on config change"
+        env:
+          DEPLOYMENT_MODE: cloud
+          SCRAPE_TARGETS: chatgpt:stub,perplexity:stub,gemini:stub,copilot:stub,claude:stub,claude:stub:online
+          STRIPE_SECRET_KEY: sk_test_ci
+          STRIPE_WEBHOOK_SECRET: whsec_ci
+          RESEND_API_KEY: re_ci
+          RESEND_FROM_EMAIL: Elmo <ci@example.com>
+          GOOGLE_CLIENT_ID: ci
+          GOOGLE_CLIENT_SECRET: ci
+        run: |
+          nohup pnpm -C apps/worker exec tsx src/index.ts > /tmp/worker-expedite.log 2>&1 &
+          echo $! > /tmp/worker.pid
+          sleep 15
+          npx tsx e2e/scheduling/verify-scheduling.ts expedite
+          kill "$(cat /tmp/worker.pid)" || true
+
       - name: Dump worker logs
         if: failure()
         run: |
           echo "=== local worker ==="; cat /tmp/worker-local.log 2>/dev/null || true
           echo "=== cloud worker ==="; cat /tmp/worker-cloud.log 2>/dev/null || true
+          echo "=== expedite worker ==="; cat /tmp/worker-expedite.log 2>/dev/null || true

--- a/apps/web/src/lib/expedite-prompts.ts
+++ b/apps/web/src/lib/expedite-prompts.ts
@@ -1,50 +1,17 @@
-import { db } from "@workspace/lib/db/db";
-import { sql } from "drizzle-orm";
-import { createMultiplePromptJobSchedulers } from "@/lib/job-scheduler";
+import { expeditePromptRuns as expedite } from "@workspace/lib/prompt-jobs";
+import { getBoss } from "@/lib/boss-client";
 
 /**
- * Bring prompts' next cycle forward after a configuration change — platforms
- * added to a brand, a premium model added to a prompt — so the change takes
- * effect now rather than whenever the current cadence happens to come around.
- *
- * Dragging the queued row forward is the only thing that works here: the
- * `prompt-${id}` singleton swallows a fresh send while a future job exists, so
- * `boss.send` would silently do nothing. Same UPDATE the worker's
- * schedule-maintenance uses to revive stalled chains.
- *
- * Safe to call on any save, and cheap: the cycle it triggers runs only the
- * targets that are actually due, so platforms that ran recently are skipped
- * rather than paid for a second time.
- *
- * Best-effort by design. A prompt whose cycle is mid-flight has no queued row
- * to move and holds the singleton against a new one, so its added target waits
- * for maintenance to expedite the job that cycle queues on its way out.
+ * Expedite wrapper for the save paths: best-effort by design, because a
+ * configuration save must not fail over scheduling. Maintenance reaches the
+ * same state on its own, just later.
  */
 export async function expeditePromptRuns(promptIds: string[]): Promise<void> {
 	if (promptIds.length === 0) return;
 
 	try {
-		const idList = sql.join(
-			promptIds.map((id) => sql`${id}`),
-			sql`, `,
-		);
-		const result = await db.execute(sql`
-			UPDATE pgboss.job
-			SET start_after = now()
-			WHERE name = 'process-prompt'
-			  AND state = 'created'
-			  AND (data->>'promptId') IN (${idList})
-			RETURNING (data->>'promptId') AS prompt_id
-		`);
-
-		const moved = new Set((result.rows as { prompt_id: string }[]).map((row) => row.prompt_id));
-		const unqueued = promptIds.filter((id) => !moved.has(id));
-		if (unqueued.length > 0) {
-			await createMultiplePromptJobSchedulers(unqueued);
-		}
+		await expedite(await getBoss(), promptIds);
 	} catch (error) {
-		// Never fail the save over this: maintenance reaches the same state on its
-		// own, just an hour later.
 		console.error("Failed to expedite prompt runs:", error);
 	}
 }

--- a/apps/web/src/lib/job-scheduler.ts
+++ b/apps/web/src/lib/job-scheduler.ts
@@ -1,7 +1,8 @@
-import { db } from "@workspace/lib/db/db";
-import { prompts, brands } from "@workspace/lib/db/schema";
-import { eq } from "drizzle-orm";
 import { getDefaultDelayHours } from "@workspace/lib/constants";
+import { db } from "@workspace/lib/db/db";
+import { brands, prompts } from "@workspace/lib/db/schema";
+import { PROMPT_QUEUE, promptJobSendOptions } from "@workspace/lib/prompt-jobs";
+import { eq } from "drizzle-orm";
 import { getBoss } from "@/lib/boss-client";
 
 /**
@@ -72,37 +73,17 @@ export async function createPromptJobScheduler(promptId: string, options: Schedu
 			// Ignore errors - schedule may not exist
 		}
 
-		if (sendImmediate) {
-			// Send an immediate job
-			await boss.send(
-				"process-prompt",
-				{ promptId, cadenceHours },
-				{
-					singletonKey: `prompt-${promptId}`,
-					singletonSeconds: 60 * 60, // 1 hour - prevent duplicate jobs
-					retryLimit: 3,
-					retryDelay: 60,
-					retryBackoff: true,
-					expireInSeconds: 60 * 15, // 15 minute timeout
-				},
-			);
-		} else {
-			// Schedule the next run based on cadence
-			const startAfterSeconds = cadenceHours * 60 * 60;
-			await boss.send(
-				"process-prompt",
-				{ promptId, cadenceHours },
-				{
-					singletonKey: `prompt-${promptId}`,
-					singletonSeconds: startAfterSeconds, // Prevent duplicates for the cadence period
-					startAfter: startAfterSeconds,
-					retryLimit: 3,
-					retryDelay: 60,
-					retryBackoff: true,
-					expireInSeconds: 60 * 15,
-				},
-			);
-		}
+		await boss.send(
+			PROMPT_QUEUE,
+			{ promptId, cadenceHours },
+			{
+				...promptJobSendOptions(promptId, sendImmediate ? undefined : cadenceHours * 60 * 60),
+				retryLimit: 3,
+				retryDelay: 60,
+				retryBackoff: true,
+				expireInSeconds: 60 * 15, // 15 minute timeout
+			},
+		);
 
 		console.log(`Created job for prompt ${promptId} with ${cadenceHours}h cadence`);
 		return true;
@@ -214,12 +195,10 @@ export async function scheduleNextPromptRun(promptId: string, cadenceHours: numb
 		const startAfterSeconds = cadenceHours * 60 * 60;
 
 		await boss.send(
-			"process-prompt",
+			PROMPT_QUEUE,
 			{ promptId, cadenceHours },
 			{
-				singletonKey: `prompt-${promptId}`,
-				singletonSeconds: startAfterSeconds, // Prevent duplicates for the cadence period
-				startAfter: startAfterSeconds,
+				...promptJobSendOptions(promptId, startAfterSeconds),
 				retryLimit: 3,
 				retryDelay: 60,
 				retryBackoff: true,

--- a/apps/worker/src/jobs/process-prompt.ts
+++ b/apps/worker/src/jobs/process-prompt.ts
@@ -13,6 +13,7 @@ import {
 	usageEvents,
 } from "@workspace/lib/db/schema";
 import { type Entitlements, getOrgEntitlements } from "@workspace/lib/entitlements";
+import { PROMPT_QUEUE, promptJobSendOptions } from "@workspace/lib/prompt-jobs";
 import { getProvider, type ModelConfig, type Provider, parseScrapeTargets } from "@workspace/lib/providers";
 import { failureBackoffHours } from "@workspace/lib/run-backoff";
 import {
@@ -79,12 +80,10 @@ async function scheduleNextRun(promptId: string, cadenceHours: number, consecuti
 
 	try {
 		await boss.send(
-			"process-prompt",
+			PROMPT_QUEUE,
 			{ promptId, consecutiveFailures },
 			{
-				singletonKey: `prompt-${promptId}`,
-				singletonSeconds: startAfterSeconds, // Prevent duplicates until the next attempt is due
-				startAfter: startAfterSeconds,
+				...promptJobSendOptions(promptId, startAfterSeconds),
 				...PROMPT_JOB_OPTIONS,
 			},
 		);

--- a/apps/worker/src/jobs/schedule-maintenance.ts
+++ b/apps/worker/src/jobs/schedule-maintenance.ts
@@ -4,6 +4,7 @@ import { getDefaultDelayHours } from "@workspace/lib/constants";
 import { db } from "@workspace/lib/db/db";
 import { brands, promptRuns, prompts } from "@workspace/lib/db/schema";
 import { getOrgEntitlementsMap } from "@workspace/lib/entitlements";
+import { PROMPT_QUEUE, promptJobSendOptions } from "@workspace/lib/prompt-jobs";
 import { parseScrapeTargets } from "@workspace/lib/providers";
 import {
 	computeMaintenanceDecisions,
@@ -216,15 +217,7 @@ async function runMaintenanceCheck(): Promise<void> {
 			const batch = decisions.toSchedule.slice(i, i + BATCH_SIZE);
 			const results = await Promise.allSettled(
 				batch.map(({ promptId }) =>
-					boss.send(
-						"process-prompt",
-						{ promptId },
-						{
-							singletonKey: `prompt-${promptId}`,
-							singletonSeconds: 60 * 60, // 1 hour - prevent duplicates
-							...PROMPT_JOB_OPTIONS,
-						},
-					),
+					boss.send(PROMPT_QUEUE, { promptId }, { ...promptJobSendOptions(promptId), ...PROMPT_JOB_OPTIONS }),
 				),
 			);
 

--- a/e2e/scheduling/verify-scheduling.ts
+++ b/e2e/scheduling/verify-scheduling.ts
@@ -17,13 +17,25 @@
  *     - canceling the subscription stops due targets from running
  *     - resubscribing revives tracking via schedule-maintenance
  *
- * Scenario is argv[2]: local | cloud. DATABASE_URL env overrides the default
- * local connection string. The worker must already be running in the matching
- * mode — see the workflow for the exact env.
+ *   expedite scenario (DEPLOYMENT_MODE=cloud, same targets as cloud):
+ *     - a finished job does not block the next send for the same prompt
+ *     - adding a premium model to a prompt runs that model now, and re-runs
+ *       nothing that is still fresh
+ *
+ * Scenario is argv[2]: local | cloud | expedite. DATABASE_URL env overrides the
+ * default local connection string. The worker must already be running in the
+ * matching mode — see the workflow for the exact env.
  */
+import { randomUUID } from "node:crypto";
 import pg from "pg";
 import { PgBoss } from "pg-boss";
 import { getRunsPerPrompt } from "@workspace/lib/constants";
+import {
+  expeditePromptRuns,
+  IMMEDIATE_SINGLETON_SECONDS,
+  PROMPT_QUEUE,
+  promptJobSendOptions,
+} from "@workspace/lib/prompt-jobs";
 
 const RUNS_PER_PROMPT = getRunsPerPrompt();
 import { DATABASE_URL as FIXTURES_DATABASE_URL } from "../fixtures.js";
@@ -37,8 +49,52 @@ const boss = new PgBoss(DATABASE_URL);
 boss.on("error", () => {});
 await boss.start();
 
+/**
+ * Fire a prompt's cycle directly, bypassing queue dedup. The local and cloud
+ * scenarios use this to assert what the run policy does once a job reaches the
+ * worker, which is independent of how the job got queued.
+ */
 async function sendJob(promptId: string) {
-  await boss.send("process-prompt", { promptId }, { retryLimit: 0, expireInSeconds: 900 });
+  await boss.send(PROMPT_QUEUE, { promptId }, { retryLimit: 0, expireInSeconds: 900 });
+}
+
+/**
+ * Queue a prompt the way production does. The addressing matters as much as the
+ * payload: a send that collides with an existing job is dropped rather than
+ * rejected, so a caller that invents its own options can never observe that.
+ */
+async function sendPromptJob(promptId: string): Promise<string | null> {
+  return boss.send(PROMPT_QUEUE, { promptId }, { ...promptJobSendOptions(promptId), retryLimit: 0 });
+}
+
+/**
+ * Sends are deduplicated per fixed-width time slot, so a pair of sends only
+ * proves anything about each other when they share one. Step over a boundary
+ * rather than race it. The headroom covers the slowest gap either pair below
+ * can open: one worker cycle plus its polling latency.
+ */
+async function awaitSlotHeadroom(): Promise<void> {
+  const slotMs = IMMEDIATE_SINGLETON_SECONDS * 1000;
+  const remaining = slotMs - (Date.now() % slotMs);
+  if (remaining < 180_000) await new Promise((r) => setTimeout(r, remaining + 1000));
+}
+
+async function jobCount(promptId: string, state: string): Promise<number> {
+  const { rows } = await client.query(
+    "SELECT COUNT(*)::int AS n FROM pgboss.job WHERE name = $1 AND state = $2 AND data->>'promptId' = $3",
+    [PROMPT_QUEUE, state, promptId],
+  );
+  return rows[0].n;
+}
+
+async function runShape(promptId: string): Promise<string> {
+  const { rows } = await client.query(
+    "SELECT model, web_search_enabled, COUNT(*)::int AS n FROM prompt_runs WHERE prompt_id = $1 GROUP BY 1,2 ORDER BY 1,2",
+    [promptId],
+  );
+  return rows
+    .map((r: { model: string; web_search_enabled: boolean; n: number }) => `${r.model}:${r.web_search_enabled ? "web" : "base"}=${r.n}`)
+    .join(",");
 }
 
 async function runCount(promptId: string): Promise<number> {
@@ -116,10 +172,7 @@ if (scenario === "local") {
   await sendJob(prompt.id);
   await waitFor(async () => (await runCount(prompt.id)) > 0, 120000, "cloud runs");
   await new Promise((r) => setTimeout(r, 5000));
-  const { rows: runs } = await client.query(
-    "SELECT model, web_search_enabled, COUNT(*)::int AS n FROM prompt_runs WHERE prompt_id = $1 GROUP BY 1,2 ORDER BY 1,2",
-    [prompt.id]);
-  const shape = runs.map((r: { model: string; web_search_enabled: boolean; n: number }) => `${r.model}:${r.web_search_enabled ? "web" : "base"}=${r.n}`).join(",");
+  const shape = await runShape(prompt.id);
   assert(
     shape === "chatgpt:base=1,claude:web=1,perplexity:base=1",
     `cloud volume: picked platforms + one premium slot, replication 1 (got ${shape})`,
@@ -147,8 +200,76 @@ if (scenario === "local") {
   await waitFor(async () => (await runCount(prompt.id)) > 3, 120000, "revival runs");
   const revived = await runCount(prompt.id);
   assert(revived === 6, `resubscribe: maintenance revives the chain and due targets run (got ${revived})`);
+} else if (scenario === "expedite") {
+  // --- A finished job must not block the next send for the same prompt ------
+  //
+  // No prompt row behind this id, so the worker completes the job as a no-op.
+  // That is all this needs: a finished job sitting on the queue.
+  await awaitSlotHeadroom();
+  const ghostId = randomUUID();
+  const firstSend = await sendPromptJob(ghostId);
+  assert(firstSend !== null, "queue accepts a send for a prompt with nothing queued");
+  await waitFor(async () => (await jobCount(ghostId, "completed")) === 1, 60000, "the first job to finish");
+
+  const secondSend = await sendPromptJob(ghostId);
+  assert(secondSend !== null, "a finished job does not block the next send for the same prompt");
+  await client.query("DELETE FROM pgboss.job WHERE name = $1 AND data->>'promptId' = $2", [PROMPT_QUEUE, ghostId]);
+
+  // --- Adding a premium model runs that model, and only that model ----------
+  await client.query("DELETE FROM usage_events WHERE brand_id = 'expeditebrand-1'");
+  await client.query("DELETE FROM prompt_runs WHERE brand_id = 'expeditebrand-1'");
+  await client.query("DELETE FROM prompts WHERE brand_id = 'expeditebrand-1'");
+  await client.query("DELETE FROM brands WHERE id = 'expeditebrand-1'");
+  await client.query("DELETE FROM subscription WHERE reference_id = 'expediteorg-1'");
+  await client.query("DELETE FROM organization_settings WHERE organization_id = 'expediteorg-1'");
+  await client.query("DELETE FROM organization WHERE id = 'expediteorg-1'");
+
+  await client.query(
+    "INSERT INTO organization (id, name, slug, created_at) VALUES ('expediteorg-1', 'Expedite Verify', 'expedite-verify', NOW())");
+  // Starts canceled so the first cycle is a deliberate no-op — see below.
+  await client.query(
+    `INSERT INTO subscription (id, plan, reference_id, status, period_start, period_end)
+     VALUES ('sub-expedite-1', 'pro', 'expediteorg-1', 'canceled', NOW() - interval '1 day', NOW() + interval '29 days')`);
+  await client.query(
+    `INSERT INTO brands (id, organization_id, name, website, enabled, onboarded, enabled_models, created_at, updated_at)
+     VALUES ('expeditebrand-1', 'expediteorg-1', 'Expedite Verify Brand', 'https://expedite.example', true, true, '{chatgpt}', NOW(), NOW())`);
+  const { rows: [prompt] } = await client.query(
+    "INSERT INTO prompts (brand_id, value, enabled, premium_models) VALUES ('expeditebrand-1', 'scheduling e2e — expedite', true, '{}') RETURNING id");
+
+  // A cycle for an unentitled org queues nothing on its way out, which is how
+  // this reaches the state a configuration change has to recover from: a
+  // finished job on the queue and no chain behind it.
+  await awaitSlotHeadroom();
+  await sendPromptJob(prompt.id);
+  await waitFor(async () => (await jobCount(prompt.id, "completed")) === 1, 60000, "the parked cycle to finish");
+  assert(
+    (await jobCount(prompt.id, "created")) === 0 && (await runCount(prompt.id)) === 0,
+    "an unentitled cycle records no runs and leaves no queued job",
+  );
+
+  // Give the standard target fresh history so only the premium target can come
+  // due — this is what makes "only the new model runs" observable.
+  await client.query(
+    `INSERT INTO prompt_runs
+       (prompt_id, brand_id, model, provider, version, web_search_enabled, raw_output, web_queries, brand_mentioned, competitors_mentioned)
+     VALUES ($1, 'expeditebrand-1', 'chatgpt', 'stub', 'stub', false, '{}', '{}', false, '{}')`,
+    [prompt.id],
+  );
+
+  await client.query("UPDATE subscription SET status = 'active' WHERE id = 'sub-expedite-1'");
+  await client.query("UPDATE prompts SET premium_models = '{claude}' WHERE id = $1", [prompt.id]);
+
+  await expeditePromptRuns(boss, [prompt.id]);
+  await waitFor(async () => (await runCount(prompt.id)) > 1, 120000, "the expedited premium run");
+  await new Promise((r) => setTimeout(r, 5000));
+
+  const shape = await runShape(prompt.id);
+  assert(
+    shape === "chatgpt:base=1,claude:web=1",
+    `adding a premium model runs it now, and re-runs nothing else (got ${shape})`,
+  );
 } else {
-  console.error("scenario must be local or cloud");
+  console.error("scenario must be local, cloud, or expedite");
   process.exit(2);
 }
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -25,6 +25,7 @@
 		"./onboarding": "./src/onboarding/index.ts",
 		"./tag-utils": "./src/tag-utils.ts",
 		"./bulk-prompts": "./src/bulk-prompts.ts",
+		"./prompt-jobs": "./src/prompt-jobs.ts",
 		"./website-excerpt": "./src/website-excerpt.ts",
 		"./report-metrics": "./src/report-metrics.ts",
 		"./secrets": "./src/secrets/index.ts",

--- a/packages/lib/src/prompt-jobs.ts
+++ b/packages/lib/src/prompt-jobs.ts
@@ -1,0 +1,77 @@
+/**
+ * How a prompt's job is addressed on the queue, and how a configuration change
+ * brings its next cycle forward.
+ *
+ * The web app's scheduler, the worker's reschedule, the maintenance sweep, and
+ * the expedite path all send to the same queue under the same singleton key.
+ * They have to agree on that addressing exactly — a mismatch doesn't error, it
+ * silently drops the send — so it is resolved here rather than spelled out at
+ * each call site.
+ */
+
+import { sql } from "drizzle-orm";
+import { db } from "./db/db";
+
+export const PROMPT_QUEUE = "process-prompt";
+
+/** Dedup window for a job meant to run now. */
+export const IMMEDIATE_SINGLETON_SECONDS = 60 * 60;
+
+export interface PromptJobSendOptions {
+	singletonKey: string;
+	singletonSeconds: number;
+	startAfter?: number;
+}
+
+/**
+ * Queue addressing for one prompt's job. Omit `startAfterSeconds` for a job
+ * that should run now; pass it to hold the job back by that long.
+ */
+export function promptJobSendOptions(promptId: string, startAfterSeconds?: number): PromptJobSendOptions {
+	const singletonKey = `prompt-${promptId}`;
+	if (startAfterSeconds === undefined) {
+		return { singletonKey, singletonSeconds: IMMEDIATE_SINGLETON_SECONDS };
+	}
+	return { singletonKey, singletonSeconds: startAfterSeconds, startAfter: startAfterSeconds };
+}
+
+/** The slice of pg-boss this module needs, so lib doesn't take on the dependency. */
+export interface PromptJobSender {
+	send(queue: string, data: { promptId: string }, options: PromptJobSendOptions): Promise<string | null>;
+}
+
+/**
+ * Bring prompts' next cycle forward after a configuration change — platforms
+ * added to a brand, a premium model added to a prompt — so the change takes
+ * effect now rather than whenever the current cadence happens to come around.
+ *
+ * Cheap to call on any save: the cycle it triggers runs only the targets that
+ * are actually due, so platforms that ran recently are skipped rather than
+ * paid for a second time.
+ *
+ * Throws on failure. Callers on a user-facing save path decide whether that
+ * should surface, since maintenance reaches the same state on its own.
+ */
+export async function expeditePromptRuns(sender: PromptJobSender, promptIds: string[]): Promise<void> {
+	if (promptIds.length === 0) return;
+
+	const idList = sql.join(
+		promptIds.map((id) => sql`${id}`),
+		sql`, `,
+	);
+	const result = await db.execute(sql`
+		UPDATE pgboss.job
+		SET start_after = now()
+		WHERE name = ${PROMPT_QUEUE}
+		  AND state = 'created'
+		  AND (data->>'promptId') IN (${idList})
+		RETURNING (data->>'promptId') AS prompt_id
+	`);
+
+	const moved = new Set((result.rows as { prompt_id: string }[]).map((row) => row.prompt_id));
+	const unqueued = promptIds.filter((id) => !moved.has(id));
+
+	await Promise.all(
+		unqueued.map((promptId) => sender.send(PROMPT_QUEUE, { promptId }, promptJobSendOptions(promptId))),
+	);
+}


### PR DESCRIPTION
Two failing CI tests for the scheduler bug behind a prompt that sits on "Evaluating for the first time" and a premium model that never fires. No fix here — the fix is the follow-up, and these are what will show it working.

## The bug

pg-boss v12 dedups on `job_i4`:

```sql
UNIQUE (name, singleton_on, COALESCE(singleton_key,''))
  WHERE state <> 'cancelled' AND singleton_on IS NOT NULL
```

`singleton_on` is `floor(epoch(now()) / singletonSeconds) * singletonSeconds`, the insert is `ON CONFLICT DO NOTHING`, and `boss.send` resolves with `null` instead of throwing. Two consequences we were not accounting for:

- A **completed** job still holds its slot — only `cancelled` is excluded, and rows survive for the queue's `deletion_seconds` (7 days).
- Every caller logs success on a dropped send, which is why this ran silently.

So once a prompt's cycle finishes, every further send for that prompt in the same slot is swallowed: the worker's own reschedule, the maintenance sweep, and `expeditePromptRuns`' fallback. A prompt whose premium model is added right after a cycle completes stays dark until the slot rolls over.

Verified against a throwaway Postgres:

```
policy=standard singletonSeconds=3600 -> first=queued second=DROPPED
policy=stately  singletonSeconds=3600 -> first=queued second=DROPPED
policy=stately  singletonSeconds=omitted -> first=queued second=queued
```

Note the middle line: switching the queue to `stately` is **not** sufficient on its own, because `job_i4` applies regardless of policy. The time slot has to go too.

## What's here

**Queue addressing in one place.** `packages/lib/src/prompt-jobs.ts` owns `promptJobSendOptions`, and `expeditePromptRuns` moves next to it so the harness can exercise the real function rather than a copy. Behavior-preserving: every call site keeps the options it had, and the expedite fallback keeps the same payload and queue defaults.

**Two tests in the `scheduling-policy` job**, which already runs a real worker against an ephemeral `postgres:16-alpine` with the no-network stub provider:

1. *A finished job does not block the next send for the same prompt.* Sends for a prompt id with no row behind it, so the worker completes it as a no-op, then sends again.
2. *Adding a premium model runs that model, and only that model.* Parks a cycle under a canceled subscription (an unentitled cycle queues nothing on its way out, so this reaches the real stranded state without manufacturing it), gives the standard target fresh history, then reactivates, adds `claude`, and expedites. Expects `chatgpt:base=1,claude:web=1` — the new target runs, the fresh one is not paid for again.

Both are deterministic: `awaitSlotHeadroom` steps over a slot boundary rather than racing it.

The existing `local` and `cloud` scenarios are untouched — pointing their `sendJob` at the production addressing would make them flaky rather than red, since whether the worker's 6h reschedule collides depends on where in the 6h block the run lands. Worth doing once the fix is in.

## Follow-ups

- The fix: drop `singletonSeconds`, set the queue to `policy: 'stately'`.
- `job-scheduler.ts` sends with `retryLimit: 3, expireInSeconds: 900` while the worker uses `PROMPT_JOB_OPTIONS` (`retryLimit: 0`, 90 min). Every prompt's first job — the one onboarding creates — is therefore exposed to the expire-and-retry double-submit that `PROMPT_JOB_OPTIONS` exists to prevent. Observed live: a job expired at 15 min, retried, and ran the fan-out twice.
- Treat a `null` from `boss.send` as a failure. `scheduleNextRun` and `schedule-maintenance` both count a swallowed send as success.
- `expeditePromptRuns` matches only `state = 'created'`; `retry` should count too.