### PR TITLE
break visibility down by model on the overview page

### DIFF
--- a/.changeset/visibility-by-model.md
+++ b/.changeset/visibility-by-model.md
@@ -2,4 +2,4 @@
 "@workspace/web": patch
 ---
 
-The overview page now breaks visibility down by platform for brands tracking more than one, so a low score on a single AI platform isn't hidden by the blended number.
+The overview page now breaks visibility down by platform for brands tracking more than one.

--- a/.changeset/visibility-by-model.md
+++ b/.changeset/visibility-by-model.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+The overview page now breaks visibility down by platform for brands tracking more than one, so a low score on a single AI platform isn't hidden by the blended number.

--- a/apps/web/src/components/visibility-by-model.tsx
+++ b/apps/web/src/components/visibility-by-model.tsx
@@ -1,0 +1,85 @@
+/**
+ * The overview's visibility score split by the platform that produced the
+ * answers. A brand tracked on several can be well covered overall and still be
+ * missing from one of them, which the blended number hides.
+ */
+import { Link } from "@tanstack/react-router";
+import { ModelIcon } from "@workspace/ui/brand/model-icon";
+import { Skeleton } from "@workspace/ui/components/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
+import { getVisibilityBarColor, getVisibilityTextColor, type TargetVisibility } from "@/lib/chart-utils";
+import { iconIdForModelFilter, labelForModelFilter, type TrackedTarget } from "@/lib/model-filter";
+
+export function VisibilityByModel({
+	brandId,
+	targets,
+	byTarget,
+	loading,
+}: {
+	brandId: string;
+	targets: TrackedTarget[];
+	byTarget: TargetVisibility[];
+	loading: boolean;
+}) {
+	if (loading) {
+		return (
+			<div className="space-y-3">
+				{targets.map((target) => (
+					<Skeleton key={target.value} className="h-5 w-full" />
+				))}
+			</div>
+		);
+	}
+
+	// What the brand tracks decides the rows and the summary only ranks them, so
+	// a platform switched off mid-window doesn't linger on the card, and one
+	// switched on yesterday shows up before its first run lands.
+	const ranked = byTarget.filter((entry) => targets.some((target) => target.value === entry.target));
+	const rankedTargets = new Set(ranked.map((entry) => entry.target));
+	const rows: TargetVisibility[] = [
+		...ranked,
+		...targets
+			.filter((target) => !rankedTargets.has(target.value))
+			.map((target) => ({ target: target.value, current: null, average: null, runs: 0 })),
+	];
+
+	return (
+		<div className="space-y-3">
+			{rows.map((row) => (
+				<div key={row.target} className="flex items-center gap-3">
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Link
+								to="/app/$brand/visibility"
+								params={{ brand: brandId }}
+								search={{ model: row.target }}
+								className="flex w-44 shrink-0 items-center gap-2 hover:underline"
+							>
+								<ModelIcon iconId={iconIdForModelFilter(row.target)} className="size-3.5 shrink-0" />
+								<span className="truncate text-sm">{labelForModelFilter(row.target)}</span>
+							</Link>
+						</TooltipTrigger>
+						<TooltipContent className="max-w-xs text-sm">
+							{row.runs > 0
+								? `Averaged ${row.average}% over ${row.runs.toLocaleString()} evaluations in the last 30 days.`
+								: "No evaluations on this platform in the last 30 days."}
+						</TooltipContent>
+					</Tooltip>
+					<div className="relative h-2 flex-1 overflow-hidden rounded-full bg-primary/10">
+						{row.current !== null && (
+							<div
+								className={`h-full rounded-full transition-all ${getVisibilityBarColor(row.current)}`}
+								style={{ width: `${row.current}%` }}
+							/>
+						)}
+					</div>
+					<span
+						className={`w-10 shrink-0 text-right text-sm font-semibold tabular-nums ${row.current === null ? "text-muted-foreground" : getVisibilityTextColor(row.current)}`}
+					>
+						{row.current === null ? "—" : `${row.current}%`}
+					</span>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/apps/web/src/lib/__tests__/chart-utils.test.ts
+++ b/apps/web/src/lib/__tests__/chart-utils.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
 	citationDateWindow,
+	mergeTargetVisibility,
+	summarizeVisibilityByTarget,
 	applyPerPromptKeyedLVCF,
 	getDaysFromLookback,
 	getDefaultLookbackPeriod,
@@ -127,5 +129,83 @@ describe("applyPerPromptKeyedLVCF", () => {
 		const daily = applyPerPromptKeyedLVCF(rows, range, 24, keys);
 		expect(toRoundedPercentages(daily.get("2026-06-01")!)).toEqual({ brand: 33, editorial: 67, other: 0 });
 		expect(toRoundedPercentages(daily.get("2026-06-02")!)).toEqual({ brand: 33, editorial: 67, other: 0 });
+	});
+});
+
+describe("mergeTargetVisibility", () => {
+	it("sums a prompt-day's targets back into one observation", () => {
+		expect(
+			mergeTargetVisibility([
+				{ prompt_id: "p1", date: "2026-06-01", target: "chatgpt", total_runs: 4, brand_mentioned_count: 3 },
+				{ prompt_id: "p1", date: "2026-06-01", target: "perplexity", total_runs: 2, brand_mentioned_count: 0 },
+				{ prompt_id: "p2", date: "2026-06-01", target: "chatgpt", total_runs: 1, brand_mentioned_count: 1 },
+			]),
+		).toEqual([
+			{ prompt_id: "p1", date: "2026-06-01", total_runs: 6, brand_mentioned_count: 3 },
+			{ prompt_id: "p2", date: "2026-06-01", total_runs: 1, brand_mentioned_count: 1 },
+		]);
+	});
+});
+
+describe("summarizeVisibilityByTarget", () => {
+	const range = ["2026-06-01", "2026-06-02", "2026-06-03"];
+
+	it("scores each target on its own runs, ranked best-first", () => {
+		const summaries = summarizeVisibilityByTarget(
+			[
+				{ prompt_id: "p1", date: "2026-06-03", target: "chatgpt", total_runs: 4, brand_mentioned_count: 3 },
+				{ prompt_id: "p1", date: "2026-06-03", target: "perplexity", total_runs: 4, brand_mentioned_count: 1 },
+			],
+			range,
+			[],
+		);
+		expect(summaries).toEqual([
+			{ target: "chatgpt", current: 75, average: 75, runs: 4 },
+			{ target: "perplexity", current: 25, average: 25, runs: 4 },
+		]);
+	});
+
+	it("carries a target's last run forward so a rarely sampled platform still has a current score", () => {
+		// perplexity only ran on the first day; without smoothing it would have no
+		// value on the last day of the window and drop off the breakdown.
+		const [chatgpt, perplexity] = summarizeVisibilityByTarget(
+			[
+				{ prompt_id: "p1", date: "2026-06-01", target: "perplexity", total_runs: 2, brand_mentioned_count: 1 },
+				{ prompt_id: "p1", date: "2026-06-03", target: "chatgpt", total_runs: 2, brand_mentioned_count: 2 },
+			],
+			range,
+			[],
+		);
+		expect(chatgpt).toEqual({ target: "chatgpt", current: 100, average: 100, runs: 2 });
+		expect(perplexity).toEqual({ target: "perplexity", current: 50, average: 50, runs: 2 });
+	});
+
+	it("keeps the same model's scraped and grounded targets apart", () => {
+		expect(
+			summarizeVisibilityByTarget(
+				[
+					{ prompt_id: "p1", date: "2026-06-01", target: "chatgpt", total_runs: 2, brand_mentioned_count: 0 },
+					{ prompt_id: "p1", date: "2026-06-01", target: "chatgpt::premium", total_runs: 2, brand_mentioned_count: 2 },
+				],
+				range,
+				[],
+			).map((s) => [s.target, s.current]),
+		).toEqual([
+			["chatgpt::premium", 100],
+			["chatgpt", 0],
+		]);
+	});
+
+	it("averages over actual runs while the current score reflects the latest day", () => {
+		const [summary] = summarizeVisibilityByTarget(
+			[
+				{ prompt_id: "p1", date: "2026-06-01", target: "chatgpt", total_runs: 10, brand_mentioned_count: 0 },
+				{ prompt_id: "p1", date: "2026-06-03", target: "chatgpt", total_runs: 2, brand_mentioned_count: 2 },
+			],
+			range,
+			[],
+		);
+		// Carried-forward days inflate neither total: 2 of 12 actual runs mentioned nothing extra.
+		expect(summary).toEqual({ target: "chatgpt", current: 100, average: 17, runs: 12 });
 	});
 });

--- a/apps/web/src/lib/chart-utils.ts
+++ b/apps/web/src/lib/chart-utils.ts
@@ -186,6 +186,103 @@ export function applyPerPromptLVCF(
 	return { dailyVisibilityMap, totalBrandedRuns, totalBrandedMentioned, totalNonBrandedRuns, totalNonBrandedMentioned };
 }
 
+/** A prompt-day's runs on one of the brand's tracked targets. */
+export interface TargetVisibilityPoint extends PerPromptVisibilityPoint {
+	/** Matches `TrackedTarget.value` — the model id, or `<model>::premium`. */
+	target: string;
+}
+
+export interface TargetVisibility {
+	target: string;
+	/** Latest LVCF day, the same measure as the headline visibility score. */
+	current: number | null;
+	/** Share of the window's actual runs that mentioned the brand. */
+	average: number | null;
+	/** Actual (non-carried-forward) runs in the window. */
+	runs: number;
+}
+
+/** Sum the targets back together so a prompt-day is one observation again. */
+export function mergeTargetVisibility(rows: TargetVisibilityPoint[]): PerPromptVisibilityPoint[] {
+	const merged = new Map<string, PerPromptVisibilityPoint>();
+	for (const row of rows) {
+		const date = String(row.date);
+		const key = `${row.prompt_id}|${date}`;
+		const existing = merged.get(key);
+		if (existing) {
+			existing.total_runs += Number(row.total_runs);
+			existing.brand_mentioned_count += Number(row.brand_mentioned_count);
+			continue;
+		}
+		merged.set(key, {
+			prompt_id: row.prompt_id,
+			date,
+			total_runs: Number(row.total_runs),
+			brand_mentioned_count: Number(row.brand_mentioned_count),
+		});
+	}
+	return [...merged.values()];
+}
+
+/**
+ * Visibility per target, each one smoothed on its own so a platform sampled
+ * weekly is read the same way as one sampled hourly — otherwise the rare
+ * platform's number would only describe the handful of days it happened to run.
+ *
+ * Ranked best-first, like the share-of-voice leaderboard. A target with no runs
+ * in the window sorts last rather than as a zero.
+ */
+export function summarizeVisibilityByTarget(
+	rows: TargetVisibilityPoint[],
+	dateRange: string[],
+	brandedPromptIds: string[],
+): TargetVisibility[] {
+	const byTarget = new Map<string, TargetVisibilityPoint[]>();
+	for (const row of rows) {
+		const bucket = byTarget.get(row.target);
+		if (bucket) bucket.push(row);
+		else byTarget.set(row.target, [row]);
+	}
+
+	const summaries: TargetVisibility[] = [];
+	// One row per prompt-day within a target, so these go straight to the same
+	// smoothing the headline number uses.
+	for (const [target, targetRows] of byTarget) {
+		const {
+			dailyVisibilityMap,
+			totalBrandedRuns,
+			totalBrandedMentioned,
+			totalNonBrandedRuns,
+			totalNonBrandedMentioned,
+		} = applyPerPromptLVCF(targetRows, dateRange, brandedPromptIds);
+
+		let current: number | null = null;
+		for (let i = dateRange.length - 1; i >= 0 && current === null; i--) {
+			const day = dailyVisibilityMap.get(dateRange[i]);
+			if (!day) continue;
+			const total = day.branded.total + day.nonBranded.total;
+			if (total === 0) continue;
+			current = Math.round(((day.branded.mentioned + day.nonBranded.mentioned) / total) * 100);
+		}
+
+		const runs = totalBrandedRuns + totalNonBrandedRuns;
+		summaries.push({
+			target,
+			current,
+			average: runs > 0 ? Math.round(((totalBrandedMentioned + totalNonBrandedMentioned) / runs) * 100) : null,
+			runs,
+		});
+	}
+
+	return summaries.sort((a, b) => {
+		if (a.current === null || b.current === null) {
+			if (a.current === b.current) return a.target.localeCompare(b.target);
+			return a.current === null ? 1 : -1;
+		}
+		return b.current - a.current || a.target.localeCompare(b.target);
+	});
+}
+
 export type CitationCategories = Record<CitationCategory, number>;
 
 /**
@@ -273,6 +370,33 @@ export function getBadgeClassName(value: number): string {
 	if (value > 75) return "bg-emerald-600 hover:bg-emerald-600 text-white";
 	if (value > 45) return "bg-amber-500 hover:bg-amber-500 text-white";
 	return "bg-rose-500 hover:bg-rose-500 text-white";
+}
+
+// One set of thresholds for a visibility score wherever it is shown, so the
+// headline card and a bar for one model can't disagree about what counts as good.
+
+export function getVisibilityBgColor(value: number): string {
+	if (value > 75) return "bg-emerald-50 dark:bg-emerald-950/30";
+	if (value > 45) return "bg-amber-50 dark:bg-amber-950/30";
+	return "bg-rose-50 dark:bg-rose-950/30";
+}
+
+export function getVisibilityTextColor(value: number): string {
+	if (value > 75) return "text-emerald-700 dark:text-emerald-400";
+	if (value > 45) return "text-amber-700 dark:text-amber-400";
+	return "text-rose-700 dark:text-rose-400";
+}
+
+export function getVisibilityBorderColor(value: number): string {
+	if (value > 75) return "border-emerald-200 dark:border-emerald-800";
+	if (value > 45) return "border-amber-200 dark:border-amber-800";
+	return "border-rose-200 dark:border-rose-800";
+}
+
+export function getVisibilityBarColor(value: number): string {
+	if (value > 75) return "bg-emerald-500";
+	if (value > 45) return "bg-amber-500";
+	return "bg-rose-500";
 }
 
 export interface ChartDataPoint {

--- a/apps/web/src/lib/postgres-read.ts
+++ b/apps/web/src/lib/postgres-read.ts
@@ -167,37 +167,42 @@ const API_PROVIDER_IDS = getAllProviders()
 	.map((provider) => provider.id);
 
 /**
- * Narrow to one target. A bare model id means the standard platform; the
- * `::premium` variant means the grounded API call sold from the premium pool.
+ * Whether a row is the grounded API call rather than the model scraped off its
+ * consumer product. Shared so that narrowing to a target and grouping by target
+ * can't drift apart on what counts as grounded.
  *
  * The provider list is bound one parameter per id rather than as an array:
  * drizzle flattens a JS array into a single text parameter, which `ANY(...)`
  * then can't compare element-wise.
  */
-function modelFilter(model?: string, opts?: { alias?: string; source?: "prompt_runs" | "citations" }): SQL {
-	const target = model ? parseModelFilter(model) : null;
-	if (!target) return sql``;
-	const prefix = opts?.alias ? sql.raw(`${opts.alias}.`) : sql``;
-	// No API providers configured means nothing can be grounded, so the premium
-	// side matches nothing and the standard side matches everything.
-	if (API_PROVIDER_IDS.length === 0) {
-		return target.premium ? sql`AND FALSE` : sql`AND ${prefix}model = ${target.model}`;
-	}
+function groundedExpr(prefix: SQL, source: "prompt_runs" | "citations" = "prompt_runs"): SQL {
+	// No API providers configured means nothing can be grounded.
+	if (API_PROVIDER_IDS.length === 0) return sql`FALSE`;
 	const providers = sql.join(
 		API_PROVIDER_IDS.map((id) => sql`${id}`),
 		sql`, `,
 	);
 	// A citation records which model cited it but not how that model was
 	// reached, so the grounded test has to go through the run it came from.
-	const grounded =
-		opts?.source === "citations"
-			? sql`EXISTS (
-					SELECT 1 FROM prompt_runs AS mf_run
-					WHERE mf_run.id = ${prefix}prompt_run_id
-						AND mf_run.web_search_enabled
-						AND mf_run.provider IN (${providers})
-				)`
-			: sql`(${prefix}web_search_enabled AND ${prefix}provider IN (${providers}))`;
+	return source === "citations"
+		? sql`EXISTS (
+				SELECT 1 FROM prompt_runs AS mf_run
+				WHERE mf_run.id = ${prefix}prompt_run_id
+					AND mf_run.web_search_enabled
+					AND mf_run.provider IN (${providers})
+			)`
+		: sql`(${prefix}web_search_enabled AND ${prefix}provider IN (${providers}))`;
+}
+
+/**
+ * Narrow to one target. A bare model id means the standard platform; the
+ * `::premium` variant means the grounded API call sold from the premium pool.
+ */
+function modelFilter(model?: string, opts?: { alias?: string; source?: "prompt_runs" | "citations" }): SQL {
+	const target = model ? parseModelFilter(model) : null;
+	if (!target) return sql``;
+	const prefix = opts?.alias ? sql.raw(`${opts.alias}.`) : sql``;
+	const grounded = groundedExpr(prefix, opts?.source);
 	return sql`AND ${prefix}model = ${target.model} AND ${target.premium ? grounded : sql`NOT ${grounded}`}`;
 }
 
@@ -243,19 +248,33 @@ export interface PerPromptVisibilityPoint {
 	brand_mentioned_count: number;
 }
 
-export async function getPerPromptVisibilityTimeSeries(
+/** A prompt-day split by which target produced the runs. */
+export interface PerTargetVisibilityPoint extends PerPromptVisibilityPoint {
+	model: string;
+	/** The model reached by a grounded API call rather than scraped — see `groundedExpr`. */
+	grounded: boolean;
+}
+
+/**
+ * Daily visibility per prompt, split by target so one pass over the runs serves
+ * both the blended trend and the per-model breakdown beside it. Callers that
+ * only want the blend sum the targets back together.
+ */
+export async function getPerTargetVisibilityTimeSeries(
 	brandId: string,
 	fromDate: string | null,
 	toDate: string | null,
 	timezone: string,
 	enabledPromptIds?: string[],
 	model?: string,
-): Promise<PerPromptVisibilityPoint[]> {
+): Promise<PerTargetVisibilityPoint[]> {
 	if (!enabledPromptIds?.length) return [];
-	const rows = await queryPg<PerPromptVisibilityPoint>(sql`
+	const rows = await queryPg<PerTargetVisibilityPoint>(sql`
 		SELECT
 			prompt_id,
 			(created_at AT TIME ZONE ${timezone})::date AS date,
+			model,
+			${groundedExpr(sql``)} AS grounded,
 			count(*)::int AS total_runs,
 			count(*) FILTER (WHERE brand_mentioned)::int AS brand_mentioned_count
 		FROM prompt_runs
@@ -263,7 +282,7 @@ export async function getPerPromptVisibilityTimeSeries(
 			${dateFilter(fromDate, toDate, timezone)}
 			${promptIdFilter(enabledPromptIds)}
 			${modelFilter(model)}
-		GROUP BY prompt_id, date
+		GROUP BY prompt_id, date, model, grounded
 		ORDER BY prompt_id, date
 	`);
 	return rows;
@@ -288,7 +307,7 @@ export interface VisibilityDailyAggregate {
 }
 
 /**
- * Single-query replacement for `getPerPromptVisibilityTimeSeries` + JS
+ * Single-query replacement for `getPerTargetVisibilityTimeSeries` + JS
  * `applyPerPromptLVCF`.
  *
  * Builds a (prompt × date) grid in-database, left-joins raw daily observations,

--- a/apps/web/src/routes/_authed/app/$brand/index.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/index.tsx
@@ -23,30 +23,14 @@ import { useBrand } from "@/hooks/use-brands";
 import { useDashboardSummary } from "@/hooks/use-dashboard-summary";
 import { useShareOfVoice } from "@/hooks/use-share-of-voice";
 import { TrendChart } from "@/components/trend-chart";
+import { VisibilityByModel } from "@/components/visibility-by-model";
+import { getVisibilityBgColor, getVisibilityBorderColor, getVisibilityTextColor } from "@/lib/chart-utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@workspace/ui/components/card";
 import { Button } from "@workspace/ui/components/button";
 import { Skeleton } from "@workspace/ui/components/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
 import type { ClientConfig } from "@workspace/config/types";
 import { setPersonProperties } from "@/lib/posthog";
-
-function getVisibilityBgColor(value: number): string {
-	if (value > 75) return "bg-emerald-50 dark:bg-emerald-950/30";
-	if (value > 45) return "bg-amber-50 dark:bg-amber-950/30";
-	return "bg-rose-50 dark:bg-rose-950/30";
-}
-
-function getVisibilityTextColor(value: number): string {
-	if (value > 75) return "text-emerald-700 dark:text-emerald-400";
-	if (value > 45) return "text-amber-700 dark:text-amber-400";
-	return "text-rose-700 dark:text-rose-400";
-}
-
-function getVisibilityBorderColor(value: number): string {
-	if (value > 75) return "border-emerald-200 dark:border-emerald-800";
-	if (value > 45) return "border-amber-200 dark:border-amber-800";
-	return "border-rose-200 dark:border-rose-800";
-}
 
 /** Most recent non-null value in a daily series — matches the right end of the trend line. */
 function lastValue<T>(series: T[], key: keyof T): number | null {
@@ -407,6 +391,27 @@ function DashboardPage() {
 								)}
 							</CardContent>
 						</Card>
+
+						{/* A brand tracked on one platform already has that answer in the
+						    hero number, so the split only earns its space past that. */}
+						{trackedTargets.length > 1 && (
+							<Card className="shadow-none lg:col-span-4 flex flex-col gap-3 py-4">
+								<CardHeader className="border-b border-dotted pb-2!">
+									<CardTitleWithTooltip
+										title="Visibility by Model"
+										tooltip="The same visibility score as above, measured separately on each platform you track — how often that platform's answers mention your brand. Each platform is smoothed on its own, so one sampled a few times a week is read the same way as one sampled hourly."
+									/>
+								</CardHeader>
+								<CardContent>
+									<VisibilityByModel
+										brandId={brandId}
+										targets={trackedTargets}
+										byTarget={dashboardSummary?.visibilityByTarget ?? []}
+										loading={isLoading}
+									/>
+								</CardContent>
+							</Card>
+						)}
 					</div>
 				</section>
 

--- a/apps/web/src/server/dashboard.ts
+++ b/apps/web/src/server/dashboard.ts
@@ -12,14 +12,18 @@ import {
 	generateDateRange,
 	applyPerPromptLVCF,
 	applyPerPromptCitationLVCF,
+	mergeTargetVisibility,
+	summarizeVisibilityByTarget,
 	type LookbackPeriod,
+	type TargetVisibility,
 } from "@/lib/chart-utils";
 import { getTimezoneLookbackRange, resolveTimezone } from "@/lib/timezone-utils";
 import {
 	getDashboardSummary,
-	getPerPromptVisibilityTimeSeries,
+	getPerTargetVisibilityTimeSeries,
 	getPerPromptDailyCitationStats,
 } from "@/lib/postgres-read";
+import { targetFilterValue } from "@/lib/model-filter";
 import { getEffectiveBrandedStatus } from "@workspace/lib/tag-utils";
 import {
 	type CitationCategory,
@@ -45,6 +49,8 @@ export interface DashboardSummaryResponse {
 	nonBrandedVisibility: number;
 	brandedVisibility: number;
 	visibilityTimeSeries: VisibilityTimeSeriesPoint[];
+	/** Same score as `visibilityTimeSeries`, split by the target that produced the runs. */
+	visibilityByTarget: TargetVisibility[];
 	citationTimeSeries: CitationTimeSeriesPoint[];
 	lastUpdatedAt: string | null;
 }
@@ -113,9 +119,9 @@ export const getDashboardSummaryFn = createServerFn({ method: "GET" })
 			.filter((p) => getEffectiveBrandedStatus(p.systemTags || [], p.tags || []).isBranded)
 			.map((p) => p.id);
 
-		const [summaryResult, perPromptVisibility, perPromptCitations] = await Promise.all([
+		const [summaryResult, perTargetVisibility, perPromptCitations] = await Promise.all([
 			getDashboardSummary(data.brandId, fromDateStr, toDateStr, timezone, enabledPromptIds),
-			getPerPromptVisibilityTimeSeries(data.brandId, fromDateStr, toDateStr, timezone, enabledPromptIds),
+			getPerTargetVisibilityTimeSeries(data.brandId, fromDateStr, toDateStr, timezone, enabledPromptIds),
 			getPerPromptDailyCitationStats(data.brandId, fromDateStr, toDateStr, timezone, enabledPromptIds),
 		]);
 
@@ -128,7 +134,14 @@ export const getDashboardSummaryFn = createServerFn({ method: "GET" })
 		// smoothing and the emitted series cover exactly this date domain.
 		const dateRange = generateDateRange(new Date(fromDateStr), new Date(toDateStr));
 
+		const targetVisibilityRows = perTargetVisibility.map((row) => ({
+			...row,
+			target: targetFilterValue(row.model, row.grounded),
+		}));
+		const visibilityByTarget = summarizeVisibilityByTarget(targetVisibilityRows, dateRange, brandedPromptIds);
+
 		// Process visibility via per-prompt LVCF smoothing
+		const perPromptVisibility = mergeTargetVisibility(targetVisibilityRows);
 		const {
 			dailyVisibilityMap,
 			totalBrandedRuns,
@@ -178,6 +191,7 @@ export const getDashboardSummaryFn = createServerFn({ method: "GET" })
 			nonBrandedVisibility,
 			brandedVisibility,
 			visibilityTimeSeries,
+			visibilityByTarget,
 			citationTimeSeries,
 			lastUpdatedAt,
 		};

--- a/apps/web/src/stories/analytics-fixtures.ts
+++ b/apps/web/src/stories/analytics-fixtures.ts
@@ -38,6 +38,14 @@ export const mockDashboardSummary = {
 	brandedVisibility: 92,
 	lastUpdatedAt: "2026-06-04T09:12:00.000Z",
 	visibilityTimeSeries,
+	// Best-first, spanning the three colour bands, with one tracked platform that
+	// has not reported yet.
+	visibilityByTarget: [
+		{ target: "chatgpt::premium", current: 84, average: 79, runs: 260 },
+		{ target: "chatgpt", current: 71, average: 68, runs: 1240 },
+		{ target: "google-ai-overview", current: 52, average: 49, runs: 980 },
+		{ target: "perplexity", current: 28, average: 31, runs: 640 },
+	],
 	citationTimeSeries: [],
 };
 

--- a/apps/web/src/stories/overview.stories.tsx
+++ b/apps/web/src/stories/overview.stories.tsx
@@ -26,6 +26,20 @@ const onboardedBrand = {
 	enabled: true,
 	prompts: [{ id: "p1", value: "best crm", enabled: true }],
 	effectiveModels: ["gpt-4o", "claude-3-5-sonnet", "gemini-1.5-pro"],
+	trackedTargets: [
+		{ value: "chatgpt", model: "chatgpt", premium: false, tier: "scraped", intervalHours: 6, replication: 1 },
+		{
+			value: "google-ai-overview",
+			model: "google-ai-overview",
+			premium: false,
+			tier: "scraped",
+			intervalHours: 24,
+			replication: 1,
+		},
+		{ value: "perplexity", model: "perplexity", premium: false, tier: "scraped", intervalHours: 24, replication: 1 },
+		{ value: "gemini", model: "gemini", premium: false, tier: "scraped", intervalHours: 24, replication: 1 },
+		{ value: "chatgpt::premium", model: "chatgpt", premium: true, tier: "premium", intervalHours: 72, replication: 1 },
+	],
 	earliestDataDate: "2026-05-05",
 	delayOverrideHours: 24,
 };


### PR DESCRIPTION
A brand tracked on several platforms can sit at a healthy blended score while being invisible on one of them. The overview only showed the blend, so that gap was only findable by filtering the visibility page one model at a time.

Adds a **Visibility by Model** card to the AI Visibility section, rendered only when a brand tracks more than one target.

- One row per tracked platform — icon, name, bar, current score — ranked best-first, on the same colour thresholds as the hero number.
- Row tooltip gives the 30-day average and evaluation count; clicking a row deep-links to the visibility page filtered to that platform.
- A tracked platform with no runs in the window shows `—`, not a misleading 0%.

### How it's computed

`getPerPromptVisibilityTimeSeries` became `getPerTargetVisibilityTimeSeries` — the same scan, now also grouped by `model` and a `grounded` flag, so one query feeds both the existing trend and the breakdown and the two can't disagree. `mergeTargetVisibility` sums the targets back together for the blended series, leaving the headline math untouched.

The grounded test that `modelFilter` used inline is now a shared `groundedExpr`, so "which target did this run belong to" is defined once for both filtering and grouping. Rows therefore key exactly onto `TrackedTarget.value`, keeping the scraped and grounded variants of one model apart (ChatGPT vs GPT-5 Search).

Each target is smoothed on its own, so a platform sampled twice a week is read the same way as one sampled hourly — otherwise the rare platform's number would only describe the days it happened to run.

The three visibility colour helpers moved out of the route file into `chart-utils`, so the card and the hero can't drift on what counts as a good score.

### Testing

- `check-types` clean; 27 unit tests pass, including 5 new ones covering per-target scoring, carry-forward for rarely sampled platforms, the scraped/grounded split, and average-vs-current divergence.
- All 80 Storybook render tests pass. The overview fixtures gained five tracked targets, one deliberately without data, so the card is reviewable there.

**Not verified locally:** no Postgres was reachable from this workspace, so the new `GROUP BY prompt_id, date, model, grounded` has not actually executed. It relies on Postgres resolving `grounded` as an output-column alias — the same mechanism the existing `GROUP BY prompt_id, date` already uses for the `date` alias in that query — but it's worth a run against a real database before merge.