### PR TITLE
match the Anthropic output cap to the other providers at 8000

### DIFF
--- a/packages/lib/src/providers/config.ts
+++ b/packages/lib/src/providers/config.ts
@@ -10,13 +10,12 @@ export { parseScrapeTargets } from "@workspace/config/scrape-targets";
 // it). These are code defaults; per-target overrides are a follow-up and aren't
 // threaded through ProviderOptions yet.
 //
-// anthropic-api stays at 4000 to match its long-standing production cap, so
-// nothing changes for Anthropic. The others sit at 8000; note OpenAI's and
-// OpenRouter's cap also counts reasoning tokens, so on reasoning-by-default
-// targets (gpt-5, grok-4.5, gemini-2.5-flash, deepseek-v3.2) that ceiling
-// covers reasoning plus visible output.
+// Every cap here has to cover reasoning tokens as well as visible output:
+// OpenAI and OpenRouter count them against the ceiling on reasoning-by-default
+// targets (gpt-5, grok-4.5, gemini-2.5-flash, deepseek-v3.2), and
+// claude-sonnet-5 runs adaptive thinking unless it is explicitly disabled.
 export const API_PROVIDER_MAX_OUTPUT_TOKENS: Record<string, number> = {
-	"anthropic-api": 4000,
+	"anthropic-api": 5000,
 	"openai-api": 8000,
 	openrouter: 8000,
 	"mistral-api": 8000,

--- a/packages/lib/src/providers/config.ts
+++ b/packages/lib/src/providers/config.ts
@@ -7,15 +7,11 @@ export { parseScrapeTargets } from "@workspace/config/scrape-targets";
 // Per-call output caps for the direct API providers: a worst-case bound on a
 // single tracked run, not a target length — sized well above any answer we
 // expect, so hitting one means something went wrong (warnIfOutputCapped logs
-// it). These are code defaults; per-target overrides are a follow-up and aren't
+// it). A cap covers reasoning and thinking tokens as well as visible output.
+// These are code defaults; per-target overrides are a follow-up and aren't
 // threaded through ProviderOptions yet.
-//
-// Every cap here has to cover reasoning tokens as well as visible output:
-// OpenAI and OpenRouter count them against the ceiling on reasoning-by-default
-// targets (gpt-5, grok-4.5, gemini-2.5-flash, deepseek-v3.2), and
-// claude-sonnet-5 runs adaptive thinking unless it is explicitly disabled.
 export const API_PROVIDER_MAX_OUTPUT_TOKENS: Record<string, number> = {
-	"anthropic-api": 5000,
+	"anthropic-api": 8000,
 	"openai-api": 8000,
 	openrouter: 8000,
 	"mistral-api": 8000,


### PR DESCRIPTION
Sets `API_PROVIDER_MAX_OUTPUT_TOKENS["anthropic-api"]` to 8000, so all four direct API providers share one cap.

`anthropic-api` is the only provider serving the `claude-sonnet-5` targets, and the cap is keyed per provider rather than per model, so this is the cap for Claude Sonnet.

With the values uniform, the comment above the map no longer needs to explain the per-provider differences. Trimmed it to the two things the code can't show: the cap is a worst-case guard rather than a target length, and it covers reasoning and thinking tokens as well as visible output. The enumerated list of reasoning-by-default model names went with it — that was the part most likely to go stale.

No changeset: this is a truncation guard (`warnIfOutputCapped` logs when a run hits it), not something an end user would notice.