### PR TITLE
raise the publishing bar for daily blog drafts

### DIFF
--- a/.github/workflows/daily-blog-draft.yaml
+++ b/.github/workflows/daily-blog-draft.yaml
@@ -51,6 +51,16 @@ jobs:
       - name: Log discovered candidates
         run: cat .agents/blog-candidates.json
 
+      - name: Collect previously rejected topics
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr list --state closed --search "daily blog post" --limit 60 \
+            --json title,mergedAt,files \
+            --jq '.[] | select(.mergedAt == null) | .files[].path' \
+            | sort -u > .agents/rejected-topics.txt
+          cat .agents/rejected-topics.txt
+
       # Reviewed 2026-07-24. Keep this SHA pinned and review upstream changes
       # before updating it; these files become instructions for the writing agent.
       - name: Checkout pinned marketing skills
@@ -87,9 +97,19 @@ jobs:
           prompt: |
             Use /content-strategy, /ai-seo, and /copywriting.
 
-            Read .agents/blog-candidates.json. List the posts in packages/docs/content/blog/ and read relevant posts as needed.
+            Read .agents/blog-candidates.json. List the posts in packages/docs/content/blog/ and read relevant posts as needed. Read .agents/rejected-topics.txt — those drafts were reviewed and turned down; do not propose the same topic again.
 
-            Decide whether the recent research warrants one new post, one useful refresh of an existing post, or no change. Do not duplicate existing coverage. Verify claims with primary sources using WebSearch and WebFetch.
+            Start from a question an in-house marketing, SEO, or growth team is already asking — not from a news item. The candidates are evidence for answering such a question, not the subject. If today's research updates an answer we have already published, refresh that post instead of writing a new one.
+
+            Verify every claim against the primary source with WebSearch and WebFetch. Trade-press coverage points at a source; it is never the source. If you cannot reach the original study, paper, filing, or documentation, drop the topic.
+
+            Publish a new post only if all of these hold:
+            - The title is a question or claim a reader would search for, and the slug reads as an evergreen topic rather than an event or a vendor's product name.
+            - Either three or more independent datasets bear on the question — reconciled, with disagreements explained — or the single source is a preprint, peer-reviewed paper, or first-party dataset large enough to carry a post alone. One SEO or AEO vendor's study is not enough by itself.
+            - The post adds something the sources do not: a number from our own tracking, a reconciliation of conflicting figures, a limitation the source glosses over, or a decision rule the reader can apply. Restating findings and appending takeaways does not count.
+            - The subject is a brand's presence in AI answers. Skip local-business SEO, paid-media mechanics, and arguments about whether AI visibility measurement is a legitimate category.
+
+            Never build a post around a competitor's study, index, or survey. Citing one among several corroborating sources is fine; making it the spine is not.
 
             Blog conventions:
             - Only add or edit one MDX file in packages/docs/content/blog/.


### PR DESCRIPTION
8 of the 23 daily blog drafts since the workflow started were closed unmerged, and they share a shape: a summary of one vendor's study, sometimes read through trade-press coverage rather than the study itself.

| Closed | Basis |
|---|---|
| #520 `recognition-gap` | Victorious Q2 report — one vendor study |
| #526 `iab-ai-visibility-framework` | IAB doc, read through PPC Land's summary |
| #563 `ads-and-ai-citations` | SE Ranking study — one vendor study |
| #572 `is-ai-visibility-tracking-reliable` | Two practitioner blog posts |
| #582 `ai-visibility-attribution` | Scrunch survey — a competitor's |
| #595 `ai-visibility-index` | Fractl index, never linked; only SEL + MarTech |
| #605 / #608 `local-ai-citations` | Steady Demand study, resubmitted the day after rejection |

Merged drafts instead reconcile three or more conflicting datasets (#519, #521, #523, #524, #546, #549, #550), translate an arXiv paper (#580, #591), report a dataset large enough to stand alone (#602), give an opinionated how-to (#588), refresh an existing post (#558, #587, #590), or work from a primary standards document (#533).

Three pairs make the difference concrete:

- **#526 closed → #533 merged**, same IAB document, one day apart. #526 says "as summarised by PPC Land from the document"; #533 works from the IAB release.
- **#572 closed → #588 merged**, both built on the AgencyAnalytics benchmark. #572 rates six objections to the AEO category; #588 tells an agency what report to build.
- **#605 closed → #608 closed.** The agent had no view of rejections and re-pitched the same study.

The slug is the clearest tell. Merged: `how-long-to-get-cited-by-ai`, `rankings-and-ai-citations`, `ghost-citations`, `geo-detection`. Closed: `ai-visibility-index`, `iab-ai-visibility-framework`, `local-ai-citations`, `recognition-gap` — events and vendors' product names.

## Changes

The prompt previously asked whether "the recent research warrants one new post," which makes the news item the unit of work. It now starts from a question a marketing, SEO, or growth team is already asking and treats the candidates as evidence, with four conditions on publishing: an evergreen title and slug, corroboration across three or more independent datasets unless the single source is paper-grade, a contribution the sources don't make themselves, and an on-audience subject. Building a post around a competitor's study, index, or survey is ruled out.

A new step collects the closed-unmerged draft slugs into `.agents/rejected-topics.txt` before the agent runs, so a turned-down topic isn't pitched again the next day.

Applied to the last 12 days, this would have blocked #563, #582, #595, #605, and #608 outright, and pushed #526 and #572 toward the shapes that later merged as #533 and #588.

No changeset — this is CI-only.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/eda12c9b-a73d-434a-811f-b1323a45b11c)
