### PR TITLE
use the concise output style for agents in this repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,6 @@
   "attribution": {
     "commit": "",
     "pr": ""
-  }
+  },
+  "outputStyle": "Concise"
 }


### PR DESCRIPTION
Sets `outputStyle: "Concise"` in the repo's `.claude/settings.json` so Claude Code agents running against this repo lead with the result and skip preamble and narration.