### PR TITLE
run the container binaries directly instead of through npx

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,6 +60,12 @@ RUN pnpm --filter @workspace/web build
 RUN pnpm --filter @workspace/worker deploy --legacy /deploy/worker
 RUN pnpm --filter @workspace/lib deploy --legacy /deploy/lib
 
+# The runtime stages below invoke these two by path, but both are
+# devDependencies — a --prod deploy would drop them and the break would only
+# surface once a user started the container.
+RUN test -x /deploy/lib/node_modules/.bin/drizzle-kit
+RUN test -x /deploy/worker/node_modules/.bin/tsx
+
 # Runner stage for web app (Nitro)
 FROM base AS web
 WORKDIR /app
@@ -92,11 +98,6 @@ WORKDIR /app
 
 COPY --from=builder /deploy/lib ./
 
-# drizzle-kit and tsx are devDependencies, so a --prod deploy would drop them.
-# npx would paper over that by pulling an unpinned copy off the registry at run
-# time, inside a container holding DATABASE_URL — fail the build instead.
-RUN test -x ./node_modules/.bin/drizzle-kit
-
 CMD ["./node_modules/.bin/drizzle-kit", "migrate"]
 
 # Worker stage
@@ -114,8 +115,6 @@ RUN chmod +x /entrypoint.sh
 COPY --from=builder --chown=worker:nodejs /deploy/worker ./
 
 USER worker
-
-RUN test -x ./node_modules/.bin/tsx
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["./node_modules/.bin/tsx", "src/index.ts"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,7 +92,12 @@ WORKDIR /app
 
 COPY --from=builder /deploy/lib ./
 
-CMD ["npx", "drizzle-kit", "migrate"]
+# drizzle-kit and tsx are devDependencies, so a --prod deploy would drop them.
+# npx would paper over that by pulling an unpinned copy off the registry at run
+# time, inside a container holding DATABASE_URL — fail the build instead.
+RUN test -x ./node_modules/.bin/drizzle-kit
+
+CMD ["./node_modules/.bin/drizzle-kit", "migrate"]
 
 # Worker stage
 FROM base AS worker
@@ -110,5 +115,7 @@ COPY --from=builder --chown=worker:nodejs /deploy/worker ./
 
 USER worker
 
+RUN test -x ./node_modules/.bin/tsx
+
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["npx", "tsx", "src/index.ts"]
+CMD ["./node_modules/.bin/tsx", "src/index.ts"]


### PR DESCRIPTION
The migrate and worker images ran `drizzle-kit` and `tsx` through `npx`. Today that resolves the local binary, but both are **devDependencies** — they only survive into the image because the builder stage doesn't set `NODE_ENV=production` and `pnpm deploy` isn't `--prod`.

If that ever changes, `npx` doesn't fail. Confirmed against npm 11 with no TTY: it skips the "Ok to proceed?" prompt entirely and goes straight to the registry.

```
$ npx elmo-definitely-not-a-real-pkg-xyz123 </dev/null
npm error 404 Not Found - GET https://registry.npmjs.org/elmo-definitely-not-a-real-pkg-xyz123
```

It only failed there because the package doesn't exist. With `drizzle-kit` it would have downloaded whatever is latest and run it — unpinned, not from the lockfile, with none of the `minimumReleaseAge` cooldown the workspace enforces, inside a container holding `DATABASE_URL` that then applies DDL.

So: call the deployed binaries by path, and assert in the builder stage that `pnpm deploy` actually produced them. The assertions are the part that buys something — they turn a pruned devDependency into a red build instead of a failure in a self-hoster's `docker compose up`. That matters most for the worker, since the e2e workflow builds every image but only starts web and db-migrate, so nothing was executing the worker's `CMD` before this.

They sit in `builder` rather than in the runtime stages deliberately: that's where `pnpm deploy` runs, so the failure points at the step that caused it, and the shipped images keep the layer count they had before.

Also drops the `npm notice` update-notifier banner from migration logs, which is what sent me looking.

## Testing

Docker wasn't running locally, so I verified the assumption the change rests on by replicating the Dockerfile's deploy steps directly:

```
$ pnpm --filter @workspace/lib deploy --legacy /tmp/deploy-lib
$ test -x /tmp/deploy-lib/node_modules/.bin/drizzle-kit   # passes
$ pnpm --filter @workspace/worker deploy --legacy /tmp/deploy-worker
$ test -x /tmp/deploy-worker/node_modules/.bin/tsx        # passes
```

`drizzle.config.ts` and all 15 migration SQL files ship in the lib deploy as well. CI builds all three images, so it executes both assertions.
