### PR TITLE
align docs and blog prose with the site palette

### DIFF
--- a/apps/www/src/components/blog-post-layout.tsx
+++ b/apps/www/src/components/blog-post-layout.tsx
@@ -93,7 +93,7 @@ export function BlogPostLayout({ data }: { data: BlogPostLoaderData }) {
 						<ArrowLeft className="size-3" />
 						Blog
 					</a>
-					<article className="prose mt-8 max-w-none">
+					<article className="prose prose-zinc mt-8 max-w-none">
 						<h1 className="mb-3 text-balance">{data.title}</h1>
 						{data.description && <p className="lead mt-0 text-zinc-600">{data.description}</p>}
 						<div className="not-prose mb-10 mt-6 border-b border-zinc-200 pb-8">

--- a/apps/www/src/components/docs-page-layout.tsx
+++ b/apps/www/src/components/docs-page-layout.tsx
@@ -42,7 +42,7 @@ export const clientLoader = browserCollections.docs.createClientLoader({
 	component({ toc, frontmatter, default: MDX }, _props: undefined) {
 		return (
 			<div className="flex gap-10">
-				<article className="prose min-w-0 max-w-none flex-1">
+				<article className="prose prose-zinc min-w-0 max-w-none flex-1">
 					<h1>{frontmatter.title}</h1>
 					{frontmatter.description && <p className="lead text-muted-foreground">{frontmatter.description}</p>}
 					<MDX components={useMDXComponents()} />

--- a/apps/www/src/components/docs-page-layout.tsx
+++ b/apps/www/src/components/docs-page-layout.tsx
@@ -161,7 +161,7 @@ function OpenApiContent({
 	apiProps: ClientApiPageProps;
 }) {
 	return (
-		<article className="prose min-w-0 max-w-none flex-1">
+		<article className="prose prose-zinc min-w-0 max-w-none flex-1">
 			<h1>{title}</h1>
 			{description && <p className="lead text-muted-foreground">{description}</p>}
 			<div className="not-prose">

--- a/apps/www/src/styles.css
+++ b/apps/www/src/styles.css
@@ -124,12 +124,22 @@
 	content: none !important;
 }
 
+.prose {
+	--tw-prose-links: var(--primary);
+}
+
+/*
+ * Heading text is wrapped in an anchor for the copy-link affordance, so the
+ * link colour would otherwise repaint every heading. Inherit the heading
+ * colour instead and let only the hover underline mark it as clickable.
+ */
 .prose h1 a,
 .prose h2 a,
 .prose h3 a,
 .prose h4 a,
 .prose h5 a,
 .prose h6 a {
+	color: inherit;
 	text-decoration: none !important;
 }
 


### PR DESCRIPTION
Docs and blog articles were rendering on `@tailwindcss/typography`'s built-in **gray** ramp while the rest of the site is **zinc**, and prose links were near-black rather than the site's accent blue.

The gray palette isn't a choice anyone made here — `.prose` bakes `defaultModifiers.gray.css` into its DEFAULT block, and there was no `prose-zinc` modifier or `--tw-prose-*` override anywhere in the repo to redirect it.

## Changes

- `prose-zinc` on the three prose articles (blog post, docs page, OpenAPI docs page)
- `--tw-prose-links: var(--primary)` so in-content links match the blue used everywhere else on the site

## The heading guard

fumadocs' `Heading` wraps each heading's text in an `<a href="#id">` for the copy-link affordance, so prose's link colour paints heading text. That was invisible before only because `--tw-prose-links` and `--tw-prose-headings` were both gray-900 — turning links blue without a guard turns **every docs and blog heading blue**. The existing heading-anchor rule now sets `color: inherit` to keep headings on the heading colour, leaving the hover underline as the only clickable affordance.

## Measured

Computed colours read off the live page via CDP, before and after, on `/blog/ai-citations` and `/docs/user-guide/settings`:

| | before | after |
|---|---|---|
| body | `oklch(0.373 0.034 259.733)` (gray-700) | `oklch(0.37 0.013 285.805)` (zinc-700) |
| headings | `oklch(0.21 0.034 264.665)` (gray-900) | `oklch(0.21 0.006 285.885)` (zinc-900) |
| heading anchor | `oklch(0.21 0.034 264.665)` | `oklch(0.21 0.006 285.885)` — inherits, stays dark |
| in-content link | `oklch(0.21 0.034 264.665)` — same as headings | `oklch(0.546 0.245 262.881)` (`--primary`) |

The body/heading shift is same-lightness, lower-chroma — it removes a faint blue cast against the neutral chrome and is subtle in isolation. The link colour is the change a reader will actually notice.

Both pages rendered and spot-checked in a browser; tables, code blocks, callouts and the docs sidebar are unaffected.

No changeset.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a187a74f-e066-48c8-9091-2905764ed1dd)
