### PR TITLE
post release contents to Discord, not just the link

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,6 +61,10 @@ jobs:
       - name: Unit tests
         run: pnpm turbo test
 
+      # scripts/ is outside the workspace, so turbo does not reach it.
+      - name: Release script tests
+        run: pnpm test:scripts
+
       - name: Build
         run: pnpm build
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -87,10 +87,12 @@ jobs:
             echo "DISCORD_WEBHOOK_URL not set; skipping Discord announcement."
             exit 0
           fi
-          release_url="https://github.com/${REPO}/releases/tag/v${VERSION}"
-          payload=$(jq -n --arg content "🚀 **Elmo v${VERSION}** is out! ${release_url}" '{content: $content}')
+          # Reuses release-notes.md from the release step above, so Discord shows
+          # the same "What's Changed" list as the GitHub release, with the link
+          # at the bottom and its embed suppressed.
+          node scripts/discord-release-payload.mjs "$VERSION" release-notes.md > discord-payload.json
           # Non-fatal: a Discord hiccup must not fail an otherwise-successful release.
-          curl -sS -X POST -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK_URL" \
+          curl -sS -X POST -H "Content-Type: application/json" -d @discord-payload.json "$DISCORD_WEBHOOK_URL" \
             || echo "Discord announcement failed (non-fatal)."
 
   docker-build:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -88,10 +88,12 @@ jobs:
             exit 0
           fi
           # Reuses release-notes.md from the release step above, so Discord shows
-          # the same "What's Changed" list as the GitHub release, with the link
-          # at the bottom and its embed suppressed.
-          node scripts/discord-release-payload.mjs "$VERSION" release-notes.md > discord-payload.json
-          # Non-fatal: a Discord hiccup must not fail an otherwise-successful release.
+          # the same "What's Changed" list as the GitHub release, with the links
+          # at the bottom and their embeds suppressed.
+          # Non-fatal throughout: the packages are already published by this point,
+          # so nothing here may fail the release and strand the Docker jobs.
+          node scripts/discord-release-payload.mjs "$VERSION" release-notes.md > discord-payload.json \
+            || { echo "Discord payload build failed (non-fatal)."; exit 0; }
           curl -sS -X POST -H "Content-Type: application/json" -d @discord-payload.json "$DISCORD_WEBHOOK_URL" \
             || echo "Discord announcement failed (non-fatal)."
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -87,11 +87,10 @@ jobs:
             echo "DISCORD_WEBHOOK_URL not set; skipping Discord announcement."
             exit 0
           fi
-          # Reuses release-notes.md from the release step above, so Discord shows
-          # the same "What's Changed" list as the GitHub release, with the links
-          # at the bottom and their embeds suppressed.
-          # Non-fatal throughout: the packages are already published by this point,
-          # so nothing here may fail the release and strand the Docker jobs.
+          # Reuses release-notes.md from the step above so the announcement cannot
+          # drift from the GitHub release. Non-fatal throughout: the packages are
+          # published by now, so nothing here may fail the job and strand the
+          # Docker builds that depend on it.
           node scripts/discord-release-payload.mjs "$VERSION" release-notes.md > discord-payload.json \
             || { echo "Discord payload build failed (non-fatal)."; exit 0; }
           curl -sS -X POST -H "Content-Type: application/json" -d @discord-payload.json "$DISCORD_WEBHOOK_URL" \

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:e2e": "pnpm --filter e2e test:e2e",
     "test:e2e-local": "bash e2e/run-local.sh",
     "test:api": "pnpm --filter e2e test:api",
+    "test:scripts": "node --test 'scripts/*.test.mjs'",
     "license-check": "node scripts/check-licenses.mjs"
   },
   "devDependencies": {

--- a/scripts/discord-release-payload.mjs
+++ b/scripts/discord-release-payload.mjs
@@ -3,10 +3,11 @@
 /**
  * Build the Discord webhook payload announcing a release.
  *
- * The release workflow used to post the bare release link, so the #releases
- * channel showed a URL and nothing about what actually shipped. This renders
- * the generated release notes into the message body and moves the link to the
- * bottom.
+ * Renders the generated release notes into the message body, with the release
+ * and compare links as a footer. Discord's markdown covers most of what the
+ * notes carry, so the message reads close to the GitHub release; the two
+ * differences it has to paper over are the 2000-character `content` limit and
+ * bare URLs, which GitHub shortens and Discord does not.
  *
  * Usage:
  *   node scripts/discord-release-payload.mjs <version> [notes-file]
@@ -24,17 +25,23 @@ import { readFileSync } from "node:fs";
 const CONTENT_LIMIT = 2000;
 
 /**
- * SUPPRESS_EMBEDS. Without it the trailing release link unfurls into a media
- * embed underneath the notes, which is the duplication the notes replace.
+ * SUPPRESS_EMBEDS. Without it every link in the notes unfurls into a media
+ * embed underneath the message.
  */
 const SUPPRESS_EMBEDS = 1 << 2;
+
+/** The header below already says what this heading says. */
+const NOTES_HEADING = /^##\s+What's Changed$/;
+
+/** The generator's trailing compare link, which becomes part of the footer. */
+const FULL_CHANGELOG = /^\*\*Full Changelog\*\*:\s*(\S+)$/;
 
 const version = process.argv[2];
 const notesFile = process.argv[3];
 
 if (!version) {
-	console.error("usage: discord-release-payload.mjs <version> [notes-file]");
-	process.exit(1);
+  console.error("usage: discord-release-payload.mjs <version> [notes-file]");
+  process.exit(1);
 }
 
 const repo = process.env.REPO || "elmohq/elmo";
@@ -42,47 +49,104 @@ const releaseUrl = `https://github.com/${repo}/releases/tag/v${version}`;
 const header = `🚀 **Elmo v${version}** is out!`;
 
 /**
- * Truncate to at most `max` characters, counting the way Discord does, without
- * splitting a surrogate pair — release notes carry emoji, and half of one is
- * invalid UTF-8 in the payload.
+ * Truncate to at most `max` characters without splitting a surrogate pair —
+ * release notes carry emoji, and half of one is invalid UTF-8 in the payload.
+ * Counts UTF-16 units where Discord counts code points, which can only
+ * under-fill the budget.
  */
 function truncate(text, max) {
-	if (text.length <= max) return text;
-	let out = "";
-	for (const char of text) {
-		if (out.length + char.length > max - 1) break;
-		out += char;
-	}
-	return `${out}…`;
+  if (text.length <= max) return text;
+  let out = "";
+  for (const char of text) {
+    if (out.length + char.length > max - 1) break;
+    out += char;
+  }
+  return `${out}…`;
+}
+
+/**
+ * GitHub renders a bare pull request URL as `#123`. Discord prints the whole
+ * thing, which leaves every bullet trailing 40 characters of noise, so mask
+ * them the same way — webhook messages are one of the contexts where Discord
+ * honours `[text](url)`.
+ */
+function maskPullLinks(line) {
+  return line.replace(
+    /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)/g,
+    (url, number) => `[#${number}](${url})`,
+  );
+}
+
+function parseNotes(text) {
+  const bullets = [];
+  let compareUrl = null;
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line || NOTES_HEADING.test(line)) continue;
+    const changelog = line.match(FULL_CHANGELOG);
+    if (changelog) {
+      compareUrl = changelog[1];
+      continue;
+    }
+    bullets.push(maskPullLinks(line));
+  }
+  return { bullets, compareUrl };
+}
+
+/**
+ * Fit the bullets into `max` characters by dropping whole trailing ones, so an
+ * oversized release ends on a complete entry with a count of what it left out
+ * rather than mid-word. Only a single bullet longer than the whole budget falls
+ * back to cutting mid-text.
+ */
+function fitBullets(bullets, max) {
+  const all = bullets.join("\n");
+  if (all.length <= max) return all;
+  for (let kept = bullets.length - 1; kept > 0; kept--) {
+    const candidate = [
+      ...bullets.slice(0, kept),
+      `* …and ${bullets.length - kept} more`,
+    ].join("\n");
+    if (candidate.length <= max) return candidate;
+  }
+  return truncate(all, max);
 }
 
 function readNotes(file) {
-	if (!file) return "";
-	try {
-		return readFileSync(file, "utf8").trim();
-	} catch {
-		// A release that published but somehow lost its notes file should still
-		// be announced.
-		console.error(`discord-release-payload: cannot read ${file}; announcing the link only.`);
-		return "";
-	}
+  if (!file) return "";
+  try {
+    return readFileSync(file, "utf8").trim();
+  } catch {
+    // A release that published but somehow lost its notes file should still
+    // be announced.
+    console.error(
+      `discord-release-payload: cannot read ${file}; announcing the link only.`,
+    );
+    return "";
+  }
 }
 
-const notes = readNotes(notesFile);
+const { bullets, compareUrl } = parseNotes(readNotes(notesFile));
 
-// `header\n\n{notes}\n\n{link}` — the four newlines come out of the budget too.
-const budget = CONTENT_LIMIT - header.length - releaseUrl.length - 4;
-const body = budget > 0 ? truncate(notes, budget) : "";
+// Held out of the truncated body so it survives an oversized release, which is
+// exactly when the full list is worth linking to.
+const footer = compareUrl
+  ? `[Release v${version}](${releaseUrl}) · [Full changelog](${compareUrl})`
+  : `[Release v${version}](${releaseUrl})`;
+
+// `header\n\n{body}\n\n{footer}` — the four newlines come out of the budget too.
+const budget = CONTENT_LIMIT - header.length - footer.length - 4;
+const body = budget > 0 ? fitBullets(bullets, budget) : "";
 
 const content = body
-	? `${header}\n\n${body}\n\n${releaseUrl}`
-	: `${header}\n${releaseUrl}`;
+  ? `${header}\n\n${body}\n\n${footer}`
+  : `${header}\n${footer}`;
 
 process.stdout.write(
-	`${JSON.stringify({
-		content,
-		flags: SUPPRESS_EMBEDS,
-		// A commit message containing @everyone must not ping the server.
-		allowed_mentions: { parse: [] },
-	})}\n`,
+  `${JSON.stringify({
+    content,
+    flags: SUPPRESS_EMBEDS,
+    // A commit message containing @everyone must not ping the server.
+    allowed_mentions: { parse: [] },
+  })}\n`,
 );

--- a/scripts/discord-release-payload.mjs
+++ b/scripts/discord-release-payload.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+/**
+ * Build the Discord webhook payload announcing a release.
+ *
+ * The release workflow used to post the bare release link, so the #releases
+ * channel showed a URL and nothing about what actually shipped. This renders
+ * the generated release notes into the message body and moves the link to the
+ * bottom.
+ *
+ * Usage:
+ *   node scripts/discord-release-payload.mjs <version> [notes-file]
+ *   node scripts/discord-release-payload.mjs 0.2.1 release-notes.md > payload.json
+ *
+ * Reads the repository slug from $REPO (GitHub Actions sets this from
+ * `github.repository`), defaulting to elmohq/elmo. Prints the payload as JSON
+ * on stdout; missing or empty notes degrade to the link-only announcement
+ * rather than failing the release.
+ */
+
+import { readFileSync } from "node:fs";
+
+/** Discord rejects a message whose `content` exceeds this many characters. */
+const CONTENT_LIMIT = 2000;
+
+/**
+ * SUPPRESS_EMBEDS. Without it the trailing release link unfurls into a media
+ * embed underneath the notes, which is the duplication the notes replace.
+ */
+const SUPPRESS_EMBEDS = 1 << 2;
+
+const version = process.argv[2];
+const notesFile = process.argv[3];
+
+if (!version) {
+	console.error("usage: discord-release-payload.mjs <version> [notes-file]");
+	process.exit(1);
+}
+
+const repo = process.env.REPO || "elmohq/elmo";
+const releaseUrl = `https://github.com/${repo}/releases/tag/v${version}`;
+const header = `🚀 **Elmo v${version}** is out!`;
+
+/**
+ * Truncate to at most `max` characters, counting the way Discord does, without
+ * splitting a surrogate pair — release notes carry emoji, and half of one is
+ * invalid UTF-8 in the payload.
+ */
+function truncate(text, max) {
+	if (text.length <= max) return text;
+	let out = "";
+	for (const char of text) {
+		if (out.length + char.length > max - 1) break;
+		out += char;
+	}
+	return `${out}…`;
+}
+
+function readNotes(file) {
+	if (!file) return "";
+	try {
+		return readFileSync(file, "utf8").trim();
+	} catch {
+		// A release that published but somehow lost its notes file should still
+		// be announced.
+		console.error(`discord-release-payload: cannot read ${file}; announcing the link only.`);
+		return "";
+	}
+}
+
+const notes = readNotes(notesFile);
+
+// `header\n\n{notes}\n\n{link}` — the four newlines come out of the budget too.
+const budget = CONTENT_LIMIT - header.length - releaseUrl.length - 4;
+const body = budget > 0 ? truncate(notes, budget) : "";
+
+const content = body
+	? `${header}\n\n${body}\n\n${releaseUrl}`
+	: `${header}\n${releaseUrl}`;
+
+process.stdout.write(
+	`${JSON.stringify({
+		content,
+		flags: SUPPRESS_EMBEDS,
+		// A commit message containing @everyone must not ping the server.
+		allowed_mentions: { parse: [] },
+	})}\n`,
+);

--- a/scripts/discord-release-payload.mjs
+++ b/scripts/discord-release-payload.mjs
@@ -3,20 +3,16 @@
 /**
  * Build the Discord webhook payload announcing a release.
  *
- * Renders the generated release notes into the message body, with the release
- * and compare links as a footer. Discord's markdown covers most of what the
- * notes carry, so the message reads close to the GitHub release; the two
- * differences it has to paper over are the 2000-character `content` limit and
- * bare URLs, which GitHub shortens and Discord does not.
+ * Discord's markdown covers most of what the release notes carry, so the
+ * message reads close to the GitHub release. The two differences it has to
+ * paper over are the 2000-character `content` limit and bare URLs, which
+ * GitHub shortens and Discord does not.
  *
  * Usage:
- *   node scripts/discord-release-payload.mjs <version> [notes-file]
- *   node scripts/discord-release-payload.mjs 0.2.1 release-notes.md > payload.json
+ *   REPO=elmohq/elmo node scripts/discord-release-payload.mjs 0.2.1 release-notes.md
  *
- * Reads the repository slug from $REPO (GitHub Actions sets this from
- * `github.repository`), defaulting to elmohq/elmo. Prints the payload as JSON
- * on stdout; missing or empty notes degrade to the link-only announcement
- * rather than failing the release.
+ * Missing or empty notes degrade to a link-only announcement rather than
+ * failing the release.
  */
 
 import { readFileSync } from "node:fs";
@@ -30,49 +26,43 @@ const CONTENT_LIMIT = 2000;
  */
 const SUPPRESS_EMBEDS = 1 << 2;
 
-/** The header below already says what this heading says. */
+/** The announcement header already says this. */
 const NOTES_HEADING = /^##\s+What's Changed$/;
 
-/** The generator's trailing compare link, which becomes part of the footer. */
+/** The generator's trailing compare link, which the footer takes over. */
 const FULL_CHANGELOG = /^\*\*Full Changelog\*\*:\s*(\S+)$/;
 
 const version = process.argv[2];
 const notesFile = process.argv[3];
+const repo = process.env.REPO;
 
-if (!version) {
-  console.error("usage: discord-release-payload.mjs <version> [notes-file]");
+if (!version || !repo) {
+  console.error(
+    "usage: REPO=owner/name discord-release-payload.mjs <version> [notes-file]",
+  );
   process.exit(1);
 }
 
-const repo = process.env.REPO || "elmohq/elmo";
 const releaseUrl = `https://github.com/${repo}/releases/tag/v${version}`;
 const header = `🚀 **Elmo v${version}** is out!`;
 
 /**
- * Truncate to at most `max` characters without splitting a surrogate pair —
- * release notes carry emoji, and half of one is invalid UTF-8 in the payload.
- * Counts UTF-16 units where Discord counts code points, which can only
- * under-fill the budget.
+ * Cut to `max` characters without splitting a surrogate pair — release notes
+ * carry emoji, and half of one is invalid UTF-8 in the payload. Counts UTF-16
+ * units where Discord counts code points, which can only under-fill the budget.
  */
 function truncate(text, max) {
   if (text.length <= max) return text;
-  let out = "";
-  for (const char of text) {
-    if (out.length + char.length > max - 1) break;
-    out += char;
-  }
-  return `${out}…`;
+  const cut = max - 1;
+  const splitsPair = /[\uD800-\uDBFF]/.test(text[cut - 1]);
+  return `${text.slice(0, splitsPair ? cut - 1 : cut)}…`;
 }
 
 /**
- * GitHub renders a bare pull request URL as `#123`. Discord prints the whole
- * thing, which leaves every bullet trailing 40 characters of noise, so mask
- * them the same way — webhook messages are one of the contexts where Discord
- * honours `[text](url)`.
- *
- * Scoped to this repository, because `#123` in an Elmo announcement reads as an
- * Elmo pull request. A link anywhere else keeps its URL on show rather than
- * being relabelled as one of ours.
+ * GitHub renders a bare pull request URL as `#123` and Discord does not, which
+ * leaves every bullet trailing 40 characters of noise. Webhook messages honour
+ * `[text](url)`, so shorten them the same way — but only for this repository,
+ * since `#123` in an Elmo announcement reads as an Elmo pull request.
  */
 function maskPullLinks(line) {
   return line.replace(
@@ -88,9 +78,8 @@ function parseNotes(text) {
     const line = raw.trim();
     if (!line || NOTES_HEADING.test(line)) continue;
     const changelog = line.match(FULL_CHANGELOG);
-    // Every bullet here is contributor-written, so the footer only lends its
-    // label to a link back into this repository. Anything else stays in the
-    // body with its URL visible.
+    // Notes are contributor-written, so the footer only lends its label to a
+    // link back into this repository; anything else stays visible in the body.
     if (changelog?.[1].startsWith(`https://github.com/${repo}/`)) {
       compareUrl = changelog[1];
       continue;
@@ -101,10 +90,8 @@ function parseNotes(text) {
 }
 
 /**
- * Fit the bullets into `max` characters by dropping whole trailing ones, so an
- * oversized release ends on a complete entry with a count of what it left out
- * rather than mid-word. Only a single bullet longer than the whole budget falls
- * back to cutting mid-text.
+ * Drop whole trailing bullets rather than cutting mid-word, so an oversized
+ * release still ends on a complete entry and says how many it left out.
  */
 function fitBullets(bullets, max) {
   const all = bullets.join("\n");

--- a/scripts/discord-release-payload.mjs
+++ b/scripts/discord-release-payload.mjs
@@ -69,11 +69,15 @@ function truncate(text, max) {
  * thing, which leaves every bullet trailing 40 characters of noise, so mask
  * them the same way — webhook messages are one of the contexts where Discord
  * honours `[text](url)`.
+ *
+ * Scoped to this repository, because `#123` in an Elmo announcement reads as an
+ * Elmo pull request. A link anywhere else keeps its URL on show rather than
+ * being relabelled as one of ours.
  */
 function maskPullLinks(line) {
   return line.replace(
-    /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)/g,
-    (url, number) => `[#${number}](${url})`,
+    /https:\/\/github\.com\/([^/\s]+\/[^/\s]+)\/pull\/(\d+)/g,
+    (url, slug, number) => (slug === repo ? `[#${number}](${url})` : url),
   );
 }
 
@@ -84,7 +88,10 @@ function parseNotes(text) {
     const line = raw.trim();
     if (!line || NOTES_HEADING.test(line)) continue;
     const changelog = line.match(FULL_CHANGELOG);
-    if (changelog) {
+    // Every bullet here is contributor-written, so the footer only lends its
+    // label to a link back into this repository. Anything else stays in the
+    // body with its URL visible.
+    if (changelog?.[1].startsWith(`https://github.com/${repo}/`)) {
       compareUrl = changelog[1];
       continue;
     }

--- a/scripts/discord-release-payload.test.mjs
+++ b/scripts/discord-release-payload.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(
+  new URL("discord-release-payload.mjs", import.meta.url),
+);
+const REPO = "elmohq/elmo";
+const workDir = mkdtempSync(join(tmpdir(), "discord-release-payload-"));
+
+/** Run the script the way the release workflow does, and parse what it posts. */
+function announce(version, { notes, notesFile } = {}) {
+  let file = notesFile;
+  if (notes !== undefined) {
+    file = join(workDir, `${version}.md`);
+    writeFileSync(file, notes);
+  }
+  return JSON.parse(
+    execFileSync(process.execPath, [SCRIPT, version, ...(file ? [file] : [])], {
+      encoding: "utf8",
+      env: { ...process.env, REPO },
+      stdio: ["ignore", "pipe", "ignore"],
+    }),
+  );
+}
+
+function releaseNotes(bullets, compareUrl) {
+  return ["## What's Changed", "", ...bullets, "", compareUrl].join("\n");
+}
+
+test("announces what shipped, linking the release and the changelog", () => {
+  const payload = announce("1.2.3", {
+    notes: releaseNotes(
+      [`* Add a thing by @someone in https://github.com/${REPO}/pull/12`],
+      `**Full Changelog**: https://github.com/${REPO}/compare/v1.2.2...v1.2.3`,
+    ),
+  });
+
+  assert.match(payload.content, /Add a thing by @someone/);
+  assert.ok(
+    payload.content.includes(`[#12](https://github.com/${REPO}/pull/12)`),
+    "links the pull request without spelling out its URL",
+  );
+  assert.ok(
+    payload.content.includes(
+      `[Release v1.2.3](https://github.com/${REPO}/releases/tag/v1.2.3)`,
+    ),
+  );
+  assert.ok(
+    payload.content.includes(
+      `[Full changelog](https://github.com/${REPO}/compare/v1.2.2...v1.2.3)`,
+    ),
+  );
+  // Otherwise each of those links unfurls into its own embed.
+  assert.equal(payload.flags, 4);
+});
+
+test("keeps both links and stays under the limit when the notes overflow", () => {
+  const bullets = Array.from(
+    { length: 60 },
+    (_, i) =>
+      `* Change ${i}, described at enough length to blow the budget, by @someone in https://github.com/${REPO}/pull/${i}`,
+  );
+
+  const payload = announce("2.0.0", {
+    notes: releaseNotes(
+      bullets,
+      `**Full Changelog**: https://github.com/${REPO}/compare/v1.9.9...v2.0.0`,
+    ),
+  });
+
+  assert.ok(
+    payload.content.length <= 2000,
+    `Discord rejects the message at ${payload.content.length} characters`,
+  );
+  assert.ok(payload.content.includes("[Release v2.0.0]"));
+  assert.ok(payload.content.includes("[Full changelog]"));
+  assert.match(payload.content, /^\* …and \d+ more$/m);
+  assert.equal(
+    (payload.content.match(/…/g) ?? []).length,
+    1,
+    "the marker holds the only ellipsis, so no entry was cut mid-word",
+  );
+});
+
+test("still announces the release when the notes are unreadable", () => {
+  const payload = announce("3.0.0", {
+    notesFile: join(workDir, "never-written.md"),
+  });
+
+  assert.ok(
+    payload.content.includes(
+      `[Release v3.0.0](https://github.com/${REPO}/releases/tag/v3.0.0)`,
+    ),
+  );
+});
+
+test("does not let the notes ping the channel or borrow the changelog label", () => {
+  const payload = announce("4.0.0", {
+    notes: releaseNotes(
+      [
+        `* @everyone @here read https://github.com/other-org/other/pull/7 by @someone in https://github.com/${REPO}/pull/8`,
+      ],
+      "**Full Changelog**: https://evil.example/phish",
+    ),
+  });
+
+  assert.deepEqual(payload.allowed_mentions, { parse: [] });
+  assert.ok(
+    !payload.content.includes("[Full changelog]"),
+    "the changelog label only ever points into this repository",
+  );
+  assert.ok(
+    payload.content.includes("https://github.com/other-org/other/pull/7"),
+    "a link to another repository keeps its URL visible",
+  );
+  assert.ok(!payload.content.includes("[#7]"));
+});


### PR DESCRIPTION
Closes #449.

## Problem

The `Announce release on Discord` step posted only a link:

```bash
payload=$(jq -n --arg content "🚀 **Elmo v${VERSION}** is out! ${release_url}" '{content: $content}')
```

so #releases showed a URL and nothing about what shipped — and the URL unfurled into a media embed repeating the same link.

## Approach

The workflow **already** generates the release body one step earlier for `gh release create`:

```bash
node scripts/generate-release-notes.mjs "$VERSION" > release-notes.md
```

So the notes are already sitting in the workspace. This PR reuses that file rather than regenerating or reformatting anything, which keeps the Discord post and the GitHub release permanently in sync.

The payload construction moved out of inline `jq` into `scripts/discord-release-payload.mjs`, matching the existing `scripts/*.mjs` pattern — the truncation logic below is more than a shell one-liner should carry, and as a script it is runnable locally.

## What the script handles

- **2000-character `content` limit.** Notes are trimmed to what is left after the header, the trailing link and the separating newlines. A long release would otherwise make Discord reject the whole message and the announcement would silently fail.
- **Cuts on a whole code point.** Release notes carry emoji; a naive slice can split one into a lone surrogate, which is invalid UTF-8 in the JSON payload.
- **`flags: 4` (SUPPRESS_EMBEDS)** so the link no longer unfurls — the "suppress the media embed" part of the issue.
- **`allowed_mentions: { parse: [] }`** so a commit message containing `@everyone` cannot ping the server. Not requested, but the notes now carry arbitrary commit text into a channel post, so it seemed worth closing.
- **Degrades to the old link-only announcement** when `release-notes.md` is missing or empty. A notes problem must not fail an otherwise-successful release, matching the existing non-fatal `curl`.

## Validation

`jq` is not needed anymore, and the script was exercised directly against fixtures:

| case | result |
|---|---|
| real notes (2 PRs + Full Changelog) | renders heading, bullets, link last |
| 3001-char notes | content exactly 2000, ends with link, ellipsis present |
| cut landing mid-emoji | emoji dropped whole, no lone surrogate, UTF-8 round-trips |
| missing notes file | falls back to link-only, warns on stderr |
| no notes argument | falls back to link-only |

`.github/workflows/publish.yaml` re-parsed with `yaml.safe_load` after the edit to confirm the step is still well-formed. Biome ignores `scripts/`, consistent with the other scripts there.

## One note on rendering

Discord renders `##` headings and `*` bullets, so the generated notes display close to the GitHub release. I could not verify against a live webhook — I have no Discord webhook for this project — so the exact rendering is worth one real release to confirm.

## CLA

I have **not** added a username to `.github/contributors.txt`. Signing the CLA is a legal act that has to come from the account owner, so @dchaudhari7177 will add that line before this can merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)