### PR TITLE
give the worker time to drain in-flight jobs on shutdown

### DIFF
--- a/.changeset/worker-stop-grace-period.md
+++ b/.changeset/worker-stop-grace-period.md
@@ -1,0 +1,5 @@
+---
+"@elmohq/cli": patch
+---
+
+The worker now gets time to finish in-flight jobs when a deployment stops or upgrades, instead of being killed mid-evaluation.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1483,6 +1483,11 @@ function buildWorkerService(options: {
 
 	lines.push("  env_file:", "    - path: .env", "      required: true");
 
+	// On SIGTERM the worker gives pg-boss 30s to finish in-flight jobs, then
+	// flushes telemetry. Compose's 10s default would SIGKILL it partway through
+	// an evaluation, burning the provider call that job already paid for.
+	lines.push("  stop_grace_period: 35s");
+
 	if (options.dependsOn.length > 0) {
 		lines.push("  depends_on:");
 		for (const service of options.dependsOn) {


### PR DESCRIPTION
`apps/worker/src/index.ts` handles SIGTERM by asking pg-boss for up to 30s to finish in-flight jobs, then flushing Sentry and telemetry. The generated compose file never gave it that long — Compose defaults `stop_grace_period` to 10s, so every `docker compose down`, restart, or `elmo upgrade` SIGKILLed the worker about 10 seconds in.

For a worker whose jobs are mostly LLM evaluations, that lands mid-provider-call. The job is recoverable (pg-boss expires it and retries), but the killed call was already billed, and the retry pays for it a second time.

Sets `stop_grace_period: 35s` on the worker service — the 30s pg-boss drain window plus headroom for the telemetry flush that follows it.

## Scope

This only affects **newly generated** compose files. `elmo upgrade` deliberately re-pins image tags in place rather than re-rendering the file (`repinComposeImages`), so it preserves any manual edits a user has made — and therefore won't add this line to existing deployments. Reaching those needs a CLI migration, but `MigrationContext` currently only exposes `readEnv`/`writeEnv`, so teaching it to edit compose YAML is a new capability and a separate call.

## Testing

Verified by inspection of the generated block; `buildComposeYaml` isn't exported and `index.ts` runs `main()` at module load, so there's no seam to unit-test it through without extracting the compose builders into their own module.