### PR TITLE
render llm responses as proper markdown

### DIFF
--- a/.changeset/render-response-markdown.md
+++ b/.changeset/render-response-markdown.md
@@ -3,4 +3,4 @@
 "@workspace/lib": patch
 ---
 
-Render LLM responses as proper markdown on the prompt detail page. Comparison tables now show as tables instead of rows of `|` characters, source favicons appear inline instead of as broken images, and source links open in a new tab.
+Render LLM responses as proper markdown on the prompt detail page. Comparison tables now show as tables instead of rows of `|` characters, source favicons appear inline instead of as broken images, and source links open in a new tab. Cloro's Google AI Overview answers keep their formatting instead of arriving flattened.

--- a/.changeset/render-response-markdown.md
+++ b/.changeset/render-response-markdown.md
@@ -1,0 +1,6 @@
+---
+"@workspace/web": patch
+"@workspace/lib": patch
+---
+
+Render LLM responses as proper markdown on the prompt detail page. Comparison tables now show as tables instead of rows of `|` characters, source favicons appear inline instead of as broken images, and source links open in a new tab.

--- a/.changeset/render-response-markdown.md
+++ b/.changeset/render-response-markdown.md
@@ -3,4 +3,4 @@
 "@workspace/lib": patch
 ---
 
-Render LLM responses as proper markdown on the prompt detail page. Comparison tables now show as tables instead of rows of `|` characters, source favicons appear inline instead of as broken images, and source links open in a new tab. Cloro's Google AI Overview answers keep their formatting instead of arriving flattened.
+Render LLM responses as proper markdown on the prompt detail page.

--- a/.changeset/render-response-markdown.md
+++ b/.changeset/render-response-markdown.md
@@ -3,4 +3,4 @@
 "@workspace/lib": patch
 ---
 
-Render LLM responses as proper markdown on the prompt detail page.
+Support "GitHub Flavored Markdown" on prompt detail pages. LLM responses now render tables, strikethroughs, and URL autolinks correctly.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,6 +54,7 @@
 		"react-icons": "^5.7.0",
 		"react-markdown": "^10.1.0",
 		"recharts": "^3.10.1",
+		"remark-gfm": "^4.0.1",
 		"tailwindcss": "^4.3.3",
 		"tslib": "^2.8.1",
 		"tw-animate-css": "^1.4.0",

--- a/apps/web/src/components/__tests__/response-markdown.test.tsx
+++ b/apps/web/src/components/__tests__/response-markdown.test.tsx
@@ -88,4 +88,23 @@ describe("answer rendering across providers", () => {
 	])("keeps %s blocks as separate paragraphs", (_name, provider, rawOutput) => {
 		expect(render(rawOutput, provider).match(/<p>/g)).toHaveLength(2);
 	});
+
+	it("does not load relative or protocol-relative images", () => {
+		const html = renderToStaticMarkup(
+			<ResponseMarkdown>{`![remote](https://images.example/favicon.png)
+
+![root relative](/api/session)
+
+![path relative](./pixel.png)
+
+![protocol relative](//tracker.example/pixel.png)`}</ResponseMarkdown>,
+		);
+
+		expect(html.match(/<img /g)).toHaveLength(1);
+		expect(html).toContain('src="https://images.example/favicon.png"');
+		expect(html).toContain('loading="lazy"');
+		expect(html).toContain('referrerPolicy="no-referrer"');
+		expect(html).not.toContain("/api/session");
+		expect(html).not.toContain("tracker.example");
+	});
 });

--- a/apps/web/src/components/__tests__/response-markdown.test.tsx
+++ b/apps/web/src/components/__tests__/response-markdown.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Every provider stores its answers in a different shape, and each one reaches
+ * the prompt detail page through `extractTextContent` before it is rendered.
+ * A provider whose extraction hands back flattened text or glued-together
+ * blocks looks identical to a broken renderer from the page's side, so the two
+ * halves are checked together here rather than in isolation.
+ *
+ * The shapes mirror the fixtures in each provider's own tests in
+ * `packages/lib/src/providers/registry`.
+ */
+import { extractTextContent } from "@workspace/lib/text-extraction";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ResponseMarkdown } from "@/components/response-markdown";
+
+const PROSE = "Here are the **top** trackers:";
+const TABLE = "| Tool | Price |\n| --- | --- |\n| Profound | $99 |";
+const ANSWER = `${PROSE}\n\n${TABLE}`;
+
+const render = (rawOutput: unknown, provider: string) =>
+	renderToStaticMarkup(<ResponseMarkdown>{extractTextContent(rawOutput, provider)}</ResponseMarkdown>);
+
+/** One answer, one shape per provider surface. */
+const SURFACES: [name: string, provider: string, rawOutput: unknown][] = [
+	["openai-api", "openai-api", { output: [{ type: "message", content: [{ type: "output_text", text: ANSWER }] }] }],
+	["anthropic-api", "anthropic-api", { content: [{ type: "text", text: ANSWER }] }],
+	["mistral-api", "mistral-api", { outputs: [{ content: [{ type: "text", text: ANSWER }] }] }],
+	["openrouter", "openrouter", { choices: [{ message: { content: ANSWER } }] }],
+	["olostep", "olostep", { json_content: JSON.stringify({ result: { markdown_content: ANSWER } }) }],
+	["brightdata chatbot", "brightdata", [{ answer_text_markdown: ANSWER, answer_text: "flattened" }]],
+	["brightdata AI Overview", "brightdata", [{ ai_overview: { markdown: ANSWER } }]],
+	["oxylabs ChatGPT", "oxylabs", { results: [{ content: { markdown_text: ANSWER } }] }],
+	["oxylabs Perplexity", "oxylabs", { results: [{ content: { answer_results_md: ANSWER } }] }],
+	["cloro chatbot", "cloro", { text: ANSWER }],
+	["cloro AI Overview", "cloro", { aioverview: { markdown: ANSWER, text: "flattened" } }],
+	["dataforseo scraper", "dataforseo", { tasks: [{ result: [{ markdown: ANSWER, sources: [] }] }] }],
+	[
+		"dataforseo LLM Responses",
+		"dataforseo",
+		{ tasks: [{ result: [{ items: [{ type: "message", sections: [{ type: "text", text: ANSWER }] }] }] }] },
+	],
+	[
+		"dataforseo AI Overview",
+		"dataforseo",
+		{ tasks: [{ result: [{ items: [{ type: "ai_overview", markdown: ANSWER }] }] }] },
+	],
+	// Rows written before the provider column existed dispatch on the model.
+	[
+		"legacy row without a provider",
+		"chatgpt",
+		{ output: [{ type: "message", content: [{ type: "output_text", text: ANSWER }] }] },
+	],
+];
+
+describe("answer rendering across providers", () => {
+	it.each(SURFACES)("renders %s answers as markdown", (_name, provider, rawOutput) => {
+		const html = render(rawOutput, provider);
+		expect(html).toContain("<table>");
+		expect(html).toContain("<strong>top</strong>");
+		expect(html).not.toContain("flattened");
+	});
+
+	/**
+	 * These three surfaces arrive as a list of blocks rather than one string.
+	 * Joined with a single newline they render as one run-on paragraph, which
+	 * is what the extraction's blank-line join exists to prevent.
+	 */
+	it.each([
+		[
+			"brightdata AI Overview",
+			"brightdata",
+			[{ ai_overview: { texts: [{ snippet: "First." }, { snippet: "Second." }] } }],
+		],
+		[
+			"dataforseo scraper items",
+			"dataforseo",
+			{ tasks: [{ result: [{ sources: [], items: [{ markdown: "First." }, { markdown: "Second." }] }] }] },
+		],
+		[
+			"oxylabs AI Overview",
+			"oxylabs",
+			{
+				results: [
+					{ content: { ai_overviews: [{ answer_text: [{ fragments: [{ text: "First." }, { text: "Second." }] }] }] } },
+				],
+			},
+		],
+	])("keeps %s blocks as separate paragraphs", (_name, provider, rawOutput) => {
+		expect(render(rawOutput, provider).match(/<p>/g)).toHaveLength(2);
+	});
+});

--- a/apps/web/src/components/response-markdown.tsx
+++ b/apps/web/src/components/response-markdown.tsx
@@ -8,7 +8,12 @@ import remarkGfm from "remark-gfm";
  * a script vector, so links keep the stock rules.
  */
 const urlTransform: UrlTransform = (url, key, node) => {
-	if (key === "src" && node.tagName === "img" && /^data:image\//i.test(url)) return url;
+	if (key === "src" && node.tagName === "img") {
+		if (/^data:image\//i.test(url)) return url;
+		// Relative sources could make authenticated requests against this app,
+		// while protocol-relative sources obscure the destination's scheme.
+		if (!URL.canParse(url)) return "";
+	}
 	return defaultUrlTransform(url);
 };
 
@@ -32,7 +37,13 @@ const components: Components = {
 	// of breaking the answer into a column of logos.
 	img: ({ src, alt }) =>
 		typeof src === "string" && src ? (
-			<img src={src} alt={alt ?? ""} className="my-0 inline h-[1.2em] w-auto align-middle" />
+			<img
+				src={src}
+				alt={alt ?? ""}
+				className="my-0 inline h-[1.2em] w-auto align-middle"
+				loading="lazy"
+				referrerPolicy="no-referrer"
+			/>
 		) : null,
 };
 

--- a/apps/web/src/components/response-markdown.tsx
+++ b/apps/web/src/components/response-markdown.tsx
@@ -1,0 +1,53 @@
+import ReactMarkdown, { type Components, defaultUrlTransform, type UrlTransform } from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+/**
+ * Engines inline their source favicons as `data:image/…` payloads, which the
+ * default transform blanks out into broken-image icons. Widened for image
+ * sources only — a `data:` URL is inert in `<img>`, but in an `<a href>` it is
+ * a script vector, so links keep the stock rules.
+ */
+const urlTransform: UrlTransform = (url, key, node) => {
+	if (key === "src" && node.tagName === "img" && /^data:image\//i.test(url)) return url;
+	return defaultUrlTransform(url);
+};
+
+const components: Components = {
+	// Answers link out to their sources, so a plain click would navigate the
+	// dashboard away to a third-party page.
+	a: ({ href, children }) => (
+		<a href={href} target="_blank" rel="noopener noreferrer">
+			{children}
+		</a>
+	),
+	// Tables are as wide as the model wants; the answer box is not.
+	table: ({ children }) => (
+		<div className="overflow-x-auto">
+			<table>{children}</table>
+		</div>
+	),
+	// The images engines inline are source favicons and ad thumbnails, served at
+	// their own resolution (128px squares are typical) and with no alt text.
+	// Sized to the text they sit beside they read as the chips they are, instead
+	// of breaking the answer into a column of logos.
+	img: ({ src, alt }) =>
+		typeof src === "string" && src ? (
+			<img src={src} alt={alt ?? ""} className="my-0 inline h-[1.2em] w-auto align-middle" />
+		) : null,
+};
+
+/**
+ * Renders an answer-engine answer as markdown.
+ *
+ * GFM is what makes this readable: engines answer comparison prompts with pipe
+ * tables, and CommonMark alone leaves those as a wall of literal `|`.
+ */
+export function ResponseMarkdown({ children }: { children: string }) {
+	return (
+		<div className="prose prose-sm dark:prose-invert max-w-none break-words">
+			<ReactMarkdown remarkPlugins={[remarkGfm]} components={components} urlTransform={urlTransform}>
+				{children}
+			</ReactMarkdown>
+		</div>
+	);
+}

--- a/apps/web/src/routes/_authed/app/$brand/prompts/$promptId.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/prompts/$promptId.tsx
@@ -32,8 +32,8 @@ import { usePromptStats } from "@/hooks/use-prompt-stats";
 import { usePromptRunsOnly } from "@/hooks/use-prompt-runs-only";
 import { useQueryFanout } from "@/hooks/use-query-fanout";
 import { getPromptMetadataFn } from "@/server/prompts";
+import { ResponseMarkdown } from "@/components/response-markdown";
 import { extractTextContent } from "@workspace/lib/text-extraction";
-import ReactMarkdown from "react-markdown";
 
 // -------------------------------------------------------------------
 // Types
@@ -668,8 +668,8 @@ function ResponsesTab({
 
 						<div>
 							<span className="text-xs text-muted-foreground block mb-1.5">LLM Response</span>
-							<div className="rounded-md border bg-muted/30 p-4 max-h-64 overflow-auto prose prose-sm max-w-none">
-								<ReactMarkdown>{extractTextContent(run.rawOutput, run.provider ?? run.model)}</ReactMarkdown>
+							<div className="rounded-md border bg-muted/30 p-4 max-h-64 overflow-auto">
+								<ResponseMarkdown>{extractTextContent(run.rawOutput, run.provider ?? run.model)}</ResponseMarkdown>
 							</div>
 						</div>
 

--- a/apps/web/src/stories/response-markdown.stories.tsx
+++ b/apps/web/src/stories/response-markdown.stories.tsx
@@ -88,3 +88,43 @@ Source: [https://www.example.com/blog/the-10-best-ai-visibility-tools-in-2026-a-
 `,
 	},
 };
+
+/**
+ * Answer bodies are attacker-reachable: anyone who gets a poisoned page cited
+ * by an answer engine chooses part of this markdown. Nothing in it may become
+ * live markup, so this story pins the boundary rather than trusting that the
+ * next person to touch the renderer knows it exists.
+ *
+ * The protection is that no `rehype-raw` is configured, so raw HTML stays
+ * text, and that link hrefs keep react-markdown's stock scheme allowlist.
+ */
+export const HostileContent: Story = {
+	args: {
+		children: `Before <script>alert(document.cookie)</script> after
+
+<img src=x onerror="alert(1)">
+
+[looks harmless](javascript:alert(1)) and [so does this](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)
+
+![](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)
+`,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		// Raw HTML renders as the text it is, not as markup.
+		await expect(canvasElement.querySelector("script")).toBeNull();
+		await expect(canvas.getByText(/<script>alert\(document\.cookie\)<\/script>/)).toBeVisible();
+		await expect(canvasElement.querySelector("img[onerror]")).toBeNull();
+
+		// Script-bearing URL schemes are stripped out of hrefs, leaving anchors
+		// with nothing to navigate to (and so not even exposed as links).
+		const hrefs = [...canvasElement.querySelectorAll("a")].map((a) => a.getAttribute("href"));
+		await expect(hrefs).toEqual(["", ""]);
+		await expect(canvas.queryAllByRole("link")).toHaveLength(0);
+
+		// Widening image sources to data URLs must not have widened it to
+		// `data:text/html`, which is a document, not an image.
+		await expect(canvasElement.querySelector("img")).toBeNull();
+	},
+};

--- a/apps/web/src/stories/response-markdown.stories.tsx
+++ b/apps/web/src/stories/response-markdown.stories.tsx
@@ -107,6 +107,10 @@ export const HostileContent: Story = {
 [looks harmless](javascript:alert(1)) and [so does this](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)
 
 ![](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)
+
+![](/api/session)
+
+![](//tracker.example/pixel.png)
 `,
 	},
 	play: async ({ canvasElement }) => {
@@ -126,5 +130,10 @@ export const HostileContent: Story = {
 		// Widening image sources to data URLs must not have widened it to
 		// `data:text/html`, which is a document, not an image.
 		await expect(canvasElement.querySelector("img")).toBeNull();
+
+		// Images cannot use the viewer's credentials against this app or hide
+		// their destination behind the page's current protocol.
+		await expect(canvasElement.innerHTML).not.toContain("/api/session");
+		await expect(canvasElement.innerHTML).not.toContain("tracker.example");
 	},
 };

--- a/apps/web/src/stories/response-markdown.stories.tsx
+++ b/apps/web/src/stories/response-markdown.stories.tsx
@@ -1,0 +1,90 @@
+/**
+ * Stories for <ResponseMarkdown />, the answer body on the prompt detail page.
+ *
+ * The fixtures are shaped after real answers captured from BrightData's
+ * ChatGPT and Google AI Mode collectors: a comparison table, source links,
+ * and the favicon chips the engines splice into their prose — including the
+ * `data:` ones Google AI Mode inlines.
+ */
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, within } from "storybook/test";
+import { ResponseMarkdown } from "@/components/response-markdown";
+
+const PIXEL = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==";
+
+const CHATGPT_ANSWER = `If by **AI visibility trackers** you mean tools that track whether your brand is cited in ChatGPT, the 2026 market has a few clear leaders.
+
+### My 2026 shortlist
+
+| Tool | Best for | My take |
+| --- | --- | --- |
+| **Profound** | Enterprise | Best overall for large teams |
+| **Peec AI** | Mid-market | Best balance of depth + usability |
+| **Otterly.AI** | SMBs / agencies | Best affordable starting point |
+
+Recent comparisons put [Profound](https://tryprofound.com/) and Peec among the core dedicated platforms. ![](${PIXEL}) Baarely+2
+
+* * *
+
+### What I'd buy
+
+*   **Solo founder:** Otterly
+*   **SEO team:** Peec AI
+`;
+
+const meta = {
+	title: "Components/ResponseMarkdown",
+	component: ResponseMarkdown,
+	decorators: [
+		(Story) => (
+			<div className="max-w-3xl rounded-md border bg-muted/30 p-4">
+				<Story />
+			</div>
+		),
+	],
+} satisfies Meta<typeof ResponseMarkdown>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A ChatGPT answer: the comparison table is the point of the answer. */
+export const ChatGptAnswer: Story = {
+	args: { children: CHATGPT_ANSWER },
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		// The table is GFM, which plain CommonMark leaves as literal pipes.
+		const table = canvasElement.querySelector("table");
+		await expect(table).not.toBeNull();
+		await expect(within(table as HTMLElement).getByText("Otterly.AI")).toBeVisible();
+		await expect(canvas.queryByText(/\| --- \|/)).toBeNull();
+
+		// Sources are third-party pages; following one must not unload the app.
+		const link = canvas.getByRole("link", { name: "Profound" });
+		await expect(link).toHaveAttribute("target", "_blank");
+		await expect(link).toHaveAttribute("rel", "noopener noreferrer");
+
+		// Engines inline favicons as data URLs, which react-markdown blanks by
+		// default — leaving a broken image in the middle of the answer.
+		const favicon = canvasElement.querySelector("img");
+		await expect(favicon).toHaveAttribute("src", PIXEL);
+
+		await expect(canvas.getByRole("heading", { name: "My 2026 shortlist" })).toBeVisible();
+	},
+};
+
+/**
+ * Answers that run wide: Google AI Mode returns four- and five-column tables
+ * and bare URLs as link text, neither of which may push the answer box out of
+ * the card.
+ */
+export const WideContent: Story = {
+	args: {
+		children: `| Platform | Best For | Platforms Tracked | Starting Price | Notes |
+| --- | --- | --- | --- | --- |
+| Semrush AI Visibility Toolkit | All-in-one SEO workflows | ChatGPT, Perplexity, Gemini, Copilot, Google AI Mode | $99/mo | Bundled with existing Semrush subscriptions |
+
+Source: [https://www.example.com/blog/the-10-best-ai-visibility-tools-in-2026-a-very-long-slug](https://www.example.com/blog/the-10-best-ai-visibility-tools-in-2026-a-very-long-slug)
+`,
+	},
+};

--- a/packages/lib/src/providers/registry/cloro.test.ts
+++ b/packages/lib/src/providers/registry/cloro.test.ts
@@ -160,7 +160,8 @@ describe("cloro provider", () => {
 				include: { aioverview: { markdown: true } },
 			},
 		});
-		expect(result.textContent).toContain("Brooks Ghost");
+		// The markdown the task asked for, not the flattened `text` beside it.
+		expect(result.textContent).toContain("**Brooks Ghost**");
 		expect(result.citations).toHaveLength(1);
 		expect(result.citations[0].domain).toBe("runnersworld.com");
 		// The overview exposes no query strings, but its citations prove a search ran.

--- a/packages/lib/src/text-extraction.test.ts
+++ b/packages/lib/src/text-extraction.test.ts
@@ -10,6 +10,7 @@ import {
 	extractTextFromAnthropic,
 	extractTextFromBrightdata,
 	extractTextFromDataforseoLlm,
+	extractTextFromDataforseoScraper,
 	extractTextFromGoogle,
 	extractTextFromOpenAI,
 	extractTextFromOxylabs,
@@ -213,6 +214,29 @@ describe("text-extraction", () => {
 			const raw = dfsLlmResponse({});
 			expect(extractTextFromGoogle(raw)).toBe("The answer text.");
 			expect(extractTextContent(raw, "dataforseo")).toBe("The answer text.");
+		});
+	});
+
+	describe("extractTextFromDataforseoScraper", () => {
+		it("keeps per-item blocks parseable as markdown when the top-level markdown is missing", () => {
+			const raw = {
+				tasks: [
+					{
+						result: [
+							{
+								sources: [],
+								items: [
+									{ type: "text", markdown: "Here are the top speakers." },
+									{ type: "table", markdown: "| Speaker | Price |\n| --- | --- |\n| Era 300 | $449 |" },
+								],
+							},
+						],
+					},
+				],
+			};
+			expect(extractTextFromDataforseoScraper(raw)).toBe(
+				"Here are the top speakers.\n\n| Speaker | Price |\n| --- | --- |\n| Era 300 | $449 |",
+			);
 		});
 	});
 
@@ -631,7 +655,7 @@ describe("text-extraction", () => {
 				},
 			};
 			expect(extractTextFromBrightdata(rawOutput)).toBe(
-				"The Sonos Era 300 is a well-reviewed speaker with spatial audio.\nBattery Life: 6 hours\nWater resistance: IP55",
+				"The Sonos Era 300 is a well-reviewed speaker with spatial audio.\n\nBattery Life: 6 hours\n\nWater resistance: IP55",
 			);
 		});
 

--- a/packages/lib/src/text-extraction.test.ts
+++ b/packages/lib/src/text-extraction.test.ts
@@ -218,7 +218,7 @@ describe("text-extraction", () => {
 	});
 
 	describe("extractTextFromDataforseoScraper", () => {
-		it("keeps per-item blocks parseable as markdown when the top-level markdown is missing", () => {
+		it("keeps per-item blocks separate when the top-level markdown is missing", () => {
 			const raw = {
 				tasks: [
 					{
@@ -666,6 +666,22 @@ describe("text-extraction", () => {
 		it("still reads chatbot dataset answers and reports missing content", () => {
 			expect(extractTextFromBrightdata({ answer_text_markdown: "Dataset answer." })).toBe("Dataset answer.");
 			expect(extractTextFromBrightdata({})).toBe("No text content found in BrightData output.");
+		});
+	});
+
+	describe("extractTextFromCloro", () => {
+		it("reads the AI Overview's markdown rather than the flattened text beside it", () => {
+			const rawOutput = {
+				aioverview: {
+					text: "The Brooks Ghost is a well-reviewed beginner shoe.",
+					markdown: "The **Brooks Ghost** is a well-reviewed beginner shoe.",
+				},
+			};
+			expect(extractTextContent(rawOutput, "cloro")).toBe("The **Brooks Ghost** is a well-reviewed beginner shoe.");
+		});
+
+		it("falls back to text for the chatbot tasks, which carry no markdown field", () => {
+			expect(extractTextContent({ text: "Chatbot answer." }, "cloro")).toBe("Chatbot answer.");
 		});
 	});
 

--- a/packages/lib/src/text-extraction.ts
+++ b/packages/lib/src/text-extraction.ts
@@ -130,12 +130,15 @@ export function extractTextFromDataforseoScraper(rawOutput: any): string {
 		const result = rawOutput?.tasks?.[0]?.result?.[0];
 		const markdown = result?.markdown;
 		if (typeof markdown === "string" && markdown.trim()) return markdown;
-		// Older or partial responses may only populate the per-item blocks.
+		// Older or partial responses may only populate the per-item blocks. They
+		// are separate markdown blocks, so they are joined by a blank line — a
+		// single newline would run a table's header into the paragraph above it
+		// and stop the whole block from parsing.
 		const texts: string[] = [];
 		for (const item of result?.items ?? []) {
 			if (typeof item?.markdown === "string" && item.markdown.trim()) texts.push(item.markdown.trim());
 		}
-		if (texts.length) return texts.join("\n");
+		if (texts.length) return texts.join("\n\n");
 		return "No text content found in DataForSEO Scraper output.";
 	} catch (error) {
 		console.error("Error extracting text from DataForSEO Scraper output:", error);
@@ -260,7 +263,10 @@ function extractBrightdataAiOverviewText(record: any): string | null {
 		if (!Array.isArray(aio[listKey])) continue;
 		const snippets: string[] = [];
 		collectAioSnippets(aio[listKey], snippets);
-		if (snippets.length) return snippets.join("\n");
+		// Each snippet is its own block in the overview, so they are separated by
+		// a blank line; a single newline is a markdown soft break and would render
+		// the whole overview as one run-on paragraph.
+		if (snippets.length) return snippets.join("\n\n");
 	}
 	return null;
 }

--- a/packages/lib/src/text-extraction.ts
+++ b/packages/lib/src/text-extraction.ts
@@ -131,9 +131,9 @@ export function extractTextFromDataforseoScraper(rawOutput: any): string {
 		const markdown = result?.markdown;
 		if (typeof markdown === "string" && markdown.trim()) return markdown;
 		// Older or partial responses may only populate the per-item blocks. They
-		// are separate markdown blocks, so they are joined by a blank line — a
-		// single newline would run a table's header into the paragraph above it
-		// and stop the whole block from parsing.
+		// are separate markdown blocks, so they are joined by a blank line; a
+		// single newline is a soft break, which would render consecutive blocks
+		// as one run-on paragraph.
 		const texts: string[] = [];
 		for (const item of result?.items ?? []) {
 			if (typeof item?.markdown === "string" && item.markdown.trim()) texts.push(item.markdown.trim());
@@ -357,7 +357,9 @@ export function extractTextFromCloro(rawOutput: any): string {
 	try {
 		const answer = cloroAnswer(rawOutput);
 		if (!answer) return "No content in Cloro output.";
-		for (const key of ["text", "markdown"]) {
+		// `markdown` first: the AI Overview task is asked for it explicitly, and
+		// `text` is the same answer with its formatting flattened away.
+		for (const key of ["markdown", "text"]) {
 			if (typeof answer[key] === "string" && answer[key].trim()) return answer[key].trim();
 		}
 		return "No text content found in Cloro output.";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       recharts:
         specifier: ^3.10.1
         version: 3.10.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-is@18.3.1)(react@19.2.8)(redux@5.0.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1(supports-color@7.2.0)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3


### PR DESCRIPTION
Answer bodies on the prompt detail page were rendering markdown badly enough to be unreadable — most visibly the comparison tables models emit for "best X" prompts, which arrived as a run of literal `|` characters.

Reproduced on the demo instance: I pulled the stored `rawOutput` for all 6 prompts (90 runs) and **83 of the 90 contain a markdown table**. None of them rendered as one.

## What was wrong

1. **`remark-gfm` was never enabled.** `$promptId.tsx` rendered `<ReactMarkdown>` with no plugins, so GFM tables, strikethrough, and autolinks fell through as text.
2. **Data-URI favicons rendered as broken images.** Google AI Mode inlines source favicons as `data:image/png;base64,…` — 260 across the demo runs. react-markdown's default `urlTransform` only allows `http/https/mailto/tel`, so every one became `<img src="">`.
3. **The remaining 235 favicons rendered at full 128px**, breaking each answer into a column of logos, and source links navigated the dashboard away to third-party pages.
4. **Cloro dropped markdown entirely.** `extractTextFromCloro` read `["text", "markdown"]` — the flattened field first. The Google AI Overview task *asks Cloro for markdown explicitly* (`include: { aioverview: { markdown: true } }`) and then read the plain version beside it. Same bug #223 fixed for BrightData, on the provider Elmo Cloud runs on.
5. **Two extractors glued separate blocks with a single newline** (`\n` is a soft break), rendering consecutive paragraphs as one run-on: BrightData's AI Overview snippet tree and DataForSEO's per-item scraper blocks. Oxylabs already used a blank line.

Not a regression — #223 fixed which *field* got read and it's still working; nobody ever fixed the parser. Tables were broken before that change and after it.

## What this does

A `ResponseMarkdown` component that turns GFM on, keeps favicons at text height, opens source links in a new tab, lets wide tables scroll inside the answer box, and widens image sources to `data:image/*`. Plus the Cloro field order and the two block joins.

The `\n` joins in the OpenAI, Anthropic, Mistral, OpenRouter, and DataForSEO LLM Responses paths are **left alone deliberately** — those concatenate fragments of a single streamed message split around web-search tool calls, where a soft break renders as a space and a blank line would inject paragraph breaks mid-sentence.

## Security

Answer bodies are attacker-reachable: anyone who gets a poisoned page cited by an answer engine picks part of this markdown. The boundary holds, and is now asserted rather than assumed:

| Input | Result |
|---|---|
| `<script>`, `<img onerror>`, `<iframe>` | escaped to text (no `rehype-raw`) |
| `[x](javascript:…)`, `[x](data:text/html;…)` | `href=""` |
| `![](data:text/html;…)` | dropped |
| GFM autolinks | only `http://` / `https://` |

Only `img src` was widened; hrefs keep react-markdown's stock scheme allowlist, consistent with 468c1c8. SVG via `<img>` runs in the browser's secure static mode, and the app's CSP already declares `img-src 'self' data: https:`. No new network egress — the remote favicons were already being fetched. `pnpm audit --prod` is unchanged (7 pre-existing advisories, none from remark-gfm or the micromark/mdast GFM packages, which were already in the store via `apps/www`).

## Tests

- `response-markdown.test.tsx` — 18 cases covering all 9 providers end-to-end, extraction through render, plus the legacy dispatch path where `provider` is null.
- `response-markdown.stories.tsx` — 3 stories: a real-shaped ChatGPT answer, wide content, and hostile content.

Every guard verified to bite by breaking the code: removing `remarkGfm` fails the table assertion, loosening the regex to `^data:` fails the hostile-content story, reverting the Cloro order and the blank-line join each fail their matrix case.

## Verifying by hand

The demo has BrightData data only, so Cloro, Oxylabs, DataForSEO and Olostep are covered against shapes derived from their own test fixtures rather than live traffic. Worth a look at a real Cloro AI Overview run on cloud before release.
