### PR TITLE
fix the provider test's stale getModelMeta import

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -11,6 +11,7 @@
 	},
 	"dependencies": {
 		"@sentry/node": "^10.69.0",
+		"@workspace/config": "workspace:*",
 		"@workspace/deployment": "workspace:*",
 		"@workspace/lib": "workspace:*",
 		"@workspace/whitelabel": "workspace:*",

--- a/apps/worker/scripts/test-provider.ts
+++ b/apps/worker/scripts/test-provider.ts
@@ -10,13 +10,8 @@
  *   pnpm tsx --env-file=.env scripts/test-provider.ts --target "chatgpt:olostep:online" --output-json result.json
  */
 
-import {
-	parseScrapeTargets,
-	getProvider,
-	getModelMeta,
-	STATUS_TARGETS,
-	type ScrapeResult,
-} from "@workspace/lib/providers";
+import { getModelMeta } from "@workspace/config/models";
+import { parseScrapeTargets, getProvider, STATUS_TARGETS, type ScrapeResult } from "@workspace/lib/providers";
 import { extractTextContent, extractCitations } from "@workspace/lib/text-extraction";
 import { appendFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { escapeGitHubSummaryTableCell } from "./github-summary";

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -16,6 +16,6 @@
 			"@workspace/whitelabel/*": ["../../packages/whitelabel/src/*"]
 		}
 	},
-	"include": ["src/**/*.ts"],
+	"include": ["src/**/*.ts", "scripts/**/*.ts"],
 	"exclude": ["node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
       '@sentry/node':
         specifier: ^10.69.0
         version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(supports-color@7.2.0)
+      '@workspace/config':
+        specifier: workspace:*
+        version: link:../../packages/config
       '@workspace/deployment':
         specifier: workspace:*
         version: link:../../packages/deployment


### PR DESCRIPTION
The scheduled **Test Providers** workflow has been failing on every run before it reaches a single provider:

```
TypeError: (0 , import_providers.getModelMeta) is not a function
    at runTarget (apps/worker/scripts/test-provider.ts:228:15)
```

`getModelMeta` moved out of `@workspace/lib/providers` and into `@workspace/config/models` in #536, but `test-provider.ts` kept importing it from the old location. The import resolved to `undefined`, and `runTarget` blew up on its first call — so both the scheduled full-matrix run and the `workflow_dispatch` single-target run died immediately, and `/status` has been getting no fresh uptime data.

## Changes

- Import `getModelMeta` from `@workspace/config/models`, matching how `apps/web` and `packages/lib` already reach it. This makes `@workspace/config` a real dependency of `apps/worker`, so it's added to `package.json` (the lockfile diff is one `workspace:*` link, nothing re-resolved).
- Add `scripts/**/*.ts` to the worker's `tsconfig.json` include. It only covered `src`, which is why a stale import in the script CI actually runs stayed green until the scheduled workflow tripped over it. With this, `check-types` catches the whole class.

## Verification

- `pnpm turbo check-types` passes repo-wide, now with the worker's scripts in scope.
- `pnpm install --frozen-lockfile` passes the supply-chain policy check.
- Ran the script end to end against the no-network `stub` provider — it gets past the old crash point, runs the provider, and reports normal validation output. No billed provider APIs were called; the real targets will exercise on the next scheduled run.