### PR TITLE
Migrate the shared UI components from Radix UI to Base UI

### DIFF
--- a/.changeset/base-ui-primitives.md
+++ b/.changeset/base-ui-primitives.md
@@ -1,0 +1,9 @@
+---
+"@workspace/ui": patch
+"@workspace/web": patch
+"@workspace/www": patch
+"@workspace/docs": patch
+"@workspace/whitelabel": patch
+---
+
+Rebuilt the interface on Base UI, so menus, dialogs, tooltips and form controls behave more consistently across keyboard and assistive tech.

--- a/.changeset/fresh-shadcn-primitives.md
+++ b/.changeset/fresh-shadcn-primitives.md
@@ -1,8 +1,0 @@
----
-"@workspace/web": patch
-"@workspace/docs": patch
-"@workspace/whitelabel": patch
-"@workspace/ui": patch
----
-
-Use consistent, accessible loading indicators, search fields, and keyboard hints across the product.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev --port 3000",
-		"build": "vite build && node ../../scripts/check-server-bundle.mjs .output/server",
+		"build": "vite build && node ../../scripts/check-server-bundle.mjs .",
 		"start": "node .output/server/index.mjs",
 		"preview": "vite preview",
 		"test": "vitest run --project=unit",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
 		"storybook:build": "storybook build"
 	},
 	"dependencies": {
+		"@base-ui/react": "^1.7.0",
 		"@fontsource/geist-sans": "^5.3.0",
 		"@fontsource/titan-one": "^5.3.0",
 		"@resvg/resvg-js": "^2.6.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev --port 3000",
-		"build": "vite build",
+		"build": "vite build && node ../../scripts/check-server-bundle.mjs .output/server",
 		"start": "node .output/server/index.mjs",
 		"preview": "vite preview",
 		"test": "vitest run --project=unit",

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -211,10 +211,8 @@ export function AppSidebar({
 						{scope === "account" ? (
 							<div className="flex items-center gap-2 p-2">{brandmark}</div>
 						) : (
-							<SidebarMenuButton size="lg" asChild>
-								<Link to="/app" onClick={() => setOpenMobile(false)}>
-									{brandmark}
-								</Link>
+							<SidebarMenuButton size="lg" render={<Link to="/app" onClick={() => setOpenMobile(false)} />}>
+								{brandmark}
 							</SidebarMenuButton>
 						)}
 					</SidebarMenuItem>

--- a/apps/web/src/components/citations/content-gaps-card.tsx
+++ b/apps/web/src/components/citations/content-gaps-card.tsx
@@ -22,9 +22,7 @@ export function ContentGapsCard({
 				<CardTitle className="flex items-center gap-1.5">
 					Content Gaps
 					<Tooltip>
-						<TooltipTrigger asChild>
-							<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-						</TooltipTrigger>
+						<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 						<TooltipContent className="max-w-xs text-sm font-normal">
 							Prompts where competitors are cited but your brand isn&apos;t — opportunities to improve your citation
 							presence.

--- a/apps/web/src/components/citations/google-shopping-card.tsx
+++ b/apps/web/src/components/citations/google-shopping-card.tsx
@@ -70,9 +70,7 @@ export function GoogleShoppingCard({ googleModule, brandId }: { googleModule: Go
 				<CardTitle className="flex items-center gap-1.5">
 					Google Shopping
 					<Tooltip>
-						<TooltipTrigger asChild>
-							<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-						</TooltipTrigger>
+						<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 						<TooltipContent className="max-w-xs text-sm font-normal">
 							Product cards Google AI Mode showed when answering your prompts. The number next to each is how many times
 							that card appeared across results (card inclusions, not unique products). Kept separate from the citation

--- a/apps/web/src/components/citations/recent-changes-card.tsx
+++ b/apps/web/src/components/citations/recent-changes-card.tsx
@@ -53,9 +53,7 @@ export function RecentChangesCard({
 				<CardTitle className="flex items-center gap-1.5">
 					Recent Changes
 					<Tooltip>
-						<TooltipTrigger asChild>
-							<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-						</TooltipTrigger>
+						<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 						<TooltipContent className="max-w-xs text-sm font-normal">
 							Compares this {formatPeriodLabel(days)} with the {formatPeriodLabel(days)} before it. Shows new and
 							dropped pages, title changes, and new and dropped domains.

--- a/apps/web/src/components/citations/reddit-card.tsx
+++ b/apps/web/src/components/citations/reddit-card.tsx
@@ -80,9 +80,7 @@ export function RedditCard({ subreddits }: { subreddits: ReturnType<typeof useSu
 				<CardTitle className="flex items-center gap-1.5">
 					Reddit
 					<Tooltip>
-						<TooltipTrigger asChild>
-							<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-						</TooltipTrigger>
+						<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 						<TooltipContent className="max-w-xs text-sm font-normal">
 							Reddit communities most frequently cited by AI models. Extracted from all reddit.com URLs in your citation
 							data.

--- a/apps/web/src/components/citations/stats-cards.tsx
+++ b/apps/web/src/components/citations/stats-cards.tsx
@@ -9,9 +9,7 @@ function StatCard({ title, tooltip, value }: { title: string; tooltip: React.Rea
 				<CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
 					{title}
 					<Tooltip>
-						<TooltipTrigger asChild>
-							<IconInfoCircle className="h-3.5 w-3.5 cursor-help" />
-						</TooltipTrigger>
+						<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 cursor-help" />} />
 						<TooltipContent className="max-w-xs text-sm font-normal">{tooltip}</TooltipContent>
 					</Tooltip>
 				</CardTitle>

--- a/apps/web/src/components/citations/top-domains-card.tsx
+++ b/apps/web/src/components/citations/top-domains-card.tsx
@@ -52,9 +52,7 @@ export function TopDomainsCard({
 						<CardTitle className="flex items-center gap-1.5">
 							Top Cited Domains
 							<Tooltip>
-								<TooltipTrigger asChild>
-									<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-								</TooltipTrigger>
+								<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 								<TooltipContent className="max-w-xs text-sm font-normal">
 									The most frequently cited domains across all prompt evaluations. Each domain is colored by its
 									category (brand, competitor, etc.).

--- a/apps/web/src/components/citations/top-urls-card.tsx
+++ b/apps/web/src/components/citations/top-urls-card.tsx
@@ -67,9 +67,7 @@ export function TopUrlsCard({
 						<CardTitle className="flex items-center gap-1.5">
 							Top Cited URLs
 							<Tooltip>
-								<TooltipTrigger asChild>
-									<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-								</TooltipTrigger>
+								<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 								<TooltipContent className="max-w-xs text-sm font-normal">
 									<p className="mb-2">
 										The specific pages most frequently cited by AI models. Filter by category to focus on brand,
@@ -183,10 +181,8 @@ export function TopUrlsCard({
 								<div className="flex items-center gap-3 shrink-0 pt-0.5">
 									{citation.avgPosition != null && (
 										<Tooltip>
-											<TooltipTrigger asChild>
-												<span className="text-[11px] text-muted-foreground tabular-nums">
-													avg {citation.avgPosition.toFixed(1)}
-												</span>
+											<TooltipTrigger render={<span className="text-[11px] text-muted-foreground tabular-nums" />}>
+												avg {citation.avgPosition.toFixed(1)}
 											</TooltipTrigger>
 											<TooltipContent className="text-xs">
 												Average citation position (lower = cited earlier in the response)
@@ -194,10 +190,10 @@ export function TopUrlsCard({
 										</Tooltip>
 									)}
 									<Tooltip>
-										<TooltipTrigger asChild>
-											<span className="text-sm font-semibold tabular-nums min-w-[2rem] text-right">
-												{citation.count.toLocaleString()}
-											</span>
+										<TooltipTrigger
+											render={<span className="text-sm font-semibold tabular-nums min-w-[2rem] text-right" />}
+										>
+											{citation.count.toLocaleString()}
 										</TooltipTrigger>
 										<TooltipContent className="text-xs">
 											Total times this URL was cited across all prompt evaluations

--- a/apps/web/src/components/citations/track-domain-popover.tsx
+++ b/apps/web/src/components/citations/track-domain-popover.tsx
@@ -86,14 +86,16 @@ export function TrackDomainPopover({
 
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
-			<PopoverTrigger asChild>
-				<button
-					type="button"
-					className="shrink-0 p-1 rounded hover:bg-muted cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
-					title={`Track ${domain}`}
-				>
-					<IconPlus className="h-3.5 w-3.5" />
-				</button>
+			<PopoverTrigger
+				render={
+					<button
+						type="button"
+						className="shrink-0 p-1 rounded hover:bg-muted cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
+						title={`Track ${domain}`}
+					/>
+				}
+			>
+				<IconPlus className="h-3.5 w-3.5" />
 			</PopoverTrigger>
 			<PopoverContent className="w-72 p-3" align="end">
 				<div className="space-y-3">
@@ -107,9 +109,7 @@ export function TrackDomainPopover({
 						<div className="flex items-center gap-1">
 							<p className="text-[11px] text-muted-foreground">Add as brand domain</p>
 							<Tooltip>
-								<TooltipTrigger asChild>
-									<IconInfoCircle className="h-3 w-3 text-muted-foreground cursor-help" />
-								</TooltipTrigger>
+								<TooltipTrigger render={<IconInfoCircle className="h-3 w-3 text-muted-foreground cursor-help" />} />
 								<TooltipContent className="max-w-xs text-xs font-normal">
 									Applies <strong>retroactively</strong> &mdash; all existing and future citations from this domain will
 									be classified as your brand.
@@ -131,9 +131,7 @@ export function TrackDomainPopover({
 							<div className="flex items-center gap-1">
 								<p className="text-[11px] text-muted-foreground">Add to existing competitor</p>
 								<Tooltip>
-									<TooltipTrigger asChild>
-										<IconInfoCircle className="h-3 w-3 text-muted-foreground cursor-help" />
-									</TooltipTrigger>
+									<TooltipTrigger render={<IconInfoCircle className="h-3 w-3 text-muted-foreground cursor-help" />} />
 									<TooltipContent className="max-w-xs text-xs font-normal">
 										Applies <strong>retroactively</strong> &mdash; all existing and future citations from this domain
 										will be classified under the selected competitor.

--- a/apps/web/src/components/citations/trend-area-chart.tsx
+++ b/apps/web/src/components/citations/trend-area-chart.tsx
@@ -35,9 +35,7 @@ export function TrendAreaChart({
 				<CardTitle className="text-sm font-medium flex items-center gap-1.5">
 					{title}
 					<Tooltip>
-						<TooltipTrigger asChild>
-							<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-						</TooltipTrigger>
+						<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 						<TooltipContent className="max-w-xs text-sm font-normal">{tooltip}</TooltipContent>
 					</Tooltip>
 				</CardTitle>

--- a/apps/web/src/components/col-head.tsx
+++ b/apps/web/src/components/col-head.tsx
@@ -7,10 +7,8 @@ export function ColHead({ label, tip, right }: { label: string; tip: string; rig
 		<span className={`inline-flex items-center gap-1 ${right ? "w-full justify-end" : ""}`}>
 			{label}
 			<Tooltip>
-				<TooltipTrigger asChild>
-					<span className="cursor-help text-muted-foreground/60">
-						<IconInfoCircle className="size-3.5" />
-					</span>
+				<TooltipTrigger render={<span className="cursor-help text-muted-foreground/60" />}>
+					<IconInfoCircle className="size-3.5" />
 				</TooltipTrigger>
 				<TooltipContent className="max-w-[240px] text-xs font-normal">{tip}</TooltipContent>
 			</Tooltip>

--- a/apps/web/src/components/competitors-editor.tsx
+++ b/apps/web/src/components/competitors-editor.tsx
@@ -103,9 +103,9 @@ export function CompetitorsEditor({ competitors, onChange, disabled }: Competito
 								<Label className="text-xs font-medium flex items-center gap-1.5">
 									Name
 									<Tooltip>
-										<TooltipTrigger asChild>
-											<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-										</TooltipTrigger>
+										<TooltipTrigger
+											render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />}
+										/>
 										<TooltipContent className="max-w-xs text-xs font-normal">
 											The primary name used to detect this competitor in AI responses. Mention detection applies to{" "}
 											<strong>future</strong> prompt runs only.
@@ -126,9 +126,9 @@ export function CompetitorsEditor({ competitors, onChange, disabled }: Competito
 								<Label className="text-xs font-medium flex items-center gap-1.5">
 									Domains
 									<Tooltip>
-										<TooltipTrigger asChild>
-											<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-										</TooltipTrigger>
+										<TooltipTrigger
+											render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />}
+										/>
 										<TooltipContent className="max-w-xs text-xs font-normal">
 											All domains owned by this competitor. Citation categorization updates retroactively &mdash;
 											existing citations from these domains will immediately be classified as &quot;competitor&quot;.
@@ -150,9 +150,9 @@ export function CompetitorsEditor({ competitors, onChange, disabled }: Competito
 								<Label className="text-xs font-medium flex items-center gap-1.5">
 									Aliases
 									<Tooltip>
-										<TooltipTrigger asChild>
-											<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-										</TooltipTrigger>
+										<TooltipTrigger
+											render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />}
+										/>
 										<TooltipContent className="max-w-xs text-xs font-normal">
 											Alternative names for this competitor (sub-brands, product names, abbreviations). Used for mention
 											detection in <strong>future</strong> prompt runs only &mdash; does not apply retroactively.

--- a/apps/web/src/components/demo-mode-pill.tsx
+++ b/apps/web/src/components/demo-mode-pill.tsx
@@ -11,11 +11,13 @@ export function DemoModePill() {
 
 	return (
 		<Tooltip>
-			<TooltipTrigger asChild>
-				<span className="inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-700 dark:text-amber-400">
-					<IconInfoCircle className="size-3" />
-					Demo
-				</span>
+			<TooltipTrigger
+				render={
+					<span className="inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-700 dark:text-amber-400" />
+				}
+			>
+				<IconInfoCircle className="size-3" />
+				Demo
 			</TooltipTrigger>
 			<TooltipContent>This is a read-only demo. Any edits will fail.</TooltipContent>
 		</Tooltip>

--- a/apps/web/src/components/fanout-sections.tsx
+++ b/apps/web/src/components/fanout-sections.tsx
@@ -28,10 +28,8 @@ export const FANOUT_PURPLE = "#8b5cf6";
 export function InfoTip({ children }: { children: React.ReactNode }) {
 	return (
 		<Tooltip>
-			<TooltipTrigger asChild>
-				<span className="cursor-help">
-					<IconInfoCircle className="text-muted-foreground/60 size-3.5" />
-				</span>
+			<TooltipTrigger render={<span className="cursor-help" />}>
+				<IconInfoCircle className="text-muted-foreground/60 size-3.5" />
 			</TooltipTrigger>
 			<TooltipContent className="max-w-xs text-sm font-normal">{children}</TooltipContent>
 		</Tooltip>

--- a/apps/web/src/components/filter-bar.tsx
+++ b/apps/web/src/components/filter-bar.tsx
@@ -11,12 +11,7 @@ import {
 	DropdownMenuRadioItem,
 	DropdownMenuTrigger,
 } from "@workspace/ui/components/dropdown-menu";
-import {
-	InputGroup,
-	InputGroupAddon,
-	InputGroupButton,
-	InputGroupInput,
-} from "@workspace/ui/components/input-group";
+import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "@workspace/ui/components/input-group";
 import { Popover, PopoverContent, PopoverTrigger } from "@workspace/ui/components/popover";
 import { ChevronDown, Clock, Search, Tag as TagIcon, X } from "lucide-react";
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
@@ -83,9 +78,9 @@ type FilterTriggerButtonProps = {
 	badgeCount?: number;
 } & React.ComponentProps<"button">;
 
-// Props forward to the underlying Button so `<DropdownMenuTrigger asChild>` /
-// `<PopoverTrigger asChild>` can hand their ref + data-state directly to the
-// button element (wrapping in a div would make Slot target the div instead).
+// Props forward to the underlying Button so a trigger's `render` prop can hand
+// its ref and state straight to the button element (wrapping in a div would
+// leave the trigger targeting the div instead).
 // Exported so page-specific bar controls (e.g. the prompts sort dropdown)
 // share the same trigger look without re-implementing it.
 export function FilterTriggerButton({
@@ -145,9 +140,11 @@ export function ModelDropdown({ trackedTargets }: { trackedTargets: TrackedTarge
 	const groups = groupTrackedTargets(trackedTargets);
 	return (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<FilterTriggerButton icon={iconForModel(selected)} label={labelForModel(selected)} active={isFiltered} />
-			</DropdownMenuTrigger>
+			<DropdownMenuTrigger
+				render={
+					<FilterTriggerButton icon={iconForModel(selected)} label={labelForModel(selected)} active={isFiltered} />
+				}
+			/>
 			<DropdownMenuContent align="start" className="w-56">
 				<DropdownMenuRadioGroup value={selected} onValueChange={handleChange}>
 					<DropdownMenuRadioItem value={ALL_MODELS_VALUE} className="cursor-pointer gap-2">
@@ -156,9 +153,7 @@ export function ModelDropdown({ trackedTargets }: { trackedTargets: TrackedTarge
 					</DropdownMenuRadioItem>
 					{groups.map((group) => (
 						<DropdownMenuGroup key={group.tier}>
-							<DropdownMenuLabel className="text-muted-foreground text-xs font-medium">
-								{group.label}
-							</DropdownMenuLabel>
+							<DropdownMenuLabel className="text-muted-foreground text-xs font-medium">{group.label}</DropdownMenuLabel>
 							{group.values.map((value) => (
 								<DropdownMenuRadioItem key={value} value={value} className="cursor-pointer gap-2">
 									{iconForModel(value)}
@@ -190,9 +185,9 @@ export function LookbackDropdown() {
 
 	return (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<FilterTriggerButton icon={<Clock className="size-3.5" />} label={getLookbackLabel(selected)} />
-			</DropdownMenuTrigger>
+			<DropdownMenuTrigger
+				render={<FilterTriggerButton icon={<Clock className="size-3.5" />} label={getLookbackLabel(selected)} />}
+			/>
 			<DropdownMenuContent align="start" className="w-48">
 				<DropdownMenuRadioGroup value={selected} onValueChange={(v) => handleChange(v as LookbackPeriod)}>
 					{LOOKBACK_OPTIONS.map((opt) => (
@@ -228,15 +223,17 @@ export function TagsDropdown({ availableTags }: { availableTags: readonly string
 
 	return (
 		<Popover open={open} onOpenChange={setOpen} modal={false}>
-			<PopoverTrigger asChild>
-				<FilterTriggerButton
-					icon={<TagIcon className="size-3.5" />}
-					label="Tags"
-					active={selected.length > 0}
-					badgeCount={selected.length > 0 ? selected.length : undefined}
-				/>
-			</PopoverTrigger>
-			<PopoverContent align="start" className="w-64 p-0" onOpenAutoFocus={(e) => e.preventDefault()}>
+			<PopoverTrigger
+				render={
+					<FilterTriggerButton
+						icon={<TagIcon className="size-3.5" />}
+						label="Tags"
+						active={selected.length > 0}
+						badgeCount={selected.length > 0 ? selected.length : undefined}
+					/>
+				}
+			/>
+			<PopoverContent align="start" className="w-64 p-0" initialFocus={false}>
 				<div className="flex items-center justify-between px-3 h-10 border-b">
 					<span className="font-medium text-sm">Tags</span>
 					{selected.length > 0 && (

--- a/apps/web/src/components/full-page-card.tsx
+++ b/apps/web/src/components/full-page-card.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
 import { Card, CardContent, CardHeader, CardTitle } from "@workspace/ui/components/card";
-import { Button } from "@workspace/ui/components/button";
+import { buttonVariants } from "@workspace/ui/components/button";
 import { Separator } from "@workspace/ui/components/separator";
 import { Logo } from "@/components/logo";
 
@@ -52,9 +52,9 @@ export default function FullPageCard({
 					<div className="flex justify-center">{customBackButton}</div>
 				) : showBackButton ? (
 					<div className="flex justify-center">
-						<Button variant="outline" size="sm" asChild>
-							<Link to={backButtonHref}>{backButtonText}</Link>
-						</Button>
+						<Link to={backButtonHref} className={buttonVariants({ variant: "outline", size: "sm" })}>
+							{backButtonText}
+						</Link>
 					</div>
 				) : null}
 			</div>

--- a/apps/web/src/components/history-button.tsx
+++ b/apps/web/src/components/history-button.tsx
@@ -1,5 +1,5 @@
 import { GoStack } from "react-icons/go";
-import { Button } from "@workspace/ui/components/button";
+import { buttonVariants } from "@workspace/ui/components/button";
 import { Link } from "@tanstack/react-router";
 
 interface HistoryButtonProps {
@@ -16,11 +16,18 @@ export function HistoryButton({ brandId, promptName, promptId, tab }: HistoryBut
 	}
 
 	return (
-		<Button size="sm" variant="secondary" className="text-xs cursor-pointer h-6 flex items-center px-2" asChild>
-			<Link to="/app/$brand/prompts/$promptId" params={{ brand: brandId, promptId }} search={tab ? { tab } : undefined}>
-				<GoStack className="size-3 mr-0.5" />
-				<span className="text-xs font-normal">View Details</span>
-			</Link>
-		</Button>
+		<Link
+			to="/app/$brand/prompts/$promptId"
+			params={{ brand: brandId, promptId }}
+			search={tab ? { tab } : undefined}
+			className={buttonVariants({
+				variant: "secondary",
+				size: "sm",
+				className: "text-xs cursor-pointer h-6 flex items-center px-2",
+			})}
+		>
+			<GoStack className="size-3 mr-0.5" />
+			<span className="text-xs font-normal">View Details</span>
+		</Link>
 	);
 }

--- a/apps/web/src/components/nav-app-info.tsx
+++ b/apps/web/src/components/nav-app-info.tsx
@@ -25,18 +25,16 @@ export function NavAppInfo() {
 			</a>
 			<div className="flex items-center gap-1">
 				<Tooltip>
-					<TooltipTrigger asChild>
-						<a href="https://www.elmohq.com/" target="_blank" className={linkClass}>
-							<IconWorld className="size-4" />
-						</a>
+					<TooltipTrigger render={<a href="https://www.elmohq.com/" target="_blank" className={linkClass} />}>
+						<IconWorld className="size-4" />
 					</TooltipTrigger>
 					<TooltipContent>elmohq.com</TooltipContent>
 				</Tooltip>
 				<Tooltip>
-					<TooltipTrigger asChild>
-						<a href="https://github.com/elmohq/elmo" target="_blank" rel="noreferrer" className={linkClass}>
-							<IconBrandGithub className="size-4" />
-						</a>
+					<TooltipTrigger
+						render={<a href="https://github.com/elmohq/elmo" target="_blank" rel="noreferrer" className={linkClass} />}
+					>
+						<IconBrandGithub className="size-4" />
 					</TooltipTrigger>
 					<TooltipContent>View on GitHub</TooltipContent>
 				</Tooltip>

--- a/apps/web/src/components/nav-main.tsx
+++ b/apps/web/src/components/nav-main.tsx
@@ -49,11 +49,13 @@ export function NavMain({ groups }: { groups: NavGroup[] }) {
 					<SidebarMenu>
 						{group.items.map((item) => (
 							<SidebarMenuItem key={item.title}>
-								<SidebarMenuButton asChild tooltip={item.title} isActive={isActive(item.url, item.absolute)}>
-									<Link to={getHref(item.url, item.absolute)} onClick={() => setOpenMobile(false)}>
-										{item.icon && <item.icon />}
-										<span>{item.title}</span>
-									</Link>
+								<SidebarMenuButton
+									render={<Link to={getHref(item.url, item.absolute)} onClick={() => setOpenMobile(false)} />}
+									tooltip={item.title}
+									isActive={isActive(item.url, item.absolute)}
+								>
+									{item.icon && <item.icon />}
+									<span>{item.title}</span>
 								</SidebarMenuButton>
 							</SidebarMenuItem>
 						))}

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -40,44 +40,49 @@ export function NavUser({ canSwitchBrand = true }: { canSwitchBrand?: boolean } 
 		<SidebarMenu>
 			<SidebarMenuItem>
 				<DropdownMenu>
-					<DropdownMenuTrigger asChild>
-						<SidebarMenuButton
-							size="lg"
-							className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground cursor-pointer"
-						>
-							<Avatar className="h-8 w-8 rounded-lg">
-								<AvatarImage src={user.picture} alt={user.name} />
-								<AvatarFallback className="rounded-lg bg-primary/10 text-primary">
-									<IconUser className="size-4" />
-								</AvatarFallback>
-							</Avatar>
-							<div className="grid flex-1 text-left text-sm leading-tight">
-								<span className="truncate font-medium">{user.name}</span>
-								<span className="truncate text-xs">{isNameEmailSame ? "Your Account" : user.email}</span>
-							</div>
-							<IconSelector className="ml-auto size-4" />
-						</SidebarMenuButton>
+					<DropdownMenuTrigger
+						render={
+							<SidebarMenuButton
+								size="lg"
+								className="data-popup-open:bg-sidebar-accent data-popup-open:text-sidebar-accent-foreground cursor-pointer"
+							/>
+						}
+					>
+						<Avatar className="h-8 w-8 rounded-lg">
+							<AvatarImage src={user.picture} alt={user.name} />
+							<AvatarFallback className="rounded-lg bg-primary/10 text-primary">
+								<IconUser className="size-4" />
+							</AvatarFallback>
+						</Avatar>
+						<div className="grid flex-1 text-left text-sm leading-tight">
+							<span className="truncate font-medium">{user.name}</span>
+							<span className="truncate text-xs">{isNameEmailSame ? "Your Account" : user.email}</span>
+						</div>
+						<IconSelector className="ml-auto size-4" />
 					</DropdownMenuTrigger>
 					<DropdownMenuContent
-						className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg"
+						className="w-(--anchor-width) min-w-56 rounded-lg"
 						side={isMobile ? "bottom" : "right"}
 						align="end"
 						sideOffset={4}
 					>
-						<DropdownMenuLabel className="p-0 font-normal">
-							<div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-								<Avatar className="h-8 w-8 rounded-lg">
-									<AvatarImage src={user.picture} alt={user.name} />
-									<AvatarFallback className="rounded-lg bg-primary/10 text-primary">
-										<IconUser className="size-4" />
-									</AvatarFallback>
-								</Avatar>
-								<div className="grid flex-1 text-left text-sm leading-tight">
-									<span className="truncate font-medium">{user.name}</span>
-									<span className="truncate text-xs">{isNameEmailSame ? "Your Account" : user.email}</span>
+						{/* Base UI wires the label to its group, so it has to sit inside one. */}
+						<DropdownMenuGroup>
+							<DropdownMenuLabel className="p-0 font-normal">
+								<div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+									<Avatar className="h-8 w-8 rounded-lg">
+										<AvatarImage src={user.picture} alt={user.name} />
+										<AvatarFallback className="rounded-lg bg-primary/10 text-primary">
+											<IconUser className="size-4" />
+										</AvatarFallback>
+									</Avatar>
+									<div className="grid flex-1 text-left text-sm leading-tight">
+										<span className="truncate font-medium">{user.name}</span>
+										<span className="truncate text-xs">{isNameEmailSame ? "Your Account" : user.email}</span>
+									</div>
 								</div>
-							</div>
-						</DropdownMenuLabel>
+							</DropdownMenuLabel>
+						</DropdownMenuGroup>
 						<DropdownMenuSeparator />
 						{/* The group and the rule under it come and go together: a
 						    deployment with no parent dashboard, on a page that cannot
@@ -87,19 +92,21 @@ export function NavUser({ canSwitchBrand = true }: { canSwitchBrand?: boolean } 
 							<>
 								<DropdownMenuGroup>
 									{canSwitchBrand && (
-										<DropdownMenuItem asChild className="cursor-pointer">
-											<Link to="/app" onClick={() => setOpenMobile(false)}>
-												<IconStatusChange />
-												Switch Brand
-											</Link>
+										<DropdownMenuItem
+											render={<Link to="/app" onClick={() => setOpenMobile(false)} />}
+											className="cursor-pointer"
+										>
+											<IconStatusChange />
+											Switch Brand
 										</DropdownMenuItem>
 									)}
 									{parentDashboard && (
-										<DropdownMenuItem asChild className="cursor-pointer">
-											<a href={parentDashboard.url} target="_blank" rel="noreferrer">
-												<IconExternalLink />
-												{parentDashboard.name} Dashboard
-											</a>
+										<DropdownMenuItem
+											render={<a href={parentDashboard.url} target="_blank" rel="noreferrer" />}
+											className="cursor-pointer"
+										>
+											<IconExternalLink />
+											{parentDashboard.name} Dashboard
 										</DropdownMenuItem>
 									)}
 								</DropdownMenuGroup>

--- a/apps/web/src/components/page-header.tsx
+++ b/apps/web/src/components/page-header.tsx
@@ -20,9 +20,7 @@ export function PageHeader({ title, subtitle, infoContent, children }: PageHeade
 					{title}
 					{infoContent && (
 						<Tooltip>
-							<TooltipTrigger asChild>
-								<IconInfoCircle className="h-5 w-5 text-muted-foreground cursor-help" />
-							</TooltipTrigger>
+							<TooltipTrigger render={<IconInfoCircle className="h-5 w-5 text-muted-foreground cursor-help" />} />
 							<TooltipContent className="max-w-xs text-sm font-normal">{infoContent}</TooltipContent>
 						</Tooltip>
 					)}

--- a/apps/web/src/components/progress-bar-chart.tsx
+++ b/apps/web/src/components/progress-bar-chart.tsx
@@ -95,18 +95,20 @@ export function ProgressBarChart({
 							<div className="flex items-center gap-1 min-w-0 flex-1">
 								{item.tooltip ? (
 									<Tooltip>
-										<TooltipTrigger asChild>
-											<span
-												className={cn(
-													"text-sm cursor-default",
-													isHighlighted ? "font-bold" : "font-medium",
-													truncateLabels && "truncate",
-													isClickable && "cursor-pointer hover:underline",
-												)}
-												onClick={item.onClick}
-											>
-												{item.label}
-											</span>
+										<TooltipTrigger
+											render={
+												<span
+													className={cn(
+														"text-sm cursor-default",
+														isHighlighted ? "font-bold" : "font-medium",
+														truncateLabels && "truncate",
+														isClickable && "cursor-pointer hover:underline",
+													)}
+													onClick={item.onClick}
+												/>
+											}
+										>
+											{item.label}
 										</TooltipTrigger>
 										<TooltipContent className="max-w-xs text-xs font-normal">{item.tooltip}</TooltipContent>
 									</Tooltip>

--- a/apps/web/src/components/prompt-order-dropdown.tsx
+++ b/apps/web/src/components/prompt-order-dropdown.tsx
@@ -42,13 +42,15 @@ export function PromptOrderDropdown() {
 
 	return (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<FilterTriggerButton
-					icon={<ArrowUpDown className="size-3.5" />}
-					label={label}
-					active={selected !== DEFAULT_PROMPT_ORDER}
-				/>
-			</DropdownMenuTrigger>
+			<DropdownMenuTrigger
+				render={
+					<FilterTriggerButton
+						icon={<ArrowUpDown className="size-3.5" />}
+						label={label}
+						active={selected !== DEFAULT_PROMPT_ORDER}
+					/>
+				}
+			/>
 			<DropdownMenuContent align="start" className="w-60">
 				<DropdownMenuRadioGroup value={selected} onValueChange={(v) => setOrder(v as PromptOrder)}>
 					{PROMPT_ORDER_OPTIONS.map((o) => (

--- a/apps/web/src/components/prompts-display.tsx
+++ b/apps/web/src/components/prompts-display.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { Card, CardContent, CardFooter, CardHeader } from "@workspace/ui/components/card";
 import { Separator } from "@workspace/ui/components/separator";
-import { Button } from "@workspace/ui/components/button";
+import { buttonVariants } from "@workspace/ui/components/button";
 import { Inbox } from "lucide-react";
 import { IconEditCircle } from "@tabler/icons-react";
 import { usePromptsSummary } from "@/hooks/use-prompts-summary";
@@ -122,12 +122,10 @@ function PromptsContent({ brandId, editLink }: { brandId: string | undefined; ed
 					<div className="text-center py-8 text-muted-foreground">
 						<Inbox className="h-12 w-12 mx-auto mb-4 opacity-50" />
 						<p className="mb-4">No prompts yet.</p>
-						<Button asChild size="sm" className="h-7 flex cursor-pointer">
-							<Link to={editLink}>
-								<IconEditCircle />
-								<span>Edit</span>
-							</Link>
-						</Button>
+						<Link to={editLink} className={buttonVariants({ size: "sm", className: "h-7 flex cursor-pointer" })}>
+							<IconEditCircle />
+							<span>Edit</span>
+						</Link>
 					</div>
 				</div>
 			}

--- a/apps/web/src/components/prompts-list-editor.tsx
+++ b/apps/web/src/components/prompts-list-editor.tsx
@@ -108,26 +108,28 @@ function PremiumModelsField({
 
 	return (
 		<Popover>
-			<PopoverTrigger asChild>
-				<Button
-					type="button"
-					variant="outline"
-					size="sm"
-					disabled={!promptEnabled}
-					className="h-8 w-full justify-center gap-1 px-2"
-					aria-label={`Premium models: ${summary}`}
-				>
-					{selected.length === 0 ? (
-						<span className="text-muted-foreground">{showLabel ? "Premium: none" : "—"}</span>
-					) : (
-						<>
-							{selected.map((model) => (
-								<ModelIcon key={model} iconId={getModelMeta(model).iconId} className="size-3.5" />
-							))}
-							{showLabel && <span className="ml-1 text-xs">{summary}</span>}
-						</>
-					)}
-				</Button>
+			<PopoverTrigger
+				render={
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						disabled={!promptEnabled}
+						className="h-8 w-full justify-center gap-1 px-2"
+						aria-label={`Premium models: ${summary}`}
+					/>
+				}
+			>
+				{selected.length === 0 ? (
+					<span className="text-muted-foreground">{showLabel ? "Premium: none" : "—"}</span>
+				) : (
+					<>
+						{selected.map((model) => (
+							<ModelIcon key={model} iconId={getModelMeta(model).iconId} className="size-3.5" />
+						))}
+						{showLabel && <span className="ml-1 text-xs">{summary}</span>}
+					</>
+				)}
 			</PopoverTrigger>
 			<PopoverContent align="end" className="w-64 space-y-1 p-2">
 				{PREMIUM_MODELS.map((model) => {
@@ -140,7 +142,9 @@ function PremiumModelsField({
 							// Normalized through the catalog on every toggle, because that is
 							// what the server stores — appending in click order instead would
 							// reshuffle the row the moment a save came back.
-							onClick={() => onChange(selectPremiumModels(checked ? selected.filter((m) => m !== model) : [...selected, model]))}
+							onClick={() =>
+								onChange(selectPremiumModels(checked ? selected.filter((m) => m !== model) : [...selected, model]))
+							}
 							className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
 						>
 							<Checkbox checked={checked} disabled={atCapacity && !checked} className="pointer-events-none" />
@@ -340,9 +344,7 @@ export function PromptsListEditor({
 				<div className="flex items-center gap-1 min-w-0">
 					Prompt Text
 					<Tooltip>
-						<TooltipTrigger asChild>
-							<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-						</TooltipTrigger>
+						<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 						<TooltipContent>
 							<p className="max-w-xs">The question or query that will be sent to AI models for evaluation.</p>
 						</TooltipContent>
@@ -352,9 +354,7 @@ export function PromptsListEditor({
 					<div className="hidden md:flex items-center gap-1">
 						System
 						<Tooltip>
-							<TooltipTrigger asChild>
-								<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-							</TooltipTrigger>
+							<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 							<TooltipContent>
 								<p className="max-w-xs">
 									Auto-generated tags like &quot;branded&quot; or &quot;unbranded&quot; based on prompt content.
@@ -366,9 +366,7 @@ export function PromptsListEditor({
 				<div className="flex items-center gap-1 min-w-0">
 					Tags
 					<Tooltip>
-						<TooltipTrigger asChild>
-							<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-						</TooltipTrigger>
+						<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 						<TooltipContent>
 							<p className="max-w-xs">Custom labels to organize and filter prompts.</p>
 						</TooltipContent>
@@ -378,9 +376,7 @@ export function PromptsListEditor({
 					<div className="flex items-center justify-center gap-1">
 						Premium
 						<Tooltip>
-							<TooltipTrigger asChild>
-								<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-							</TooltipTrigger>
+							<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 							<TooltipContent>
 								<p className="max-w-xs">
 									Also track this prompt on a model called directly with its own web search on, for a grounded answer

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -39,9 +39,7 @@ function AdminBreadcrumbs({ pathname }: { pathname: string }) {
 			return (
 				<>
 					<BreadcrumbItem className="hidden md:block">
-						<BreadcrumbLink asChild>
-							<Link to="/reports">Reports</Link>
-						</BreadcrumbLink>
+						<BreadcrumbLink render={<Link to="/reports" />}>Reports</BreadcrumbLink>
 					</BreadcrumbItem>
 					<BreadcrumbSeparator className="hidden md:block" />
 					<BreadcrumbItem>
@@ -120,28 +118,18 @@ function BrandBreadcrumbs({
 	return (
 		<>
 			<BreadcrumbItem className="hidden md:block">
-				<BreadcrumbLink asChild>
-					{brandId ? (
-						<Link to="/app/$brand" params={{ brand: brandId }}>
-							{brandName}
-						</Link>
-					) : (
-						<span>{brandName}</span>
-					)}
+				<BreadcrumbLink render={brandId ? <Link to="/app/$brand" params={{ brand: brandId }} /> : <span />}>
+					{brandName}
 				</BreadcrumbLink>
 			</BreadcrumbItem>
 			<BreadcrumbSeparator className="hidden md:block" />
 			{isPromptDetailPage ? (
 				<>
 					<BreadcrumbItem className="hidden md:block">
-						<BreadcrumbLink asChild>
-							{brandId ? (
-								<Link to="/app/$brand/visibility" params={{ brand: brandId }}>
-									Visibility
-								</Link>
-							) : (
-								<span>Visibility</span>
-							)}
+						<BreadcrumbLink
+							render={brandId ? <Link to="/app/$brand/visibility" params={{ brand: brandId }} /> : <span />}
+						>
+							Visibility
 						</BreadcrumbLink>
 					</BreadcrumbItem>
 					<BreadcrumbSeparator className="hidden md:block" />
@@ -162,9 +150,7 @@ function BrandBreadcrumbs({
 			) : isEditPage ? (
 				<>
 					<BreadcrumbItem className="hidden md:block">
-						<BreadcrumbLink asChild>
-							<Link to={pathname.slice(0, -5)}>{pageName}</Link>
-						</BreadcrumbLink>
+						<BreadcrumbLink render={<Link to={pathname.slice(0, -5)} />}>{pageName}</BreadcrumbLink>
 					</BreadcrumbItem>
 					<BreadcrumbSeparator className="hidden md:block" />
 					<BreadcrumbItem>

--- a/apps/web/src/components/visibility-bar.tsx
+++ b/apps/web/src/components/visibility-bar.tsx
@@ -108,9 +108,7 @@ export function VisibilityBar({
 				)}
 
 				<Tooltip>
-					<TooltipTrigger asChild>
-						<IconInfoCircle className={`h-3.5 w-3.5 shrink-0 ${colors.muted} cursor-help`} />
-					</TooltipTrigger>
+					<TooltipTrigger render={<IconInfoCircle className={`h-3.5 w-3.5 shrink-0 ${colors.muted} cursor-help`} />} />
 					<TooltipContent side="bottom" className="max-w-xs text-sm">
 						AI visibility for the {totalPrompts.toLocaleString()} prompt{totalPrompts !== 1 ? "s" : ""} shown below,
 						calculated as the percentage of AI responses that mention your brand over the time period for the selected

--- a/apps/web/src/routes/_authed/accept-invitation/$invitationId.tsx
+++ b/apps/web/src/routes/_authed/accept-invitation/$invitationId.tsx
@@ -8,7 +8,7 @@
  */
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { Alert, AlertDescription } from "@workspace/ui/components/alert";
-import { Button } from "@workspace/ui/components/button";
+import { Button, buttonVariants } from "@workspace/ui/components/button";
 import { useState } from "react";
 import FullPageCard from "@/components/full-page-card";
 import { acceptInvitationFn, getInvitationFn } from "@/server/team";
@@ -45,9 +45,9 @@ function AcceptInvitationPage() {
 					<p className="text-sm text-muted-foreground text-center">
 						Make sure you're signed in with the email address that received this invitation.
 					</p>
-					<Button variant="outline" className="w-full" asChild>
-						<Link to="/auth/logout">Switch account</Link>
-					</Button>
+					<Link to="/auth/logout" className={buttonVariants({ variant: "outline", className: "w-full" })}>
+						Switch account
+					</Link>
 				</div>
 			</FullPageCard>
 		);

--- a/apps/web/src/routes/_authed/admin/index.tsx
+++ b/apps/web/src/routes/_authed/admin/index.tsx
@@ -132,10 +132,8 @@ function DelayOverrideDialog({ brand, onUpdate }: { brand: BrandStats; onUpdate:
 
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
-			<DialogTrigger asChild>
-				<Button variant="outline" size="sm" className="cursor-pointer">
-					<Settings className="h-4 w-4" />
-				</Button>
+			<DialogTrigger render={<Button variant="outline" size="sm" className="cursor-pointer" />}>
+				<Settings className="h-4 w-4" />
 			</DialogTrigger>
 			<DialogContent className="max-w-2xl">
 				<DialogHeader>

--- a/apps/web/src/routes/_authed/admin/tools.tsx
+++ b/apps/web/src/routes/_authed/admin/tools.tsx
@@ -79,11 +79,9 @@ function AnalyzeBrandDialog() {
 
 	return (
 		<Dialog open={open} onOpenChange={(o) => (o ? setOpen(true) : handleClose())}>
-			<DialogTrigger asChild>
-				<Button variant="outline" className="cursor-pointer w-full">
-					<Sparkles className="h-4 w-4 mr-2" />
-					Analyze brand
-				</Button>
+			<DialogTrigger render={<Button variant="outline" className="cursor-pointer w-full" />}>
+				<Sparkles className="h-4 w-4 mr-2" />
+				Analyze brand
 			</DialogTrigger>
 			<DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
 				<DialogHeader>

--- a/apps/web/src/routes/_authed/admin/workflows.tsx
+++ b/apps/web/src/routes/_authed/admin/workflows.tsx
@@ -335,14 +335,16 @@ function JobDetailsDialog({ job, onRetrySuccess }: { job: RecentJob; onRetrySucc
 
 	return (
 		<Dialog open={isOpen} onOpenChange={setIsOpen}>
-			<DialogTrigger asChild>
-				<Button
-					variant="ghost"
-					size="sm"
-					className={`cursor-pointer ${isFailed ? "text-red-600 hover:text-red-700" : "text-muted-foreground hover:text-foreground"}`}
-				>
-					View Logs
-				</Button>
+			<DialogTrigger
+				render={
+					<Button
+						variant="ghost"
+						size="sm"
+						className={`cursor-pointer ${isFailed ? "text-red-600 hover:text-red-700" : "text-muted-foreground hover:text-foreground"}`}
+					/>
+				}
+			>
+				View Logs
 			</DialogTrigger>
 			<DialogContent className="max-w-[90vw] sm:max-w-[90vw] w-full max-h-[80vh] overflow-y-auto">
 				<DialogHeader>
@@ -408,11 +410,7 @@ function JobDetailsDialog({ job, onRetrySuccess }: { job: RecentJob; onRetrySucc
 							) : (
 								<>
 									<Button onClick={handleRetry} disabled={retryLoading} className="cursor-pointer">
-										{retryLoading ? (
-											<Spinner className="mr-2" />
-										) : (
-											<Play className="h-4 w-4 mr-2" />
-										)}
+										{retryLoading ? <Spinner className="mr-2" /> : <Play className="h-4 w-4 mr-2" />}
 										Retry This Job
 									</Button>
 									{retryError && <span className="text-sm text-red-600">{retryError}</span>}

--- a/apps/web/src/routes/_authed/app/$brand/$.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/$.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { Button } from "@workspace/ui/components/button";
+import { buttonVariants } from "@workspace/ui/components/button";
 
 export const Route = createFileRoute("/_authed/app/$brand/$")({
 	component: BrandSubpathNotFound,
@@ -16,11 +16,9 @@ function BrandSubpathNotFound() {
 			</div>
 
 			<div className="pt-2">
-				<Button asChild variant="outline">
-					<Link to="/app/$brand" params={{ brand: brandId }}>
-						Go Back
-					</Link>
-				</Button>
+				<Link to="/app/$brand" params={{ brand: brandId }} className={buttonVariants({ variant: "outline" })}>
+					Go Back
+				</Link>
 			</div>
 		</div>
 	);

--- a/apps/web/src/routes/_authed/app/$brand/index.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/index.tsx
@@ -24,7 +24,7 @@ import { useDashboardSummary } from "@/hooks/use-dashboard-summary";
 import { useShareOfVoice } from "@/hooks/use-share-of-voice";
 import { TrendChart } from "@/components/trend-chart";
 import { Card, CardContent, CardHeader, CardTitle } from "@workspace/ui/components/card";
-import { Button } from "@workspace/ui/components/button";
+import { buttonVariants } from "@workspace/ui/components/button";
 import { Skeleton } from "@workspace/ui/components/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@workspace/ui/components/tooltip";
 import type { ClientConfig } from "@workspace/config/types";
@@ -115,14 +115,12 @@ function StatWithTooltip({
 }) {
 	return (
 		<Tooltip>
-			<TooltipTrigger asChild>
-				<div className="flex items-center gap-2 cursor-help">
-					<Icon className="h-4 w-4 flex-shrink-0" />
-					<span>
-						<span className="font-semibold text-foreground">{value}</span> {label}
-					</span>
-					<IconInfoCircle className="h-3.5 w-3.5 opacity-50" />
-				</div>
+			<TooltipTrigger render={<div className="flex items-center gap-2 cursor-help" />}>
+				<Icon className="h-4 w-4 flex-shrink-0" />
+				<span>
+					<span className="font-semibold text-foreground">{value}</span> {label}
+				</span>
+				<IconInfoCircle className="h-3.5 w-3.5 opacity-50" />
 			</TooltipTrigger>
 			<TooltipContent className="max-w-xs text-sm">{tooltip}</TooltipContent>
 		</Tooltip>
@@ -142,9 +140,7 @@ function CardTitleWithTooltip({
 		<CardTitle className={`text-sm font-medium flex items-center gap-1.5 ${className}`}>
 			{title}
 			<Tooltip>
-				<TooltipTrigger asChild>
-					<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-				</TooltipTrigger>
+				<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 				<TooltipContent className="max-w-xs text-sm font-normal">{tooltip}</TooltipContent>
 			</Tooltip>
 		</CardTitle>
@@ -201,11 +197,13 @@ function DashboardPage() {
 								<IconEye className="h-5 w-5 text-muted-foreground" />
 								AI Visibility
 							</h2>
-							<Button asChild variant="ghost" size="sm" className="h-8">
-								<Link to="/app/$brand/visibility" params={{ brand: brandId }}>
-									View Visibility <IconArrowRight className="h-4 w-4 ml-1" />
-								</Link>
-							</Button>
+							<Link
+								to="/app/$brand/visibility"
+								params={{ brand: brandId }}
+								className={buttonVariants({ variant: "ghost", size: "sm", className: "h-8" })}
+							>
+								View Visibility <IconArrowRight className="h-4 w-4 ml-1" />
+							</Link>
 						</div>
 						<div className="grid gap-4 lg:grid-cols-4">
 							<Card className="shadow-none flex flex-col gap-3 py-4">
@@ -232,11 +230,13 @@ function DashboardPage() {
 								<IconSpeakerphone className="h-5 w-5 text-muted-foreground" />
 								Share of Voice
 							</h2>
-							<Button asChild variant="ghost" size="sm" className="h-8">
-								<Link to="/app/$brand/share-of-voice" params={{ brand: brandId }}>
-									View Share of Voice <IconArrowRight className="h-4 w-4 ml-1" />
-								</Link>
-							</Button>
+							<Link
+								to="/app/$brand/share-of-voice"
+								params={{ brand: brandId }}
+								className={buttonVariants({ variant: "ghost", size: "sm", className: "h-8" })}
+							>
+								View Share of Voice <IconArrowRight className="h-4 w-4 ml-1" />
+							</Link>
 						</div>
 						<div className="grid gap-4 lg:grid-cols-4">
 							<Card className="shadow-none flex flex-col gap-3 py-4">
@@ -345,12 +345,14 @@ function DashboardPage() {
 							<span className="font-semibold">{totalPrompts.toLocaleString()}</span>
 						</div>
 					)}
-					<Button asChild variant="outline" className="w-full">
-						<Link to="/app/$brand/settings/prompts" params={{ brand: brandId }}>
-							{hasEnabledPrompts ? "View Your Prompts" : hasPrompts ? "Edit Prompts" : "Set Up Prompts"}{" "}
-							<IconArrowRight className="h-4 w-4 ml-1" />
-						</Link>
-					</Button>
+					<Link
+						to="/app/$brand/settings/prompts"
+						params={{ brand: brandId }}
+						className={buttonVariants({ variant: "outline", className: "w-full" })}
+					>
+						{hasEnabledPrompts ? "View Your Prompts" : hasPrompts ? "Edit Prompts" : "Set Up Prompts"}{" "}
+						<IconArrowRight className="h-4 w-4 ml-1" />
+					</Link>
 				</div>
 				{hasEnabledPrompts && (
 					<p className="text-xs text-muted-foreground mt-6">
@@ -371,11 +373,13 @@ function DashboardPage() {
 							<IconEye className="h-5 w-5 text-muted-foreground" />
 							AI Visibility
 						</h2>
-						<Button asChild variant="ghost" size="sm" className="h-8">
-							<Link to="/app/$brand/visibility" params={{ brand: brandId }}>
-								View Visibility <IconArrowRight className="h-4 w-4 ml-1" />
-							</Link>
-						</Button>
+						<Link
+							to="/app/$brand/visibility"
+							params={{ brand: brandId }}
+							className={buttonVariants({ variant: "ghost", size: "sm", className: "h-8" })}
+						>
+							View Visibility <IconArrowRight className="h-4 w-4 ml-1" />
+						</Link>
 					</div>
 
 					<div className="grid gap-4 lg:grid-cols-4">
@@ -416,11 +420,13 @@ function DashboardPage() {
 							<IconSpeakerphone className="h-5 w-5 text-muted-foreground" />
 							Share of Voice
 						</h2>
-						<Button asChild variant="ghost" size="sm" className="h-8">
-							<Link to="/app/$brand/share-of-voice" params={{ brand: brandId }}>
-								View Share of Voice <IconArrowRight className="h-4 w-4 ml-1" />
-							</Link>
-						</Button>
+						<Link
+							to="/app/$brand/share-of-voice"
+							params={{ brand: brandId }}
+							className={buttonVariants({ variant: "ghost", size: "sm", className: "h-8" })}
+						>
+							View Share of Voice <IconArrowRight className="h-4 w-4 ml-1" />
+						</Link>
 					</div>
 
 					<div className="grid gap-4 lg:grid-cols-4">

--- a/apps/web/src/routes/_authed/app/$brand/prompts/$promptId.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/prompts/$promptId.tsx
@@ -404,9 +404,7 @@ function MentionsTab({
 				<CardTitle className="flex items-center gap-1.5 text-base">
 					Mentions
 					<Tooltip>
-						<TooltipTrigger asChild>
-							<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-						</TooltipTrigger>
+						<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 						<TooltipContent className="max-w-xs text-sm font-normal">
 							<p>
 								Only competitors from your{" "}

--- a/apps/web/src/routes/_authed/app/$brand/query-fan-out.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/query-fan-out.tsx
@@ -105,7 +105,7 @@ function QueryFanoutPage() {
 		// Runs happened but none exposed fan-out — still show the KPIs (run counts)
 		// above the explanation rather than hiding everything.
 		content = (
-			<TooltipProvider delayDuration={150}>
+			<TooltipProvider delay={150}>
 				<div className="space-y-6">
 					<StatRow data={data} />
 					<EmptyState message="No web queries in this period — the engines you track didn't expose any searches for these prompts and filters." />
@@ -114,7 +114,7 @@ function QueryFanoutPage() {
 		);
 	} else {
 		content = (
-			<TooltipProvider delayDuration={150}>
+			<TooltipProvider delay={150}>
 				<div className="space-y-6">
 					<StatRow data={data} />
 					<Tabs value={tab} onValueChange={(v) => setTab(v as FanoutTab)} className="gap-4">
@@ -145,12 +145,7 @@ function QueryFanoutPage() {
 			infoContent={infoContent}
 		>
 			<FilterSection>
-				<FilterBar
-					availableTags={availableTags}
-					trackedTargets={trackedTargets}
-					showSearch={false}
-					showModelSelector
-				/>
+				<FilterBar availableTags={availableTags} trackedTargets={trackedTargets} showSearch={false} showModelSelector />
 			</FilterSection>
 			{content}
 		</PageHeader>

--- a/apps/web/src/routes/_authed/app/$brand/settings/brand.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/settings/brand.tsx
@@ -151,9 +151,7 @@ function BrandSettingsPage() {
 						<Label className="flex items-center gap-1.5">
 							Additional Domains
 							<Tooltip>
-								<TooltipTrigger asChild>
-									<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-								</TooltipTrigger>
+								<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 								<TooltipContent className="max-w-xs text-xs font-normal">
 									Other domains your brand owns (e.g. blog.example.com, shop.example.com). Citations from these domains
 									will be counted as your brand&apos;s citations. <strong>Updates retroactively</strong> &mdash;
@@ -176,9 +174,7 @@ function BrandSettingsPage() {
 						<Label className="flex items-center gap-1.5">
 							Brand Aliases
 							<Tooltip>
-								<TooltipTrigger asChild>
-									<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-								</TooltipTrigger>
+								<TooltipTrigger render={<IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />} />
 								<TooltipContent className="max-w-xs text-xs font-normal">
 									Alternative names for your brand (sub-brands, product lines, abbreviations). Used for mention
 									detection in <strong>future</strong> prompt runs only &mdash; does not apply retroactively to past

--- a/apps/web/src/routes/_authed/app/$brand/settings/llms.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/settings/llms.tsx
@@ -20,11 +20,16 @@ import { PREMIUM_MODELS, PREMIUM_RUNS_PER_DAY, premiumModelLabel } from "@worksp
 import { ModelIcon } from "@workspace/ui/brand/model-icon";
 import { Alert, AlertDescription } from "@workspace/ui/components/alert";
 import { Badge } from "@workspace/ui/components/badge";
-import { Button } from "@workspace/ui/components/button";
+import { buttonVariants } from "@workspace/ui/components/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@workspace/ui/components/card";
 import { cn } from "@workspace/ui/lib/utils";
 import { useState } from "react";
-import { formatUsd, PlatformOperatorDetail, PlatformPicker, projectSelectionCostUsd } from "@/components/platform-picker";
+import {
+	formatUsd,
+	PlatformOperatorDetail,
+	PlatformPicker,
+	projectSelectionCostUsd,
+} from "@/components/platform-picker";
 import { UnsavedChangesBar } from "@/components/unsaved-changes-bar";
 import { groupPlatformOptions, platformGroupCopy, platformGroupId } from "@/lib/platform-groups";
 import { buildTitle, getAppName, getBrandName } from "@/lib/route-head";
@@ -250,12 +255,14 @@ function UpgradePanel({ options, brandId }: { options: ModelPickerState["upgrade
 					</div>
 				))}
 			</div>
-			<Button asChild size="sm" variant="outline">
-				<Link to="/app/$brand/settings/billing" params={{ brand: brandId }}>
-					Compare plans
-					<IconArrowUpRight className="h-4 w-4" />
-				</Link>
-			</Button>
+			<Link
+				to="/app/$brand/settings/billing"
+				params={{ brand: brandId }}
+				className={buttonVariants({ variant: "outline", size: "sm" })}
+			>
+				Compare plans
+				<IconArrowUpRight className="h-4 w-4" />
+			</Link>
 		</div>
 	);
 }
@@ -331,17 +338,21 @@ function PremiumApiPool({ premium }: { premium: PremiumPool }) {
 				</p>
 
 				<div className="flex flex-wrap gap-2">
-					<Button asChild variant="outline" size="sm">
-						<Link to="/app/$brand/settings/prompts" params={{ brand: brandId }}>
-							Choose prompts
-						</Link>
-					</Button>
-					<Button asChild variant="ghost" size="sm">
-						<Link to="/app/$brand/settings/billing" params={{ brand: brandId }}>
-							Change how many
-							<IconArrowUpRight className="h-4 w-4" />
-						</Link>
-					</Button>
+					<Link
+						to="/app/$brand/settings/prompts"
+						params={{ brand: brandId }}
+						className={buttonVariants({ variant: "outline", size: "sm" })}
+					>
+						Choose prompts
+					</Link>
+					<Link
+						to="/app/$brand/settings/billing"
+						params={{ brand: brandId }}
+						className={buttonVariants({ variant: "ghost", size: "sm" })}
+					>
+						Change how many
+						<IconArrowUpRight className="h-4 w-4" />
+					</Link>
 				</div>
 			</CardContent>
 		</Card>
@@ -398,12 +409,15 @@ function AddPlatformsCard({ platforms }: { platforms: ModelPickerState["unconfig
 						</div>
 					))}
 				</div>
-				<Button asChild variant="outline" size="sm">
-					<a href={PROVIDERS_DOCS_URL} target="_blank" rel="noopener noreferrer">
-						Provider setup guide
-						<IconExternalLink className="h-4 w-4" />
-					</a>
-				</Button>
+				<a
+					href={PROVIDERS_DOCS_URL}
+					target="_blank"
+					rel="noopener noreferrer"
+					className={buttonVariants({ variant: "outline", size: "sm" })}
+				>
+					Provider setup guide
+					<IconExternalLink className="h-4 w-4" />
+				</a>
 			</CardContent>
 		</Card>
 	);

--- a/apps/web/src/routes/_authed/app/$brand/settings/members.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/settings/members.tsx
@@ -153,7 +153,11 @@ function TeamSettingsPage() {
 				</div>
 				<div className="flex flex-col gap-2">
 					<Label htmlFor="invite-role">Role</Label>
-					<Select value={inviteRole} onValueChange={(value) => setInviteRole(value as "member" | "admin")}>
+					<Select
+						items={{ member: "Member", admin: "Admin" }}
+						value={inviteRole}
+						onValueChange={(value) => setInviteRole(value as "member" | "admin")}
+					>
 						<SelectTrigger id="invite-role" className="w-32">
 							<SelectValue />
 						</SelectTrigger>

--- a/apps/web/src/routes/_authed/app/$brand/share-of-voice.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/share-of-voice.tsx
@@ -108,7 +108,7 @@ function ShareOfVoicePage() {
 		// The big number = the trend's last plotted point, so it matches the line beside it.
 		const currentShare = currentShareOf(data.shareTimeSeries);
 		content = (
-			<TooltipProvider delayDuration={150}>
+			<TooltipProvider delay={150}>
 				<div className="grid gap-6 lg:grid-cols-2">
 					<Card>
 						<CardHeader>
@@ -213,12 +213,7 @@ function ShareOfVoicePage() {
 			infoContent={infoContent}
 		>
 			<FilterSection>
-				<FilterBar
-					availableTags={availableTags}
-					trackedTargets={trackedTargets}
-					showSearch={false}
-					showModelSelector
-				/>
+				<FilterBar availableTags={availableTags} trackedTargets={trackedTargets} showSearch={false} showModelSelector />
 			</FilterSection>
 			<div className="space-y-6">{content}</div>
 		</PageHeader>

--- a/apps/web/src/routes/_authed/app/index.tsx
+++ b/apps/web/src/routes/_authed/app/index.tsx
@@ -9,7 +9,7 @@
 
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
-import { Button } from "@workspace/ui/components/button";
+import { buttonVariants } from "@workspace/ui/components/button";
 import { Skeleton } from "@workspace/ui/components/skeleton";
 import { syncAuth0UserById } from "@workspace/whitelabel/auth-hooks";
 import FullPageCard from "@/components/full-page-card";
@@ -96,27 +96,33 @@ function BrandSwitcherPage() {
 				{brandList.length > 0 || unprovisionedOrgs.length > 0 ? (
 					<>
 						{brandList.map((brand) => (
-							<Button key={brand.id} asChild variant="secondary">
-								<Link to="/app/$brand" params={{ brand: brand.id }}>
-									{brand.name}
-								</Link>
-							</Button>
+							<Link
+								key={brand.id}
+								to="/app/$brand"
+								params={{ brand: brand.id }}
+								className={buttonVariants({ variant: "secondary" })}
+							>
+								{brand.name}
+							</Link>
 						))}
 						{unprovisionedOrgs.map((org) => (
-							<Button key={org.id} asChild variant="outline">
-								<Link to="/app/$brand" params={{ brand: org.id }}>
-									Set up {org.name}
-								</Link>
-							</Button>
+							<Link
+								key={org.id}
+								to="/app/$brand"
+								params={{ brand: org.id }}
+								className={buttonVariants({ variant: "outline" })}
+							>
+								Set up {org.name}
+							</Link>
 						))}
 					</>
 				) : (
 					<p className="text-muted-foreground text-center">No brands available</p>
 				)}
 				{canCreateBrands && (
-					<Button asChild variant="outline">
-						<Link to="/app/new">+ Create new brand</Link>
-					</Button>
+					<Link to="/app/new" className={buttonVariants({ variant: "outline" })}>
+						+ Create new brand
+					</Link>
 				)}
 			</div>
 		</FullPageCard>

--- a/apps/web/src/routes/_authed/app/new.tsx
+++ b/apps/web/src/routes/_authed/app/new.tsx
@@ -20,7 +20,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { db } from "@workspace/lib/db/db";
 import { brands } from "@workspace/lib/db/schema";
 import { checkBrandCreate, type EntitlementDenialCode } from "@workspace/lib/entitlements";
-import { Button } from "@workspace/ui/components/button";
+import { Button, buttonVariants } from "@workspace/ui/components/button";
 import { Input } from "@workspace/ui/components/input";
 import { Label } from "@workspace/ui/components/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@workspace/ui/components/select";
@@ -107,7 +107,13 @@ function WorkspaceSelect({ organizations, value, onChange, disabled }: Workspace
 	return (
 		<div className="space-y-2">
 			<Label htmlFor="organization">Workspace</Label>
-			<Select value={value} onValueChange={onChange} disabled={disabled}>
+			{/* `items` lets the trigger show the workspace name rather than its id. */}
+			<Select
+				items={organizations.map((org) => ({ value: org.id, label: org.name }))}
+				value={value}
+				onValueChange={(next) => next && onChange(next)}
+				disabled={disabled}
+			>
 				<SelectTrigger id="organization" className="w-full">
 					<SelectValue />
 				</SelectTrigger>
@@ -205,17 +211,19 @@ function NewBrandPage() {
 			>
 				<div className="space-y-4">
 					<WorkspaceSelect organizations={organizations} value={organizationId} onChange={setOrganizationId} />
-					<Button asChild className="w-full">
-						{activeOrg.billingBrandId ? (
-							<Link to="/app/$brand/settings/billing" params={{ brand: activeOrg.billingBrandId }}>
-								Go to billing
-							</Link>
-						) : (
-							<Link to="/choose-plan" search={{ org: activeOrg.id }}>
-								Choose a plan
-							</Link>
-						)}
-					</Button>
+					{activeOrg.billingBrandId ? (
+						<Link
+							to="/app/$brand/settings/billing"
+							params={{ brand: activeOrg.billingBrandId }}
+							className={buttonVariants({ className: "w-full" })}
+						>
+							Go to billing
+						</Link>
+					) : (
+						<Link to="/choose-plan" search={{ org: activeOrg.id }} className={buttonVariants({ className: "w-full" })}>
+							Choose a plan
+						</Link>
+					)}
 				</div>
 			</FullPageCard>
 		);

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -11,7 +11,7 @@
  * Shows sign-in for unauthenticated users in other modes.
  */
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { Button } from "@workspace/ui/components/button";
+import { buttonVariants } from "@workspace/ui/components/button";
 import FullPageCard from "@/components/full-page-card";
 import { getSession } from "@/lib/auth/session";
 
@@ -53,9 +53,9 @@ function HomePage() {
 
 	return (
 		<FullPageCard className="">
-			<Button asChild>
-				<a href={signInUrl}>Sign In</a>
-			</Button>
+			<a href={signInUrl} className={buttonVariants({})}>
+				Sign In
+			</a>
 		</FullPageCard>
 	);
 }

--- a/apps/web/src/stories/cloud-llms-settings.stories.tsx
+++ b/apps/web/src/stories/cloud-llms-settings.stories.tsx
@@ -173,7 +173,7 @@ export const CloudAtPickLimit: Story = {
 		await expect(await canvas.findByText(CARD_TITLES.scraped)).toBeVisible();
 		await expect(await canvas.findByText(CARD_TITLES.api)).toBeVisible();
 		await expect(await canvas.findByRole("checkbox", { name: /claude/i })).toBeChecked();
-		await expect(await canvas.findByRole("checkbox", { name: /mistral/i })).toBeDisabled();
+		await expect(await canvas.findByRole("checkbox", { name: /mistral/i })).toHaveAttribute("aria-disabled", "true");
 	},
 };
 
@@ -211,7 +211,7 @@ export const CloudSwappingAPlatform: Story = {
 		await expect(await canvas.findByText("3 / 4 picks")).toBeVisible();
 
 		const mistral = await canvas.findByRole("checkbox", { name: /mistral/i });
-		await expect(mistral).toBeEnabled();
+		await expect(mistral).not.toHaveAttribute("aria-disabled", "true");
 		await userEvent.click(mistral);
 		await expect(await canvas.findByText("4 / 4 picks")).toBeVisible();
 		await expect(await canvas.findByRole("button", { name: /save changes/i })).toBeEnabled();
@@ -546,7 +546,7 @@ export const Whitelabel: Story = {
 		const canvas = within(canvasElement);
 		// Uncapped, like local.
 		await expect(canvas.queryByText(/picks$/)).toBeNull();
-		await expect(await canvas.findByRole("checkbox", { name: /grok/i })).toBeEnabled();
+		await expect(await canvas.findByRole("checkbox", { name: /grok/i })).not.toHaveAttribute("aria-disabled", "true");
 
 		// Operator detail withheld, like cloud.
 		await expect(canvas.queryByText("Track more platforms")).toBeNull();

--- a/apps/web/src/stories/optimize-button.stories.tsx
+++ b/apps/web/src/stories/optimize-button.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { OptimizeButton } from "@workspace/whitelabel/components/optimize-button";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+const meta = {
+	title: "Whitelabel/OptimizeButton",
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const PROPS = {
+	brandId: "mock-brand-id",
+	promptId: "mock-prompt-id",
+	promptName: "best crm for startups",
+	parentName: "Acme",
+	optimizationUrlTemplate: "https://acme.example/optimize?prompt={prompt}&brand={brandId}",
+	availableModels: ["openai", "perplexity"],
+	lookback: "1m",
+} as const;
+
+/** One model selected: a plain button that hands straight off to the parent app. */
+export const SingleModel: Story = {
+	render: () => (
+		<div className="p-8">
+			<OptimizeButton {...PROPS} selectedModel="openai" />
+		</div>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const open = fn();
+		window.open = open;
+
+		await userEvent.click(await canvas.findByRole("button", { name: /optimize with acme/i }));
+		await expect(open).toHaveBeenCalledWith(
+			expect.stringContaining("brand=mock-brand-id"),
+			"_blank",
+			"noopener,noreferrer",
+		);
+	},
+};
+
+/**
+ * "All models" opens a menu with one entry per model. Each entry carries a menu
+ * group label, and a label rendered outside a group takes the whole menu down
+ * rather than just itself — so this asserts the entries are reachable and still
+ * hand off, not that the labels read a particular way.
+ */
+export const AllModelsMenu: Story = {
+	render: () => (
+		<div className="p-8">
+			<OptimizeButton {...PROPS} selectedModel="all" />
+		</div>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const open = fn();
+		window.open = open;
+
+		await userEvent.click(await canvas.findByRole("button", { name: /optimize with acme/i }));
+
+		// The menu portals out of the canvas, so query the whole document.
+		const screen = within(document.body);
+		const items = await screen.findAllByRole("menuitem");
+		await expect(items).toHaveLength(PROPS.availableModels.length);
+
+		await userEvent.click(items[0]);
+		await expect(open).toHaveBeenCalledWith(
+			expect.stringContaining("brand=mock-brand-id"),
+			"_blank",
+			"noopener,noreferrer",
+		);
+	},
+};

--- a/apps/web/src/stories/prompt-wizard.stories.tsx
+++ b/apps/web/src/stories/prompt-wizard.stories.tsx
@@ -150,7 +150,7 @@ export const SetupPlatformStep: StoryObj = {
 		// Gemini is the fifth option on a 4-pick plan: unchecked and disabled.
 		const gemini = canvas.getByRole("checkbox", { name: /gemini/i });
 		expect(gemini).not.toBeChecked();
-		expect(gemini).toBeDisabled();
+		expect(gemini).toHaveAttribute("aria-disabled", "true");
 		expect(canvas.getByText("4 of 4 selected")).toBeInTheDocument();
 		expect(canvas.getByRole("button", { name: /complete setup/i })).toBeEnabled();
 	},
@@ -178,7 +178,7 @@ export const SetupSinglePlatformPlan: StoryObj = {
 
 		const checkbox = await canvas.findByRole("checkbox", { name: /chatgpt/i });
 		expect(checkbox).toBeChecked();
-		expect(checkbox).toBeDisabled();
+		expect(checkbox).toHaveAttribute("aria-disabled", "true");
 		expect(canvas.getByRole("button", { name: /complete setup/i })).toBeEnabled();
 	},
 };

--- a/apps/web/src/stories/ui-primitives.stories.tsx
+++ b/apps/web/src/stories/ui-primitives.stories.tsx
@@ -1,0 +1,85 @@
+/**
+ * Behaviour the shared components are expected to keep, pinned because the
+ * underlying primitive library defaults the other way and a wrapper edit would
+ * otherwise flip it silently.
+ */
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger,
+} from "@workspace/ui/components/dropdown-menu";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@workspace/ui/components/tabs";
+import { useState } from "react";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+const meta = {
+	title: "Components/UI Primitives",
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Arrow keys move between tabs and switch the panel as they go. */
+export const TabsSwitchOnArrowKeys: Story = {
+	render: () => (
+		<div className="p-8">
+			<Tabs defaultValue="mentions">
+				<TabsList>
+					<TabsTrigger value="mentions">Mentions</TabsTrigger>
+					<TabsTrigger value="citations">Citations</TabsTrigger>
+				</TabsList>
+				<TabsContent value="mentions">who mentioned the brand</TabsContent>
+				<TabsContent value="citations">what linked to it</TabsContent>
+			</Tabs>
+		</div>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(await canvas.findByText("who mentioned the brand")).toBeVisible();
+
+		await userEvent.click(canvas.getByRole("tab", { name: "Mentions" }));
+		await userEvent.keyboard("{ArrowRight}");
+
+		// No Enter: moving focus is what selects.
+		await waitFor(async () => {
+			await expect(canvas.getByText("what linked to it")).toBeVisible();
+		});
+	},
+};
+
+/** Picking a radio option closes the menu rather than leaving it open. */
+export const RadioMenuClosesOnPick: Story = {
+	render: function RadioMenu() {
+		const [model, setModel] = useState("all");
+		return (
+			<div className="p-8">
+				<DropdownMenu>
+					<DropdownMenuTrigger>Model: {model}</DropdownMenuTrigger>
+					<DropdownMenuContent>
+						<DropdownMenuRadioGroup value={model} onValueChange={(next) => setModel(String(next))}>
+							<DropdownMenuRadioItem value="all">All models</DropdownMenuRadioItem>
+							<DropdownMenuRadioItem value="chatgpt">ChatGPT</DropdownMenuRadioItem>
+						</DropdownMenuRadioGroup>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</div>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// The menu portals out of the canvas, so query the whole document.
+		const screen = within(document.body);
+
+		await userEvent.click(await canvas.findByRole("button", { name: /model: all/i }));
+		await userEvent.click(await screen.findByRole("menuitemradio", { name: "ChatGPT" }));
+
+		await expect(await canvas.findByRole("button", { name: /model: chatgpt/i })).toBeVisible();
+		await waitFor(async () => {
+			await expect(screen.queryByRole("menuitemradio", { name: "ChatGPT" })).toBeNull();
+		});
+	},
+};

--- a/apps/www/components.json
+++ b/apps/www/components.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://ui.shadcn.com/schema.json",
-	"style": "new-york",
+	"style": "base-vega",
 	"rsc": true,
 	"tsx": true,
 	"tailwind": {

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -7,12 +7,13 @@
 	"scripts": {
 		"postinstall": "fumadocs-mdx",
 		"dev": "vite dev --port 3001",
-		"build": "vite build",
+		"build": "vite build && node ../../scripts/check-server-bundle.mjs .output/server",
 		"start": "node .output/server/index.mjs",
 		"check-types": "tsc --noEmit",
 		"generate-icons": "tsx scripts/generate-brand-icons.tsx"
 	},
 	"dependencies": {
+		"@base-ui/react": "^1.7.0",
 		"@fontsource/geist-mono": "^5.3.0",
 		"@fontsource/geist-sans": "^5.3.0",
 		"@fontsource/titan-one": "^5.3.0",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"postinstall": "fumadocs-mdx",
 		"dev": "vite dev --port 3001",
-		"build": "vite build && node ../../scripts/check-server-bundle.mjs .output/server",
+		"build": "vite build && node ../../scripts/check-server-bundle.mjs .",
 		"start": "node .output/server/index.mjs",
 		"check-types": "tsc --noEmit",
 		"generate-icons": "tsx scripts/generate-brand-icons.tsx"

--- a/apps/www/src/components/ai-visibility-software-hub.tsx
+++ b/apps/www/src/components/ai-visibility-software-hub.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { Button } from "@workspace/ui/components/button";
+import { buttonVariants } from "@workspace/ui/components/button";
 import { ArrowRight } from "lucide-react";
 
 const LINK = "font-medium text-blue-700 underline underline-offset-2 hover:text-blue-900";
@@ -150,17 +150,18 @@ export function AiVisibilitySoftwareHub() {
 							</p>
 						</div>
 						<div className="mt-8 flex flex-wrap gap-3">
-							<Button asChild size="sm">
-								<Link to="/docs">
-									Read the docs
-									<ArrowRight className="size-3.5" />
-								</Link>
-							</Button>
-							<Button asChild variant="outline" size="sm">
-								<a href="https://github.com/elmohq/elmo" target="_blank" rel="noopener noreferrer">
-									Star on GitHub
-								</a>
-							</Button>
+							<Link to="/docs" className={buttonVariants({ size: "sm" })}>
+								Read the docs
+								<ArrowRight className="size-3.5" />
+							</Link>
+							<a
+								href="https://github.com/elmohq/elmo"
+								target="_blank"
+								rel="noopener noreferrer"
+								className={buttonVariants({ variant: "outline", size: "sm" })}
+							>
+								Star on GitHub
+							</a>
 						</div>
 					</div>
 				</div>

--- a/apps/www/src/components/competitor-comparison.tsx
+++ b/apps/www/src/components/competitor-comparison.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { Badge } from "@workspace/ui/components/badge";
-import { Button } from "@workspace/ui/components/button";
+import { buttonVariants } from "@workspace/ui/components/button";
 import { Check, X, ExternalLink, ArrowLeft } from "lucide-react";
 import { AlertTriangle } from "lucide-react";
 import {
@@ -311,14 +311,17 @@ export function CompetitorComparison({ competitor }: { competitor: Competitor })
 						brand.
 					</p>
 					<div className="mt-8 flex flex-wrap justify-center gap-3">
-						<Button asChild size="sm">
-							<Link to="/docs">Deploy Elmo</Link>
-						</Button>
-						<Button asChild variant="outline" size="sm">
-							<a href="https://github.com/elmohq/elmo" target="_blank" rel="noopener noreferrer">
-								View on GitHub
-							</a>
-						</Button>
+						<Link to="/docs" className={buttonVariants({ size: "sm" })}>
+							Deploy Elmo
+						</Link>
+						<a
+							href="https://github.com/elmohq/elmo"
+							target="_blank"
+							rel="noopener noreferrer"
+							className={buttonVariants({ variant: "outline", size: "sm" })}
+						>
+							View on GitHub
+						</a>
 					</div>
 				</div>
 			</section>

--- a/apps/www/src/components/competitor-directory.tsx
+++ b/apps/www/src/components/competitor-directory.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { useState } from "react";
-import { Button } from "@workspace/ui/components/button";
+import { buttonVariants } from "@workspace/ui/components/button";
 import { Check, X } from "lucide-react";
 import {
 	sortedCompetitors,
@@ -95,14 +95,17 @@ export function CompetitorDirectory() {
 						Open source, self-hosted, and transparent. Track AI visibility without vendor lock-in or inflated pricing.
 					</p>
 					<div className="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-						<Button asChild size="sm">
-							<Link to="/docs">Read the Docs</Link>
-						</Button>
-						<Button asChild variant="outline" size="sm">
-							<a href="https://github.com/elmohq/elmo" target="_blank" rel="noopener noreferrer">
-								View on GitHub
-							</a>
-						</Button>
+						<Link to="/docs" className={buttonVariants({ size: "sm" })}>
+							Read the Docs
+						</Link>
+						<a
+							href="https://github.com/elmohq/elmo"
+							target="_blank"
+							rel="noopener noreferrer"
+							className={buttonVariants({ variant: "outline", size: "sm" })}
+						>
+							View on GitHub
+						</a>
 					</div>
 				</div>
 			</section>

--- a/apps/www/src/components/directory-shell.tsx
+++ b/apps/www/src/components/directory-shell.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { Badge } from "@workspace/ui/components/badge";
-import { Button } from "@workspace/ui/components/button";
+import { buttonVariants } from "@workspace/ui/components/button";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import type { ReactNode } from "react";
 
@@ -55,15 +55,17 @@ export function DirectoryElmoBanner({
 					<h2 className="font-heading text-xl text-zinc-950">Elmo: the open-source alternative</h2>
 					<p className="mt-2 max-w-3xl text-sm leading-relaxed text-zinc-600">{pitch}</p>
 					<div className="mt-4 flex flex-wrap gap-3">
-						<Button asChild size="sm">
-							<Link to="/docs">Deploy Elmo</Link>
-						</Button>
-						<Button asChild variant="outline" size="sm">
-							<Link to="/ai-visibility-tools/$slug" params={{ slug: comparison.slug }}>
-								Elmo vs {comparison.name}
-								<ArrowRight className="h-3.5 w-3.5" />
-							</Link>
-						</Button>
+						<Link to="/docs" className={buttonVariants({ size: "sm" })}>
+							Deploy Elmo
+						</Link>
+						<Link
+							to="/ai-visibility-tools/$slug"
+							params={{ slug: comparison.slug }}
+							className={buttonVariants({ variant: "outline", size: "sm" })}
+						>
+							Elmo vs {comparison.name}
+							<ArrowRight className="h-3.5 w-3.5" />
+						</Link>
 					</div>
 				</div>
 			</div>
@@ -81,14 +83,17 @@ export function ElmoCta() {
 					brand. Open source, self-hosted, free.
 				</p>
 				<div className="mt-8 flex flex-wrap justify-center gap-3">
-					<Button asChild size="sm">
-						<Link to="/docs">Deploy Elmo</Link>
-					</Button>
-					<Button asChild variant="outline" size="sm">
-						<a href="https://github.com/elmohq/elmo" target="_blank" rel="noopener noreferrer">
-							View on GitHub
-						</a>
-					</Button>
+					<Link to="/docs" className={buttonVariants({ size: "sm" })}>
+						Deploy Elmo
+					</Link>
+					<a
+						href="https://github.com/elmohq/elmo"
+						target="_blank"
+						rel="noopener noreferrer"
+						className={buttonVariants({ variant: "outline", size: "sm" })}
+					>
+						View on GitHub
+					</a>
 				</div>
 			</div>
 		</section>

--- a/apps/www/src/components/navbar.tsx
+++ b/apps/www/src/components/navbar.tsx
@@ -29,34 +29,34 @@ export function Navbar() {
 			<div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 md:px-6">
 				<div className="flex items-center gap-3 md:gap-8">
 					<Popover>
-						<PopoverTrigger asChild>
-							<Button className="group size-8 md:hidden" variant="ghost" size="icon" aria-label="Open menu">
-								<svg
-									className="pointer-events-none"
-									width={16}
-									height={16}
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									xmlns="http://www.w3.org/2000/svg"
-								>
-									<path
-										d="M4 12L20 12"
-										className="origin-center -translate-y-[7px] transition-all duration-300 ease-[cubic-bezier(.5,.85,.25,1.1)] group-aria-expanded:translate-x-0 group-aria-expanded:translate-y-0 group-aria-expanded:rotate-[315deg]"
-									/>
-									<path
-										d="M4 12H20"
-										className="origin-center transition-all duration-300 ease-[cubic-bezier(.5,.85,.25,1.8)] group-aria-expanded:rotate-45"
-									/>
-									<path
-										d="M4 12H20"
-										className="origin-center translate-y-[7px] transition-all duration-300 ease-[cubic-bezier(.5,.85,.25,1.1)] group-aria-expanded:translate-y-0 group-aria-expanded:rotate-[135deg]"
-									/>
-								</svg>
-							</Button>
+						<PopoverTrigger
+							render={<Button className="group size-8 md:hidden" variant="ghost" size="icon" aria-label="Open menu" />}
+						>
+							<svg
+								className="pointer-events-none"
+								width={16}
+								height={16}
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<path
+									d="M4 12L20 12"
+									className="origin-center -translate-y-[7px] transition-all duration-300 ease-[cubic-bezier(.5,.85,.25,1.1)] group-aria-expanded:translate-x-0 group-aria-expanded:translate-y-0 group-aria-expanded:rotate-[315deg]"
+								/>
+								<path
+									d="M4 12H20"
+									className="origin-center transition-all duration-300 ease-[cubic-bezier(.5,.85,.25,1.8)] group-aria-expanded:rotate-45"
+								/>
+								<path
+									d="M4 12H20"
+									className="origin-center translate-y-[7px] transition-all duration-300 ease-[cubic-bezier(.5,.85,.25,1.1)] group-aria-expanded:translate-y-0 group-aria-expanded:rotate-[135deg]"
+								/>
+							</svg>
 						</PopoverTrigger>
 						<PopoverContent align="start" className="w-44 p-1 md:hidden">
 							<NavigationMenu className="max-w-none *:w-full">

--- a/apps/www/src/routes/brand.tsx
+++ b/apps/www/src/routes/brand.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { Check, Copy, Download } from "lucide-react";
-import { Button } from "@workspace/ui/components/button";
+import { buttonVariants } from "@workspace/ui/components/button";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { ogMeta, canonicalUrl, breadcrumbJsonLd } from "@/lib/seo";
@@ -272,16 +272,22 @@ function BrandPage() {
 						or open a GitHub issue.
 					</p>
 					<div className="mt-4 flex flex-wrap items-center justify-center gap-3">
-						<Button asChild variant="outline" size="sm">
-							<a href="https://discord.gg/s24nubCtKz" target="_blank" rel="noopener noreferrer">
-								Ask on Discord
-							</a>
-						</Button>
-						<Button asChild variant="outline" size="sm">
-							<a href="https://github.com/elmohq/elmo/issues/new" target="_blank" rel="noopener noreferrer">
-								Open an Issue
-							</a>
-						</Button>
+						<a
+							href="https://discord.gg/s24nubCtKz"
+							target="_blank"
+							rel="noopener noreferrer"
+							className={buttonVariants({ variant: "outline", size: "sm" })}
+						>
+							Ask on Discord
+						</a>
+						<a
+							href="https://github.com/elmohq/elmo/issues/new"
+							target="_blank"
+							rel="noopener noreferrer"
+							className={buttonVariants({ variant: "outline", size: "sm" })}
+						>
+							Open an Issue
+						</a>
 					</div>
 				</div>
 			</main>

--- a/apps/www/src/routes/vision.tsx
+++ b/apps/www/src/routes/vision.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { CLOUD_SIGNUP_URL } from "@workspace/config/plans";
 import { ArrowRight } from "lucide-react";
-import { Button } from "@workspace/ui/components/button";
+import { buttonVariants } from "@workspace/ui/components/button";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { ogMeta, canonicalUrl, breadcrumbJsonLd } from "@/lib/seo";
@@ -216,20 +216,21 @@ function VisionPage() {
 							you.
 						</p>
 						<div className="mt-8 flex flex-wrap justify-center gap-3">
-							<Button asChild size="sm">
-								<a href={CLOUD_SIGNUP_URL}>
-									Start with Cloud
-									<ArrowRight className="size-3.5" />
-								</a>
-							</Button>
-							<Button asChild variant="outline" size="sm">
-								<Link to="/docs">Self-host free</Link>
-							</Button>
-							<Button asChild variant="outline" size="sm">
-								<a href="https://github.com/elmohq/elmo" target="_blank" rel="noopener noreferrer">
-									Star on GitHub
-								</a>
-							</Button>
+							<a href={CLOUD_SIGNUP_URL} className={buttonVariants({ size: "sm" })}>
+								Start with Cloud
+								<ArrowRight className="size-3.5" />
+							</a>
+							<Link to="/docs" className={buttonVariants({ variant: "outline", size: "sm" })}>
+								Self-host free
+							</Link>
+							<a
+								href="https://github.com/elmohq/elmo"
+								target="_blank"
+								rel="noopener noreferrer"
+								className={buttonVariants({ variant: "outline", size: "sm" })}
+							>
+								Star on GitHub
+							</a>
 						</div>
 					</div>
 				</section>

--- a/knip.json
+++ b/knip.json
@@ -21,7 +21,7 @@
     "apps/www": {
       "entry": ["src/server.ts", "scripts/**"],
       "ignore": [".source/**"],
-      "ignoreDependencies": ["shiki"]
+      "ignoreDependencies": ["shiki", "@base-ui/react"]
     },
     "apps/worker": {
       "entry": ["scripts/test-provider.ts"]

--- a/knip.json
+++ b/knip.json
@@ -14,7 +14,8 @@
         "tailwindcss",
         "tw-animate-css",
         "@tailwindcss/typography",
-        "@fontsource/geist-sans"
+        "@fontsource/geist-sans",
+        "@base-ui/react"
       ]
     },
     "apps/www": {

--- a/packages/docs/src/components/feedback/client.tsx
+++ b/packages/docs/src/components/feedback/client.tsx
@@ -99,14 +99,16 @@ export function FeedbackBlock({ id, body, children, onSendAction }: FeedbackBloc
 		<div className="group/feedback relative">
 			{children}
 			<Popover open={open} onOpenChange={setOpen}>
-				<PopoverTrigger asChild>
-					<button
-						type="button"
-						className="absolute -right-8 top-0 hidden size-6 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover/feedback:flex group-hover/feedback:opacity-100"
-						aria-label="Send feedback about this section"
-					>
-						<MessageSquare className="size-3.5" />
-					</button>
+				<PopoverTrigger
+					render={
+						<button
+							type="button"
+							className="absolute -right-8 top-0 hidden size-6 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover/feedback:flex group-hover/feedback:opacity-100"
+							aria-label="Send feedback about this section"
+						/>
+					}
+				>
+					<MessageSquare className="size-3.5" />
 				</PopoverTrigger>
 				<PopoverContent align="end" className="w-72 p-3">
 					{submitted ? (

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://ui.shadcn.com/schema.json",
-	"style": "new-york",
+	"style": "base-vega",
 	"rsc": true,
 	"tsx": true,
 	"tailwind": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,12 +25,12 @@
 		"react-dom": "^19"
 	},
 	"dependencies": {
+		"@base-ui/react": "^1.7.0",
 		"@hookform/resolvers": "^5.9.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"cmdk": "^1.1.1",
 		"lucide-react": "^1.31.0",
-		"radix-ui": "^1.6.7",
 		"react-day-picker": "^10.0.1",
 		"react-hook-form": "^7.85.0",
 		"react-icons": "^5.7.0",

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -1,14 +1,10 @@
 "use client"
 
-import * as React from "react"
-import { Avatar as AvatarPrimitive } from "radix-ui"
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar"
 
 import { cn } from "@workspace/ui/lib/utils"
 
-function Avatar({
-  className,
-  ...props
-}: React.ComponentProps<typeof AvatarPrimitive.Root>) {
+function Avatar({ className, ...props }: AvatarPrimitive.Root.Props) {
   return (
     <AvatarPrimitive.Root
       data-slot="avatar"
@@ -21,10 +17,7 @@ function Avatar({
   )
 }
 
-function AvatarImage({
-  className,
-  ...props
-}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
@@ -37,7 +30,7 @@ function AvatarImage({
 function AvatarFallback({
   className,
   ...props
-}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+}: AvatarPrimitive.Fallback.Props) {
   return (
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -1,5 +1,5 @@
-import * as React from "react"
-import { Slot } from "radix-ui"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@workspace/ui/lib/utils"
@@ -28,19 +28,22 @@ const badgeVariants = cva(
 function Badge({
   className,
   variant,
-  asChild = false,
+  render,
   ...props
-}: React.ComponentProps<"span"> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot.Root : "span"
-
-  return (
-    <Comp
-      data-slot="badge"
-      className={cn(badgeVariants({ variant }), className)}
-      {...props}
-    />
-  )
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "badge",
+    },
+  })
 }
 
 export { Badge, badgeVariants }

--- a/packages/ui/src/components/breadcrumb.tsx
+++ b/packages/ui/src/components/breadcrumb.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
 import { ChevronRight, MoreHorizontal } from "lucide-react"
-import { Slot } from "radix-ui"
 
 import { cn } from "@workspace/ui/lib/utils"
 
@@ -32,21 +33,23 @@ function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 function BreadcrumbLink({
-  asChild,
   className,
+  render,
   ...props
-}: React.ComponentProps<"a"> & {
-  asChild?: boolean
-}) {
-  const Comp = asChild ? Slot.Root : "a"
-
-  return (
-    <Comp
-      data-slot="breadcrumb-link"
-      className={cn("hover:text-foreground transition-colors", className)}
-      {...props}
-    />
-  )
+}: useRender.ComponentProps<"a">) {
+  return useRender({
+    defaultTagName: "a",
+    props: mergeProps<"a">(
+      {
+        className: cn("hover:text-foreground transition-colors", className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "breadcrumb-link",
+    },
+  })
 }
 
 function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-import { Slot } from "radix-ui"
+import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@workspace/ui/lib/utils"
@@ -39,16 +38,10 @@ function Button({
   className,
   variant,
   size,
-  asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
-  }) {
-  const Comp = asChild ? Slot.Root : "button"
-
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
   return (
-    <Comp
+    <ButtonPrimitive
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -1,20 +1,16 @@
 "use client"
 
-import * as React from "react"
-import { Checkbox as CheckboxPrimitive } from "radix-ui"
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
 import { CheckIcon } from "lucide-react"
 
 import { cn } from "@workspace/ui/lib/utils"
 
-function Checkbox({
-  className,
-  ...props
-}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
   return (
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-input dark:bg-input/30 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className
       )}
       {...props}

--- a/packages/ui/src/components/collapsible.tsx
+++ b/packages/ui/src/components/collapsible.tsx
@@ -1,32 +1,20 @@
 "use client"
 
-import { Collapsible as CollapsiblePrimitive } from "radix-ui"
+import { Collapsible as CollapsiblePrimitive } from "@base-ui/react/collapsible"
 
-function Collapsible({
-  ...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+function Collapsible({ ...props }: CollapsiblePrimitive.Root.Props) {
   return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
 }
 
-function CollapsibleTrigger({
-  ...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+function CollapsibleTrigger({ ...props }: CollapsiblePrimitive.Trigger.Props) {
   return (
-    <CollapsiblePrimitive.CollapsibleTrigger
-      data-slot="collapsible-trigger"
-      {...props}
-    />
+    <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />
   )
 }
 
-function CollapsibleContent({
-  ...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+function CollapsibleContent({ ...props }: CollapsiblePrimitive.Panel.Props) {
   return (
-    <CollapsiblePrimitive.CollapsibleContent
-      data-slot="collapsible-content"
-      {...props}
-    />
+    <CollapsiblePrimitive.Panel data-slot="collapsible-content" {...props} />
   )
 }
 

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -36,11 +36,12 @@ function CommandDialog({
   className,
   showCloseButton = true,
   ...props
-}: React.ComponentProps<typeof Dialog> & {
+}: Omit<React.ComponentProps<typeof Dialog>, "children"> & {
   title?: string
   description?: string
   className?: string
   showCloseButton?: boolean
+  children?: React.ReactNode
 }) {
   return (
     <Dialog {...props}>

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -1,44 +1,44 @@
 "use client"
 
 import * as React from "react"
-import { Dialog as DialogPrimitive } from "radix-ui"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
 import { XIcon } from "lucide-react"
 
 import { cn } from "@workspace/ui/lib/utils"
 
 function Dialog({
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+}: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
 }
 
 function DialogTrigger({
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+}: DialogPrimitive.Trigger.Props) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
 }
 
 function DialogPortal({
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+}: DialogPrimitive.Portal.Props) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
 }
 
 function DialogClose({
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+}: DialogPrimitive.Close.Props) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
 }
 
 function DialogOverlay({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+}: DialogPrimitive.Backdrop.Props) {
   return (
-    <DialogPrimitive.Overlay
+    <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-50 bg-black/50",
         className
       )}
       {...props}
@@ -51,16 +51,16 @@ function DialogContent({
   children,
   showCloseButton = true,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+}: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
 }) {
   return (
-    <DialogPortal data-slot="dialog-portal">
+    <DialogPortal>
       <DialogOverlay />
-      <DialogPrimitive.Content
+      <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
         {...props}
@@ -69,13 +69,13 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-open:bg-accent data-open:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
         )}
-      </DialogPrimitive.Content>
+      </DialogPrimitive.Popup>
     </DialogPortal>
   )
 }
@@ -106,7 +106,7 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
 function DialogTitle({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+}: DialogPrimitive.Title.Props) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
@@ -119,7 +119,7 @@ function DialogTitle({
 function DialogDescription({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+}: DialogPrimitive.Description.Props) {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -1,62 +1,59 @@
 "use client"
 
 import * as React from "react"
-import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+import { Menu as MenuPrimitive } from "@base-ui/react/menu"
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
 
 import { cn } from "@workspace/ui/lib/utils"
 
-function DropdownMenu({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
-  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
 }
 
-function DropdownMenuPortal({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
-  return (
-    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
-  )
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
 }
 
-function DropdownMenuTrigger({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
-  return (
-    <DropdownMenuPrimitive.Trigger
-      data-slot="dropdown-menu-trigger"
-      {...props}
-    />
-  )
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
 }
 
 function DropdownMenuContent({
   className,
+  align = "center",
+  alignOffset = 0,
+  side = "bottom",
   sideOffset = 4,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+}: MenuPrimitive.Popup.Props &
+  Pick<
+    MenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
   return (
-    <DropdownMenuPrimitive.Portal>
-      <DropdownMenuPrimitive.Content
-        data-slot="dropdown-menu-content"
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
         sideOffset={sideOffset}
-        className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
-          className
-        )}
-        {...props}
-      />
-    </DropdownMenuPrimitive.Portal>
+        className="isolate z-50 outline-none"
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn(
+            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--available-height) min-w-[8rem] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md outline-none",
+            className
+          )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
   )
 }
 
-function DropdownMenuGroup({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
-  return (
-    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
-  )
+function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
 }
 
 function DropdownMenuItem({
@@ -64,17 +61,17 @@ function DropdownMenuItem({
   inset,
   variant = "default",
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+}: MenuPrimitive.Item.Props & {
   inset?: boolean
   variant?: "default" | "destructive"
 }) {
   return (
-    <DropdownMenuPrimitive.Item
+    <MenuPrimitive.Item
       data-slot="dropdown-menu-item"
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -87,35 +84,30 @@ function DropdownMenuCheckboxItem({
   children,
   checked,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+}: MenuPrimitive.CheckboxItem.Props) {
   return (
-    <DropdownMenuPrimitive.CheckboxItem
+    <MenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
       {...props}
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
+        <MenuPrimitive.CheckboxItemIndicator>
           <CheckIcon className="size-4" />
-        </DropdownMenuPrimitive.ItemIndicator>
+        </MenuPrimitive.CheckboxItemIndicator>
       </span>
       {children}
-    </DropdownMenuPrimitive.CheckboxItem>
+    </MenuPrimitive.CheckboxItem>
   )
 }
 
-function DropdownMenuRadioGroup({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
   return (
-    <DropdownMenuPrimitive.RadioGroup
-      data-slot="dropdown-menu-radio-group"
-      {...props}
-    />
+    <MenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />
   )
 }
 
@@ -123,23 +115,23 @@ function DropdownMenuRadioItem({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+}: MenuPrimitive.RadioItem.Props) {
   return (
-    <DropdownMenuPrimitive.RadioItem
+    <MenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
+        <MenuPrimitive.RadioItemIndicator>
           <CircleIcon className="size-2 fill-current" />
-        </DropdownMenuPrimitive.ItemIndicator>
+        </MenuPrimitive.RadioItemIndicator>
       </span>
       {children}
-    </DropdownMenuPrimitive.RadioItem>
+    </MenuPrimitive.RadioItem>
   )
 }
 
@@ -147,15 +139,15 @@ function DropdownMenuLabel({
   className,
   inset,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+}: MenuPrimitive.GroupLabel.Props & {
   inset?: boolean
 }) {
   return (
-    <DropdownMenuPrimitive.Label
+    <MenuPrimitive.GroupLabel
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(
-        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        "px-2 py-1.5 text-sm font-medium data-inset:pl-8",
         className
       )}
       {...props}
@@ -166,9 +158,9 @@ function DropdownMenuLabel({
 function DropdownMenuSeparator({
   className,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+}: MenuPrimitive.Separator.Props) {
   return (
-    <DropdownMenuPrimitive.Separator
+    <MenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
       className={cn("bg-border -mx-1 my-1 h-px", className)}
       {...props}
@@ -192,10 +184,8 @@ function DropdownMenuShortcut({
   )
 }
 
-function DropdownMenuSub({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
-  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
 }
 
 function DropdownMenuSubTrigger({
@@ -203,36 +193,41 @@ function DropdownMenuSubTrigger({
   inset,
   children,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+}: MenuPrimitive.SubmenuTrigger.Props & {
   inset?: boolean
 }) {
   return (
-    <DropdownMenuPrimitive.SubTrigger
+    <MenuPrimitive.SubmenuTrigger
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+        "focus:bg-accent focus:text-accent-foreground data-popup-open:bg-accent data-popup-open:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-inset:pl-8",
         className
       )}
       {...props}
     >
       {children}
       <ChevronRightIcon className="ml-auto size-4" />
-    </DropdownMenuPrimitive.SubTrigger>
+    </MenuPrimitive.SubmenuTrigger>
   )
 }
 
 function DropdownMenuSubContent({
   className,
+  align = "start",
+  alignOffset = -3,
+  side = "right",
+  sideOffset = 0,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+}: React.ComponentProps<typeof DropdownMenuContent>) {
   return (
-    <DropdownMenuPrimitive.SubContent
+    <DropdownMenuContent
       data-slot="dropdown-menu-sub-content"
-      className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
-        className
-      )}
+      align={align}
+      alignOffset={alignOffset}
+      side={side}
+      sideOffset={sideOffset}
+      className={cn("min-w-[8rem] shadow-lg", className)}
       {...props}
     />
   )

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -83,11 +83,14 @@ function DropdownMenuCheckboxItem({
   className,
   children,
   checked,
+  closeOnClick = true,
   ...props
 }: MenuPrimitive.CheckboxItem.Props) {
   return (
     <MenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
+      // Base UI keeps the menu open on select; Radix closed it.
+      closeOnClick={closeOnClick}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
@@ -114,11 +117,14 @@ function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
 function DropdownMenuRadioItem({
   className,
   children,
+  closeOnClick = true,
   ...props
 }: MenuPrimitive.RadioItem.Props) {
   return (
     <MenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
+      // Base UI keeps the menu open on select; Radix closed it.
+      closeOnClick={closeOnClick}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import * as React from "react"
-import { Label as LabelPrimitive, Slot } from "radix-ui"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
 import {
   Controller,
   FormProvider,
@@ -86,10 +87,7 @@ function FormItem({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function FormLabel({
-  className,
-  ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+function FormLabel({ className, ...props }: React.ComponentProps<"label">) {
   const { error, formItemId } = useFormField()
 
   return (
@@ -103,22 +101,24 @@ function FormLabel({
   )
 }
 
-function FormControl({ ...props }: React.ComponentProps<typeof Slot.Root>) {
+function FormControl({ render, ...props }: useRender.ComponentProps<"div">) {
   const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
 
-  return (
-    <Slot.Root
-      data-slot="form-control"
-      id={formItemId}
-      aria-describedby={
-        !error
+  return useRender({
+    defaultTagName: "div",
+    render,
+    props: mergeProps<"div">(
+      {
+        "data-slot": "form-control",
+        id: formItemId,
+        "aria-describedby": !error
           ? `${formDescriptionId}`
-          : `${formDescriptionId} ${formMessageId}`
-      }
-      aria-invalid={!!error}
-      {...props}
-    />
-  )
+          : `${formDescriptionId} ${formMessageId}`,
+        "aria-invalid": !!error,
+      } as React.ComponentProps<"div">,
+      props
+    ),
+  })
 }
 
 function FormDescription({ className, ...props }: React.ComponentProps<"p">) {

--- a/packages/ui/src/components/label.tsx
+++ b/packages/ui/src/components/label.tsx
@@ -1,16 +1,12 @@
 "use client"
 
 import * as React from "react"
-import { Label as LabelPrimitive } from "radix-ui"
 
 import { cn } from "@workspace/ui/lib/utils"
 
-function Label({
-  className,
-  ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+function Label({ className, ...props }: React.ComponentProps<"label">) {
   return (
-    <LabelPrimitive.Root
+    <label
       data-slot="label"
       className={cn(
         "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",

--- a/packages/ui/src/components/navigation-menu.tsx
+++ b/packages/ui/src/components/navigation-menu.tsx
@@ -1,22 +1,20 @@
 import * as React from "react"
+import { NavigationMenu as NavigationMenuPrimitive } from "@base-ui/react/navigation-menu"
 import { cva } from "class-variance-authority"
 import { ChevronDownIcon } from "lucide-react"
-import { NavigationMenu as NavigationMenuPrimitive } from "radix-ui"
 
 import { cn } from "@workspace/ui/lib/utils"
 
 function NavigationMenu({
   className,
   children,
-  viewport = true,
+  align = "start",
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Root> & {
-  viewport?: boolean
-}) {
+}: NavigationMenuPrimitive.Root.Props &
+  Pick<NavigationMenuPrimitive.Positioner.Props, "align">) {
   return (
     <NavigationMenuPrimitive.Root
       data-slot="navigation-menu"
-      data-viewport={viewport}
       className={cn(
         "group/navigation-menu relative flex max-w-max flex-1 items-center justify-center",
         className
@@ -24,7 +22,7 @@ function NavigationMenu({
       {...props}
     >
       {children}
-      {viewport && <NavigationMenuViewport />}
+      <NavigationMenuPositioner align={align} />
     </NavigationMenuPrimitive.Root>
   )
 }
@@ -32,7 +30,7 @@ function NavigationMenu({
 function NavigationMenuList({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.List>) {
+}: NavigationMenuPrimitive.List.Props) {
   return (
     <NavigationMenuPrimitive.List
       data-slot="navigation-menu-list"
@@ -48,7 +46,7 @@ function NavigationMenuList({
 function NavigationMenuItem({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Item>) {
+}: NavigationMenuPrimitive.Item.Props) {
   return (
     <NavigationMenuPrimitive.Item
       data-slot="navigation-menu-item"
@@ -59,14 +57,14 @@ function NavigationMenuItem({
 }
 
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-[color,box-shadow] outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-accent/50 data-[state=open]:text-accent-foreground data-[state=open]:hover:bg-accent data-[state=open]:focus:bg-accent"
+  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-[color,box-shadow] outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-popup-open:bg-accent/50 data-popup-open:text-accent-foreground data-popup-open:hover:bg-accent data-popup-open:focus:bg-accent"
 )
 
 function NavigationMenuTrigger({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Trigger>) {
+}: NavigationMenuPrimitive.Trigger.Props) {
   return (
     <NavigationMenuPrimitive.Trigger
       data-slot="navigation-menu-trigger"
@@ -75,7 +73,7 @@ function NavigationMenuTrigger({
     >
       {children}{" "}
       <ChevronDownIcon
-        className="relative top-[1px] ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
+        className="relative top-[1px] ml-1 size-3 transition duration-300 group-data-popup-open:rotate-180"
         aria-hidden="true"
       />
     </NavigationMenuPrimitive.Trigger>
@@ -85,13 +83,15 @@ function NavigationMenuTrigger({
 function NavigationMenuContent({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Content>) {
+}: NavigationMenuPrimitive.Content.Props) {
   return (
     <NavigationMenuPrimitive.Content
       data-slot="navigation-menu-content"
       className={cn(
-        "top-0 left-0 w-full p-2 pr-2.5 data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 data-[motion^=from-]:animate-in data-[motion^=from-]:fade-in data-[motion^=to-]:animate-out data-[motion^=to-]:fade-out md:absolute md:w-auto",
-        "group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95",
+        "h-full w-full p-2 pr-2.5 transition-[opacity,transform] duration-200 data-starting-style:opacity-0 data-ending-style:opacity-0 md:w-auto",
+        "data-[activation-direction=left]:data-starting-style:-translate-x-12 data-[activation-direction=right]:data-starting-style:translate-x-12",
+        "data-[activation-direction=left]:data-ending-style:translate-x-12 data-[activation-direction=right]:data-ending-style:-translate-x-12",
+        "**:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none",
         className
       )}
       {...props}
@@ -99,37 +99,47 @@ function NavigationMenuContent({
   )
 }
 
-function NavigationMenuViewport({
+function NavigationMenuPositioner({
   className,
+  side = "bottom",
+  sideOffset = 6,
+  align = "start",
+  alignOffset = 0,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>) {
+}: NavigationMenuPrimitive.Positioner.Props) {
   return (
-    <div
-      className={cn(
-        "absolute top-full left-0 isolate z-50 flex justify-center"
-      )}
-    >
-      <NavigationMenuPrimitive.Viewport
-        data-slot="navigation-menu-viewport"
+    <NavigationMenuPrimitive.Portal>
+      <NavigationMenuPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
         className={cn(
-          "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
+          "isolate z-50 h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom] duration-200 data-instant:transition-none",
           className
         )}
         {...props}
-      />
-    </div>
+      >
+        <NavigationMenuPrimitive.Popup className="bg-popover text-popover-foreground relative h-(--popup-height) w-(--popup-width) origin-(--transform-origin) overflow-hidden rounded-md border shadow outline-none transition-[opacity,transform,width,height] duration-200 data-starting-style:scale-95 data-starting-style:opacity-0 data-ending-style:scale-95 data-ending-style:opacity-0">
+          <NavigationMenuPrimitive.Viewport
+            data-slot="navigation-menu-viewport"
+            className="relative size-full overflow-hidden"
+          />
+        </NavigationMenuPrimitive.Popup>
+      </NavigationMenuPrimitive.Positioner>
+    </NavigationMenuPrimitive.Portal>
   )
 }
 
 function NavigationMenuLink({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Link>) {
+}: NavigationMenuPrimitive.Link.Props) {
   return (
     <NavigationMenuPrimitive.Link
       data-slot="navigation-menu-link"
       className={cn(
-        "flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 data-[active=true]:bg-accent/50 data-[active=true]:text-accent-foreground data-[active=true]:hover:bg-accent data-[active=true]:focus:bg-accent [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        "flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 data-active:bg-accent/50 data-active:text-accent-foreground data-active:hover:bg-accent data-active:focus:bg-accent [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className
       )}
       {...props}
@@ -140,18 +150,18 @@ function NavigationMenuLink({
 function NavigationMenuIndicator({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Indicator>) {
+}: NavigationMenuPrimitive.Icon.Props) {
   return (
-    <NavigationMenuPrimitive.Indicator
+    <NavigationMenuPrimitive.Icon
       data-slot="navigation-menu-indicator"
       className={cn(
-        "top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:animate-in data-[state=visible]:fade-in",
+        "top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden transition-opacity data-starting-style:opacity-0 data-ending-style:opacity-0",
         className
       )}
       {...props}
     >
       <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md" />
-    </NavigationMenuPrimitive.Indicator>
+    </NavigationMenuPrimitive.Icon>
   )
 }
 
@@ -163,6 +173,6 @@ export {
   NavigationMenuTrigger,
   NavigationMenuLink,
   NavigationMenuIndicator,
-  NavigationMenuViewport,
+  NavigationMenuPositioner,
   navigationMenuTriggerStyle,
 }

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -1,48 +1,49 @@
 "use client"
 
-import * as React from "react"
-import { Popover as PopoverPrimitive } from "radix-ui"
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
 
 import { cn } from "@workspace/ui/lib/utils"
 
-function Popover({
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />
 }
 
-function PopoverTrigger({
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
 }
 
 function PopoverContent({
   className,
   align = "center",
+  alignOffset = 0,
+  side = "bottom",
   sideOffset = 4,
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
   return (
     <PopoverPrimitive.Portal>
-      <PopoverPrimitive.Content
-        data-slot="popover-content"
+      <PopoverPrimitive.Positioner
         align={align}
+        alignOffset={alignOffset}
+        side={side}
         sideOffset={sideOffset}
-        className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
-          className
-        )}
-        {...props}
-      />
+        className="isolate z-50"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+            className
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
     </PopoverPrimitive.Portal>
   )
 }
 
-function PopoverAnchor({
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
-  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
-}
-
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }
+export { Popover, PopoverTrigger, PopoverContent }

--- a/packages/ui/src/components/progress.tsx
+++ b/packages/ui/src/components/progress.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import * as React from "react"
-import { Progress as ProgressPrimitive } from "radix-ui"
+import { Progress as ProgressPrimitive } from "@base-ui/react/progress"
 
 import { cn } from "@workspace/ui/lib/utils"
 
@@ -9,21 +8,23 @@ function Progress({
   className,
   value,
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: ProgressPrimitive.Root.Props) {
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
+      value={value}
       className={cn(
         "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
         className
       )}
       {...props}
     >
-      <ProgressPrimitive.Indicator
-        data-slot="progress-indicator"
-        className="bg-primary h-full w-full flex-1 transition-all"
-        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
-      />
+      <ProgressPrimitive.Track className="size-full">
+        <ProgressPrimitive.Indicator
+          data-slot="progress-indicator"
+          className="bg-primary h-full transition-all"
+        />
+      </ProgressPrimitive.Track>
     </ProgressPrimitive.Root>
   )
 }

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -1,26 +1,18 @@
 "use client"
 
 import * as React from "react"
-import { Select as SelectPrimitive } from "radix-ui"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
 
 import { cn } from "@workspace/ui/lib/utils"
 
-function Select({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />
-}
+const Select = SelectPrimitive.Root
 
-function SelectGroup({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+function SelectGroup({ ...props }: SelectPrimitive.Group.Props) {
   return <SelectPrimitive.Group data-slot="select-group" {...props} />
 }
 
-function SelectValue({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+function SelectValue({ ...props }: SelectPrimitive.Value.Props) {
   return <SelectPrimitive.Value data-slot="select-value" {...props} />
 }
 
@@ -29,7 +21,7 @@ function SelectTrigger({
   size = "default",
   children,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+}: SelectPrimitive.Trigger.Props & {
   size?: "sm" | "default"
 }) {
   return (
@@ -37,15 +29,15 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
     >
       {children}
-      <SelectPrimitive.Icon asChild>
-        <ChevronDownIcon className="size-4 opacity-50" />
-      </SelectPrimitive.Icon>
+      <SelectPrimitive.Icon
+        render={<ChevronDownIcon className="size-4 opacity-50" />}
+      />
     </SelectPrimitive.Trigger>
   )
 }
@@ -53,34 +45,41 @@ function SelectTrigger({
 function SelectContent({
   className,
   children,
-  position = "popper",
+  align = "center",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  alignItemWithTrigger = false,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
   return (
     <SelectPrimitive.Portal>
-      <SelectPrimitive.Content
-        data-slot="select-content"
-        className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
-          position === "popper" &&
-            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-          className
-        )}
-        position={position}
-        {...props}
+      <SelectPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
       >
-        <SelectScrollUpButton />
-        <SelectPrimitive.Viewport
+        <SelectPrimitive.Popup
+          data-slot="select-content"
           className={cn(
-            "p-1",
-            position === "popper" &&
-              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative isolate z-50 max-h-(--available-height) min-w-[8rem] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+            className
           )}
+          {...props}
         >
-          {children}
-        </SelectPrimitive.Viewport>
-        <SelectScrollDownButton />
-      </SelectPrimitive.Content>
+          <SelectScrollUpButton />
+          <SelectPrimitive.List className="w-full min-w-(--anchor-width) scroll-my-1 p-1">
+            {children}
+          </SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
     </SelectPrimitive.Portal>
   )
 }
@@ -88,9 +87,9 @@ function SelectContent({
 function SelectLabel({
   className,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+}: SelectPrimitive.GroupLabel.Props) {
   return (
-    <SelectPrimitive.Label
+    <SelectPrimitive.GroupLabel
       data-slot="select-label"
       className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
       {...props}
@@ -102,22 +101,26 @@ function SelectItem({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+}: SelectPrimitive.Item.Props) {
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}
     >
-      <span className="absolute right-2 flex size-3.5 items-center justify-center">
-        <SelectPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
-        </SelectPrimitive.ItemIndicator>
-      </span>
-      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemText className="shrink-0 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="absolute right-2 flex size-3.5 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="size-4" />
+      </SelectPrimitive.ItemIndicator>
     </SelectPrimitive.Item>
   )
 }
@@ -125,7 +128,7 @@ function SelectItem({
 function SelectSeparator({
   className,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+}: SelectPrimitive.Separator.Props) {
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
@@ -138,36 +141,36 @@ function SelectSeparator({
 function SelectScrollUpButton({
   className,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+}: SelectPrimitive.ScrollUpArrow.Props) {
   return (
-    <SelectPrimitive.ScrollUpButton
+    <SelectPrimitive.ScrollUpArrow
       data-slot="select-scroll-up-button"
       className={cn(
-        "flex cursor-default items-center justify-center py-1",
+        "bg-popover top-0 z-10 flex w-full cursor-default items-center justify-center py-1",
         className
       )}
       {...props}
     >
       <ChevronUpIcon className="size-4" />
-    </SelectPrimitive.ScrollUpButton>
+    </SelectPrimitive.ScrollUpArrow>
   )
 }
 
 function SelectScrollDownButton({
   className,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+}: SelectPrimitive.ScrollDownArrow.Props) {
   return (
-    <SelectPrimitive.ScrollDownButton
+    <SelectPrimitive.ScrollDownArrow
       data-slot="select-scroll-down-button"
       className={cn(
-        "flex cursor-default items-center justify-center py-1",
+        "bg-popover bottom-0 z-10 flex w-full cursor-default items-center justify-center py-1",
         className
       )}
       {...props}
     >
       <ChevronDownIcon className="size-4" />
-    </SelectPrimitive.ScrollDownButton>
+    </SelectPrimitive.ScrollDownArrow>
   )
 }
 

--- a/packages/ui/src/components/separator.tsx
+++ b/packages/ui/src/components/separator.tsx
@@ -1,20 +1,17 @@
 "use client"
 
-import * as React from "react"
-import { Separator as SeparatorPrimitive } from "radix-ui"
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
 
 import { cn } from "@workspace/ui/lib/utils"
 
 function Separator({
   className,
   orientation = "horizontal",
-  decorative = true,
   ...props
-}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+}: SeparatorPrimitive.Props) {
   return (
-    <SeparatorPrimitive.Root
+    <SeparatorPrimitive
       data-slot="separator"
-      decorative={decorative}
       orientation={orientation}
       className={cn(
         "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -1,42 +1,42 @@
 "use client"
 
 import * as React from "react"
-import { Dialog as SheetPrimitive } from "radix-ui"
+import { Dialog as SheetPrimitive } from "@base-ui/react/dialog"
 import { XIcon } from "lucide-react"
 
 import { cn } from "@workspace/ui/lib/utils"
 
-function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+function Sheet({ ...props }: SheetPrimitive.Root.Props) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />
 }
 
 function SheetTrigger({
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+}: SheetPrimitive.Trigger.Props) {
   return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
 }
 
 function SheetClose({
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+}: SheetPrimitive.Close.Props) {
   return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
 }
 
 function SheetPortal({
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+}: SheetPrimitive.Portal.Props) {
   return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
 }
 
 function SheetOverlay({
   className,
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+}: SheetPrimitive.Backdrop.Props) {
   return (
-    <SheetPrimitive.Overlay
+    <SheetPrimitive.Backdrop
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-50 bg-black/50",
         className
       )}
       {...props}
@@ -49,34 +49,34 @@ function SheetContent({
   children,
   side = "right",
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+}: SheetPrimitive.Popup.Props & {
   side?: "top" | "right" | "bottom" | "left"
 }) {
   return (
     <SheetPortal>
       <SheetOverlay />
-      <SheetPrimitive.Content
+      <SheetPrimitive.Popup
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-background data-open:animate-in data-closed:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-closed:duration-300 data-open:duration-500",
           side === "right" &&
-            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+            "data-closed:slide-out-to-right data-open:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&
-            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+            "data-closed:slide-out-to-left data-open:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
           side === "top" &&
-            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+            "data-closed:slide-out-to-top data-open:slide-in-from-top inset-x-0 top-0 h-auto border-b",
           side === "bottom" &&
-            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+            "data-closed:slide-out-to-bottom data-open:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
           className
         )}
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-open:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
-      </SheetPrimitive.Content>
+      </SheetPrimitive.Popup>
     </SheetPortal>
   )
 }
@@ -104,7 +104,7 @@ function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
 function SheetTitle({
   className,
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+}: SheetPrimitive.Title.Props) {
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
@@ -117,7 +117,7 @@ function SheetTitle({
 function SheetDescription({
   className,
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+}: SheetPrimitive.Description.Props) {
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import * as React from "react"
-import { Slot } from "radix-ui"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
 import { cva, VariantProps } from "class-variance-authority"
 import { PanelLeftIcon } from "lucide-react"
 
@@ -128,7 +129,7 @@ function SidebarProvider({
 
   return (
     <SidebarContext.Provider value={contextValue}>
-      <TooltipProvider delayDuration={0}>
+      <TooltipProvider delay={0}>
         <div
           data-slot="sidebar-wrapper"
           style={
@@ -395,46 +396,50 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
 
 function SidebarGroupLabel({
   className,
-  asChild = false,
+  render,
   ...props
-}: React.ComponentProps<"div"> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot.Root : "div"
-
-  return (
-    <Comp
-      data-slot="sidebar-group-label"
-      data-sidebar="group-label"
-      className={cn(
-        "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
-        className
-      )}
-      {...props}
-    />
-  )
+}: useRender.ComponentProps<"div">) {
+  return useRender({
+    defaultTagName: "div",
+    render,
+    props: mergeProps<"div">(
+      {
+        "data-slot": "sidebar-group-label",
+        "data-sidebar": "group-label",
+        className: cn(
+          "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+          "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+          className
+        ),
+      } as React.ComponentProps<"div">,
+      props
+    ),
+  })
 }
 
 function SidebarGroupAction({
   className,
-  asChild = false,
+  render,
   ...props
-}: React.ComponentProps<"button"> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot.Root : "button"
-
-  return (
-    <Comp
-      data-slot="sidebar-group-action"
-      data-sidebar="group-action"
-      className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-        // Increases the hit area of the button on mobile.
-        "after:absolute after:-inset-2 md:after:hidden",
-        "group-data-[collapsible=icon]:hidden",
-        className
-      )}
-      {...props}
-    />
-  )
+}: useRender.ComponentProps<"button">) {
+  return useRender({
+    defaultTagName: "button",
+    render,
+    props: mergeProps<"button">(
+      {
+        "data-slot": "sidebar-group-action",
+        "data-sidebar": "group-action",
+        className: cn(
+          "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+          // Increases the hit area of the button on mobile.
+          "after:absolute after:-inset-2 md:after:hidden",
+          "group-data-[collapsible=icon]:hidden",
+          className
+        ),
+      } as React.ComponentProps<"button">,
+      props
+    ),
+  })
 }
 
 function SidebarGroupContent({
@@ -474,7 +479,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-popup-open:hover:bg-sidebar-accent data-popup-open:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -496,31 +501,33 @@ const sidebarMenuButtonVariants = cva(
 )
 
 function SidebarMenuButton({
-  asChild = false,
+  render,
   isActive = false,
   variant = "default",
   size = "default",
   tooltip,
   className,
   ...props
-}: React.ComponentProps<"button"> & {
-  asChild?: boolean
+}: useRender.ComponentProps<"button"> & {
   isActive?: boolean
   tooltip?: string | React.ComponentProps<typeof TooltipContent>
 } & VariantProps<typeof sidebarMenuButtonVariants>) {
-  const Comp = asChild ? Slot.Root : "button"
   const { isMobile, state } = useSidebar()
 
-  const button = (
-    <Comp
-      data-slot="sidebar-menu-button"
-      data-sidebar="menu-button"
-      data-size={size}
-      data-active={isActive}
-      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
-      {...props}
-    />
-  )
+  const button = useRender({
+    defaultTagName: "button",
+    render: tooltip ? <TooltipTrigger render={render} /> : render,
+    props: mergeProps<"button">(
+      {
+        "data-slot": "sidebar-menu-button",
+        "data-sidebar": "menu-button",
+        "data-size": size,
+        "data-active": isActive,
+        className: cn(sidebarMenuButtonVariants({ variant, size }), className),
+      } as React.ComponentProps<"button">,
+      props
+    ),
+  })
 
   if (!tooltip) {
     return button
@@ -534,7 +541,7 @@ function SidebarMenuButton({
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      {button}
       <TooltipContent
         side="right"
         align="center"
@@ -547,34 +554,35 @@ function SidebarMenuButton({
 
 function SidebarMenuAction({
   className,
-  asChild = false,
+  render,
   showOnHover = false,
   ...props
-}: React.ComponentProps<"button"> & {
-  asChild?: boolean
+}: useRender.ComponentProps<"button"> & {
   showOnHover?: boolean
 }) {
-  const Comp = asChild ? Slot.Root : "button"
-
-  return (
-    <Comp
-      data-slot="sidebar-menu-action"
-      data-sidebar="menu-action"
-      className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-        // Increases the hit area of the button on mobile.
-        "after:absolute after:-inset-2 md:after:hidden",
-        "peer-data-[size=sm]/menu-button:top-1",
-        "peer-data-[size=default]/menu-button:top-1.5",
-        "peer-data-[size=lg]/menu-button:top-2.5",
-        "group-data-[collapsible=icon]:hidden",
-        showOnHover &&
-          "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
-        className
-      )}
-      {...props}
-    />
-  )
+  return useRender({
+    defaultTagName: "button",
+    render,
+    props: mergeProps<"button">(
+      {
+        "data-slot": "sidebar-menu-action",
+        "data-sidebar": "menu-action",
+        className: cn(
+          "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+          // Increases the hit area of the button on mobile.
+          "after:absolute after:-inset-2 md:after:hidden",
+          "peer-data-[size=sm]/menu-button:top-1",
+          "peer-data-[size=default]/menu-button:top-1.5",
+          "peer-data-[size=lg]/menu-button:top-2.5",
+          "group-data-[collapsible=icon]:hidden",
+          showOnHover &&
+            "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-popup-open:opacity-100 md:opacity-0",
+          className
+        ),
+      } as React.ComponentProps<"button">,
+      props
+    ),
+  })
 }
 
 function SidebarMenuBadge({
@@ -667,35 +675,36 @@ function SidebarMenuSubItem({
 }
 
 function SidebarMenuSubButton({
-  asChild = false,
+  render,
   size = "md",
   isActive = false,
   className,
   ...props
-}: React.ComponentProps<"a"> & {
-  asChild?: boolean
+}: useRender.ComponentProps<"a"> & {
   size?: "sm" | "md"
   isActive?: boolean
 }) {
-  const Comp = asChild ? Slot.Root : "a"
-
-  return (
-    <Comp
-      data-slot="sidebar-menu-sub-button"
-      data-sidebar="menu-sub-button"
-      data-size={size}
-      data-active={isActive}
-      className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
-        "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
-        size === "sm" && "text-xs",
-        size === "md" && "text-sm",
-        "group-data-[collapsible=icon]:hidden",
-        className
-      )}
-      {...props}
-    />
-  )
+  return useRender({
+    defaultTagName: "a",
+    render,
+    props: mergeProps<"a">(
+      {
+        "data-slot": "sidebar-menu-sub-button",
+        "data-sidebar": "menu-sub-button",
+        "data-size": size,
+        "data-active": isActive,
+        className: cn(
+          "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+          "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
+          size === "sm" && "text-xs",
+          size === "md" && "text-sm",
+          "group-data-[collapsible=icon]:hidden",
+          className
+        ),
+      } as React.ComponentProps<"a">,
+      props
+    ),
+  })
 }
 
 export {

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -1,19 +1,15 @@
 "use client"
 
-import * as React from "react"
-import { Switch as SwitchPrimitive } from "radix-ui"
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
 
 import { cn } from "@workspace/ui/lib/utils"
 
-function Switch({
-  className,
-  ...props
-}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+function Switch({ className, ...props }: SwitchPrimitive.Root.Props) {
   return (
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-unchecked:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className
       )}
       {...props}
@@ -21,7 +17,7 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+          "bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-checked:translate-x-[calc(100%-2px)] data-unchecked:translate-x-0"
         )}
       />
     </SwitchPrimitive.Root>

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -1,14 +1,10 @@
 "use client"
 
-import * as React from "react"
-import { Tabs as TabsPrimitive } from "radix-ui"
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
 
 import { cn } from "@workspace/ui/lib/utils"
 
-function Tabs({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+function Tabs({ className, ...props }: TabsPrimitive.Root.Props) {
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
@@ -18,10 +14,7 @@ function Tabs({
   )
 }
 
-function TabsList({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.List>) {
+function TabsList({ className, ...props }: TabsPrimitive.List.Props) {
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
@@ -34,15 +27,12 @@ function TabsList({
   )
 }
 
-function TabsTrigger({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
   return (
-    <TabsPrimitive.Trigger
+    <TabsPrimitive.Tab
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-active:bg-background dark:data-active:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-active:border-input dark:data-active:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-active:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -50,12 +40,9 @@ function TabsTrigger({
   )
 }
 
-function TabsContent({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
   return (
-    <TabsPrimitive.Content
+    <TabsPrimitive.Panel
       data-slot="tabs-content"
       className={cn("flex-1 outline-none", className)}
       {...props}

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -14,10 +14,17 @@ function Tabs({ className, ...props }: TabsPrimitive.Root.Props) {
   )
 }
 
-function TabsList({ className, ...props }: TabsPrimitive.List.Props) {
+function TabsList({
+  activateOnFocus = true,
+  className,
+  ...props
+}: TabsPrimitive.List.Props) {
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
+      // Base UI waits for Enter/Space where Radix switched panels as you
+      // arrowed across the strip; keep the arrow keys doing the switching.
+      activateOnFocus={activateOnFocus}
       className={cn(
         "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
         className

--- a/packages/ui/src/components/tags-input.tsx
+++ b/packages/ui/src/components/tags-input.tsx
@@ -150,54 +150,57 @@ export function TagsInput({
   return (
     <div className={cn("flex w-full flex-col", className)}>
       <Popover open={open} onOpenChange={handleOpenChange}>
-        <PopoverTrigger asChild>
-          <div
-            role="combobox"
-            aria-expanded={open}
-            aria-disabled={disabled || undefined}
-            tabIndex={disabled ? -1 : 0}
-            onClick={() => !disabled && setOpen(true)}
-            onKeyDown={(e) => {
-              if (disabled) return;
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                setOpen(true);
-              }
-            }}
-            className={cn(
-              "border-input focus-visible:border-ring focus-visible:ring-ring/50 flex min-h-9 w-full items-center gap-2 rounded-md border bg-background px-2 py-1.5 text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px]",
-              disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
-            )}
-          >
-            <span className="flex min-w-0 flex-1 flex-wrap items-center gap-1 min-h-[22px]">
-              {value.length === 0 ? (
-                <span className="text-muted-foreground text-xs">{placeholder}</span>
-              ) : (
-                value.map((v) => (
-                  <Badge key={v} variant="secondary" className={cn("gap-1", canRemove && "pr-1")}>
-                    <span className="max-w-[14rem] truncate">{v}</span>
-                    {canRemove && (
-                      <button
-                        type="button"
-                        tabIndex={-1}
-                        aria-label={`Remove ${v}`}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          remove(v);
-                        }}
-                        onKeyDown={(e) => e.stopPropagation()}
-                        className="rounded-sm p-0.5 hover:bg-muted-foreground/20"
-                      >
-                        <RemoveIcon className="size-3" />
-                      </button>
-                    )}
-                  </Badge>
-                ))
+        <PopoverTrigger
+          nativeButton={false}
+          render={
+            <div
+              role="combobox"
+              aria-expanded={open}
+              aria-disabled={disabled || undefined}
+              tabIndex={disabled ? -1 : 0}
+              onClick={() => !disabled && setOpen(true)}
+              onKeyDown={(e) => {
+                if (disabled) return;
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setOpen(true);
+                }
+              }}
+              className={cn(
+                "border-input focus-visible:border-ring focus-visible:ring-ring/50 flex min-h-9 w-full items-center gap-2 rounded-md border bg-background px-2 py-1.5 text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px]",
+                disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
               )}
-            </span>
-          </div>
+            />
+          }
+        >
+          <span className="flex min-w-0 flex-1 flex-wrap items-center gap-1 min-h-[22px]">
+            {value.length === 0 ? (
+              <span className="text-muted-foreground text-xs">{placeholder}</span>
+            ) : (
+              value.map((v) => (
+                <Badge key={v} variant="secondary" className={cn("gap-1", canRemove && "pr-1")}>
+                  <span className="max-w-[14rem] truncate">{v}</span>
+                  {canRemove && (
+                    <button
+                      type="button"
+                      tabIndex={-1}
+                      aria-label={`Remove ${v}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        remove(v);
+                      }}
+                      onKeyDown={(e) => e.stopPropagation()}
+                      className="rounded-sm p-0.5 hover:bg-muted-foreground/20"
+                    >
+                      <RemoveIcon className="size-3" />
+                    </button>
+                  )}
+                </Badge>
+              ))
+            )}
+          </span>
         </PopoverTrigger>
-        <PopoverContent align="start" className="w-[--radix-popover-trigger-width] p-0">
+        <PopoverContent align="start" className="w-(--anchor-width) p-0">
           <Command shouldFilter={false}>
             <CommandInput
               value={query}

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -1,26 +1,23 @@
 "use client"
 
-import * as React from "react"
-import { Tooltip as TooltipPrimitive } from "radix-ui"
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
 
 import { cn } from "@workspace/ui/lib/utils"
 
 function TooltipProvider({
-  delayDuration = 0,
+  delay = 0,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+}: TooltipPrimitive.Provider.Props) {
   return (
     <TooltipPrimitive.Provider
       data-slot="tooltip-provider"
-      delayDuration={delayDuration}
+      delay={delay}
       {...props}
     />
   )
 }
 
-function Tooltip({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
   return (
     <TooltipProvider>
       <TooltipPrimitive.Root data-slot="tooltip" {...props} />
@@ -28,32 +25,44 @@ function Tooltip({
   )
 }
 
-function TooltipTrigger({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
 }
 
 function TooltipContent({
   className,
+  align = "center",
+  alignOffset = 0,
+  side = "top",
   sideOffset = 0,
   children,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
   return (
     <TooltipPrimitive.Portal>
-      <TooltipPrimitive.Content
-        data-slot="tooltip-content"
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
         sideOffset={sideOffset}
-        className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
-          className
-        )}
-        {...props}
+        className="isolate z-50"
       >
-        {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
-      </TooltipPrimitive.Content>
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] data-[side=bottom]:top-1 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>
   )
 }

--- a/packages/whitelabel/src/components/optimize-button.tsx
+++ b/packages/whitelabel/src/components/optimize-button.tsx
@@ -1,18 +1,19 @@
 "use client";
 
-import { useState } from "react";
-import { IconExternalLink, IconChevronDown } from "@tabler/icons-react";
+import { IconChevronDown, IconExternalLink } from "@tabler/icons-react";
+import type { OptimizeButtonProps } from "@workspace/config/types";
 import { Button } from "@workspace/ui/components/button";
-import { Spinner } from "@workspace/ui/components/spinner";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
+	DropdownMenuGroup,
 	DropdownMenuItem,
-	DropdownMenuTrigger,
 	DropdownMenuLabel,
 	DropdownMenuSeparator,
+	DropdownMenuTrigger,
 } from "@workspace/ui/components/dropdown-menu";
-import type { OptimizeButtonProps } from "@workspace/config/types";
+import { Spinner } from "@workspace/ui/components/spinner";
+import { Fragment, useState } from "react";
 
 export type { OptimizeButtonProps };
 
@@ -129,24 +130,28 @@ export function OptimizeButton({
 					const modelName = getModelDisplayName(model);
 					const loading = isLoading(model);
 					return (
-						<div key={model}>
+						<Fragment key={model}>
 							{index > 0 && <DropdownMenuSeparator />}
-							<DropdownMenuLabel>Optimize for {modelName}</DropdownMenuLabel>
-							<DropdownMenuItem
-								className="cursor-pointer"
-								onClick={(e) => handleOptimizeClick(e, model)}
-								disabled={loading}
-							>
-								<div className="flex items-center justify-between w-full text-xs">
-									<span>{promptName}</span>
-									{loading ? (
-										<Spinner className="ml-2 size-3" />
-									) : (
-										<IconExternalLink size={12} className="size-3 ml-2" />
-									)}
-								</div>
-							</DropdownMenuItem>
-						</div>
+							{/* The label names the entry below it, and Base UI wires that
+							    association through the group, so it has to sit inside one. */}
+							<DropdownMenuGroup>
+								<DropdownMenuLabel>Optimize for {modelName}</DropdownMenuLabel>
+								<DropdownMenuItem
+									className="cursor-pointer"
+									onClick={(e) => handleOptimizeClick(e, model)}
+									disabled={loading}
+								>
+									<div className="flex items-center justify-between w-full text-xs">
+										<span>{promptName}</span>
+										{loading ? (
+											<Spinner className="ml-2 size-3" />
+										) : (
+											<IconExternalLink size={12} className="size-3 ml-2" />
+										)}
+									</div>
+								</DropdownMenuItem>
+							</DropdownMenuGroup>
+						</Fragment>
 					);
 				})}
 			</DropdownMenuContent>

--- a/packages/whitelabel/src/components/optimize-button.tsx
+++ b/packages/whitelabel/src/components/optimize-button.tsx
@@ -120,11 +120,9 @@ export function OptimizeButton({
 	// Dropdown for "all" model selection - shows options for each model
 	return (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button size="sm" className="text-xs cursor-pointer p-0 m-0 h-6">
-					Optimize with {parentName}
-					<IconChevronDown size={12} className="size-3 ml-0.5" />
-				</Button>
+			<DropdownMenuTrigger render={<Button size="sm" className="text-xs cursor-pointer p-0 m-0 h-6" />}>
+				Optimize with {parentName}
+				<IconChevronDown size={12} className="size-3 ml-0.5" />
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end" className="w-48">
 				{availableModels.map((model, index) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.7.0
+        version: 1.7.0(@date-fns/tz@1.5.0)(@types/react@19.2.18)(date-fns@4.3.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@fontsource/geist-sans':
         specifier: ^5.3.0
         version: 5.3.0
@@ -140,7 +143,7 @@ importers:
         version: 1.167.1(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.2.8))(@tanstack/react-router@1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/router-core@1.171.24)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start':
         specifier: ^1.168.46
-        version: 1.168.46(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 1.168.46(crossws@0.4.4(srvx@0.11.15))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       '@tanstack/react-virtual':
         specifier: ^3.14.9
         version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -358,7 +361,7 @@ importers:
         version: 1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start':
         specifier: ^1.168.46
-        version: 1.168.46(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 1.168.46(crossws@0.4.4(srvx@0.11.15))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       '@upstash/redis':
         specifier: ^1.38.2
         version: 1.38.2
@@ -12919,14 +12922,14 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@tanstack/react-start-rsc@0.1.45(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+  '@tanstack/react-start-rsc@0.1.45(crossws@0.4.4(srvx@0.11.15))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/router-core': 1.171.24
       '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
       '@tanstack/start-client-core': 1.170.24
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.36(@tanstack/react-router@1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.2)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.36(@tanstack/react-router@1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.4(srvx@0.11.15))(esbuild@0.28.2)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       '@tanstack/start-storage-context': 1.167.26
       pathe: 2.0.3
       react: 19.2.8
@@ -12972,26 +12975,26 @@ snapshots:
       - webpack
     optional: true
 
-  '@tanstack/react-start-server@1.167.34(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tanstack/react-start-server@1.167.34(crossws@0.4.4(srvx@0.11.15))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/react-router': 1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/router-core': 1.171.24
-      '@tanstack/start-server-core': 1.169.28
+      '@tanstack/start-server-core': 1.169.28(crossws@0.4.4(srvx@0.11.15))
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.46(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+  '@tanstack/react-start@1.168.46(crossws@0.4.4(srvx@0.11.15))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start-client': 1.168.27(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tanstack/react-start-rsc': 0.1.45(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@tanstack/react-start-server': 1.167.34(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/react-start-rsc': 0.1.45(crossws@0.4.4(srvx@0.11.15))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@tanstack/react-start-server': 1.167.34(crossws@0.4.4(srvx@0.11.15))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
       '@tanstack/start-client-core': 1.170.24
-      '@tanstack/start-plugin-core': 1.171.36(@tanstack/react-router@1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.2)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@tanstack/start-server-core': 1.169.28
+      '@tanstack/start-plugin-core': 1.171.36(@tanstack/react-router@1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.4(srvx@0.11.15))(esbuild@0.28.2)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@tanstack/start-server-core': 1.169.28(crossws@0.4.4(srvx@0.11.15))
       pathe: 2.0.3
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -13016,11 +13019,11 @@ snapshots:
       '@tanstack/react-router': 1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start-client': 1.168.27(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start-rsc': 0.1.45(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@tanstack/react-start-server': 1.167.34(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/react-start-server': 1.167.34(crossws@0.4.4(srvx@0.11.15))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.24
       '@tanstack/start-plugin-core': 1.171.36(@tanstack/react-router@1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.2)(rolldown@1.2.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@tanstack/start-server-core': 1.169.28
+      '@tanstack/start-server-core': 1.169.28(crossws@0.4.4(srvx@0.11.15))
       pathe: 2.0.3
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -13185,7 +13188,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.36(@tanstack/react-router@1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.2)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+  '@tanstack/start-plugin-core@1.171.36(@tanstack/react-router@1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.4(srvx@0.11.15))(esbuild@0.28.2)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.7(supports-color@7.2.0)
@@ -13194,7 +13197,7 @@ snapshots:
       '@tanstack/router-generator': 1.167.30(supports-color@7.2.0)
       '@tanstack/router-plugin': 1.168.32(@tanstack/react-router@1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.2)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
-      '@tanstack/start-server-core': 1.169.28
+      '@tanstack/start-server-core': 1.169.28(crossws@0.4.4(srvx@0.11.15))
       exsolve: 1.1.1
       lightningcss: 1.33.0
       pathe: 2.0.3
@@ -13232,7 +13235,7 @@ snapshots:
       '@tanstack/router-generator': 1.167.30
       '@tanstack/router-plugin': 1.168.32(@tanstack/react-router@1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.2)(rolldown@1.2.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       '@tanstack/router-utils': 1.162.2
-      '@tanstack/start-server-core': 1.169.28
+      '@tanstack/start-server-core': 1.169.28(crossws@0.4.4(srvx@0.11.15))
       exsolve: 1.1.1
       lightningcss: 1.33.0
       pathe: 2.0.3
@@ -13262,14 +13265,14 @@ snapshots:
       - webpack
     optional: true
 
-  '@tanstack/start-server-core@1.169.28':
+  '@tanstack/start-server-core@1.169.28(crossws@0.4.4(srvx@0.11.15))':
     dependencies:
       '@tanstack/history': 1.162.1
       '@tanstack/router-core': 1.171.24
       '@tanstack/start-client-core': 1.170.24
       '@tanstack/start-storage-context': 1.167.26
       fetchdts: 0.1.7
-      h3-v2: h3@2.0.1-rc.26
+      h3-v2: h3@2.0.1-rc.26(crossws@0.4.4(srvx@0.11.15))
       seroval: 1.6.2
     transitivePeerDependencies:
       - crossws
@@ -14119,7 +14122,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@prisma/client': 5.22.0
-      '@tanstack/react-start': 1.168.46(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@tanstack/react-start': 1.168.46(crossws@0.4.4(srvx@0.11.15))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       better-sqlite3: 12.11.1
       drizzle-kit: 0.31.10
       drizzle-orm: 0.41.0(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/pg@8.21.0)(better-sqlite3@12.11.1)(kysely@0.28.17)(pg@8.23.0)
@@ -14150,7 +14153,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@prisma/client': 5.22.0
-      '@tanstack/react-start': 1.168.46(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@tanstack/react-start': 1.168.46(crossws@0.4.4(srvx@0.11.15))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(supports-color@7.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       better-sqlite3: 12.11.1
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/pg@8.21.0)(@upstash/redis@1.38.2)(better-sqlite3@12.11.1)(kysely@0.28.17)(pg@8.23.0)
@@ -15408,10 +15411,12 @@ snapshots:
     optionalDependencies:
       crossws: 0.4.4(srvx@0.11.15)
 
-  h3@2.0.1-rc.26:
+  h3@2.0.1-rc.26(crossws@0.4.4(srvx@0.11.15)):
     dependencies:
       rou3: 0.9.2
       srvx: 0.12.5
+    optionalDependencies:
+      crossws: 0.4.4(srvx@0.11.15)
 
   handlebars@4.7.9:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -721,6 +721,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.7.0
+        version: 1.7.0(@date-fns/tz@1.5.0)(@types/react@19.2.18)(date-fns@4.3.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@hookform/resolvers':
         specifier: ^5.9.0
         version: 5.9.0(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(react-hook-form@7.85.0(react@19.2.8))(zod@4.4.3)
@@ -736,9 +739,6 @@ importers:
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
-      radix-ui:
-        specifier: ^1.6.7
-        version: 1.6.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19
         version: 19.2.8
@@ -2868,19 +2868,6 @@ packages:
   '@radix-ui/primitive@1.1.7':
     resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
 
-  '@radix-ui/react-accessible-icon@1.1.15':
-    resolution: {integrity: sha512-WTQwcAvQf5sOcuUyi90lKPbhwcvQ+j55cjrSmeaN+L2vKU3DooOvlKw2MDeiJ5IkV5N905KW0/fGojKOBhD11A==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-accordion@1.2.20':
     resolution: {integrity: sha512-jDhG9FvAEnlhnjrsINbNXcUa4G+L1KqSkJSunkbKEzFRcAb52jvM0PjPxPRvhe1HNc5F5yc0yzzWeeqlH4yBIg==}
     peerDependencies:
@@ -2894,60 +2881,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-alert-dialog@1.1.23':
-    resolution: {integrity: sha512-VAYOiQRqj3GPpYJE0I9J+X8Ip05cyVlNdKOFeiGS2Ou1HHGfpl0BxOyZm6nmVDyU+W+NF3/XLzmjHmVGydhwgA==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-arrow@1.1.15':
     resolution: {integrity: sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-aspect-ratio@1.1.15':
-    resolution: {integrity: sha512-fy+dyVR+90nelK8rqIznFlxzx7uPcGbhxH8Nfr2bHb4UfSe+e3hklOC0luK0hDwVwnRX7xTRySpsrQVeW+/oNQ==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-avatar@1.2.6':
-    resolution: {integrity: sha512-4ULOTJ/mqy2hT9GlWa/MFHxHSvH3nJzHnZM1waNsc5Bonv7i70aNenghXmD97S6OJ81ekXONGGt4nT1r0PfEdA==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-checkbox@1.3.11':
-    resolution: {integrity: sha512-Gnptr9pDDQxD3hgq2dtPbtrp/c2qH1mBwIzw3X/ivrMb2e1t0jMTi606fVEqFPaQR1ggXIVQWKj3P2WW9v7zGQ==}
     peerDependencies:
       '@types/react': ^19.2.14
       '@types/react-dom': ^19.2.3
@@ -3003,19 +2938,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-context-menu@2.3.7':
-    resolution: {integrity: sha512-CtXP35dxaB5T3zXSd+E3uHe/QpXcpYnZmxp6OaIbfthtfW4wyb77M23BG+bwIJDtsMwEP/YssdsmNyZu7jhWew==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-context@1.2.2':
     resolution: {integrity: sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==}
     peerDependencies:
@@ -3060,19 +2982,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-dropdown-menu@2.1.24':
-    resolution: {integrity: sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-focus-guards@1.1.6':
     resolution: {integrity: sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==}
     peerDependencies:
@@ -3084,32 +2993,6 @@ packages:
 
   '@radix-ui/react-focus-scope@1.1.16':
     resolution: {integrity: sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-form@0.1.16':
-    resolution: {integrity: sha512-Q4TLEn2A7TAypxwmd6R9EwrlXDvkfYSDMrq9/887AXAGh+G1rH+kYJKSTv+Si9Y0JPKTwKYv6PviAJosysNimA==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-hover-card@1.1.23':
-    resolution: {integrity: sha512-H8qONfZd3ltrU3+jHCIgITbWo6e1iTKvP9DHdrvYbX48ooRM5FjEDTn16AMwdfuOGkWdZEhpl3PLL/Wk/AnHDQ==}
     peerDependencies:
       '@types/react': ^19.2.14
       '@types/react-dom': ^19.2.3
@@ -3139,73 +3022,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-label@2.1.15':
-    resolution: {integrity: sha512-o/rdYEwZTTo5tjknnPeyQFU45kUC4i/XyeDPP+HGyi6XqpOP6Zf5Ya5vh/Yfe9Id5JiuWnnAx2XqIeD3UYZt0g==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-menu@2.1.24':
-    resolution: {integrity: sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-menubar@1.1.24':
-    resolution: {integrity: sha512-eeVs0vf7cuqXaM0qLQCPcufImiJNVBXdJDLu7ZGYl2732UH23Qat/foNGrr6vYV3/DdTsBqASoggUFgH14OcZA==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-navigation-menu@1.2.22':
     resolution: {integrity: sha512-ou7iLEJ+yrhQndkkA4U21XIdS/CS45F4iXIkTZcb6/Ne9EMsOuDudVmCwmDnfFZZ+y1FZqXRNSIgBy+YMvZVZg==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-one-time-password-field@0.1.16':
-    resolution: {integrity: sha512-Tj9P6ntAJEw52oq/F0AGknXR4XncxEt7XU47O3xJQOiWfLzEy3d9gtgKfvjSzGxzHkfL+VzvxGu2KTFsloJqXw==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-password-toggle-field@0.1.11':
-    resolution: {integrity: sha512-4gvFnmDXu3dgj21CqsufzIameRvlRd4SBqaWhcrlrNhRo0Y5i/49AmRJYe1fdAM3G2VNBbmin4b0D6cdQocwgw==}
     peerDependencies:
       '@types/react': ^19.2.14
       '@types/react-dom': ^19.2.3
@@ -3295,32 +3113,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-progress@1.1.16':
-    resolution: {integrity: sha512-5XnomAsoZZCY+KNTxbIghpGqPruZvKFNlvcAljVAOdDRDsH4/OZQxhtwo5wdtoDM5R6MhJBb2sPnDuRFep3lzg==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-radio-group@1.4.7':
-    resolution: {integrity: sha512-cgYFEkntCxppHZgtSZ+7vh0wbZQ+IC7PPMw8DSnRG27B6kDd32/Zw0OJt7dGDigCoprMuWHjg2PvUn3PYvPFoQ==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-roving-focus@1.1.19':
     resolution: {integrity: sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==}
     peerDependencies:
@@ -3336,45 +3128,6 @@ packages:
 
   '@radix-ui/react-scroll-area@1.2.18':
     resolution: {integrity: sha512-Zn5Cd171wxsO3Dfg8HaW6RifTb9CYTKQJHs/G4+LN1GfmJpaQMZQyQxMprVPHpaz7QY4l9BxK2JwQuzHsXC8nA==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-select@2.3.7':
-    resolution: {integrity: sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-separator@1.1.15':
-    resolution: {integrity: sha512-jOLO4lssEzWpoDu7G+Ze4VjwMRUBt291pnZD0gmalREZipnTX3wadQo7Fy48GCTfe14/YRN6rw/rOJqrE85Wxw==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-slider@1.4.7':
-    resolution: {integrity: sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==}
     peerDependencies:
       '@types/react': ^19.2.14
       '@types/react-dom': ^19.2.3
@@ -3404,86 +3157,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-switch@1.3.7':
-    resolution: {integrity: sha512-48tB/4dn2UVLBCYhTu9AuR63IHl73l/qLbLgxd86noTUor4/K4LFDAcYjK+isP5313qxaFpjPVogE7+Y0/V3Kw==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-tabs@1.1.21':
     resolution: {integrity: sha512-UKxJlZid7FVtsk/WTxj4i4uSEgj2Au+KBbS7SQyTlzMhhn+86Cz3tISZdTa87bfEfcuvZezf2ZsxD4xuEKtkog==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-toast@1.2.23':
-    resolution: {integrity: sha512-ofhyAsYaocRGOs/n0XWdUOSVzEAG6BfrMVM8z0c0kLEWY38w/0WuMFPTJP/HVaZPYkMvHZoKIIhNcjbTCBILPg==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-toggle-group@1.1.19':
-    resolution: {integrity: sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-toggle@1.1.18':
-    resolution: {integrity: sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-toolbar@1.1.19':
-    resolution: {integrity: sha512-Ph0IvtYw4VB12ZnZg+YtrGs8yJQsnizwo/zu0R4Y/nWugtJzA7Pg1eWeuDR9+LSqn+xjamss+UOSOJJJ4gx8jw==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-tooltip@1.2.16':
-    resolution: {integrity: sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==}
     peerDependencies:
       '@types/react': ^19.2.14
       '@types/react-dom': ^19.2.3
@@ -3515,15 +3190,6 @@ packages:
 
   '@radix-ui/react-use-effect-event@0.0.5':
     resolution: {integrity: sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-escape-keydown@1.1.5':
-    resolution: {integrity: sha512-ge3ipobwSXTj4JyVtswQ7qZj0ZHdtbGuOno/LrgAAeSxtsJ6Vs4Gz5IkPH2bmqpjcLUFoqGhA/mueuIf63UXlA==}
     peerDependencies:
       '@types/react': ^19.2.14
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -8411,19 +8077,6 @@ packages:
     resolution: {integrity: sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==}
     engines: {node: '>=16.0.0'}
 
-  radix-ui@1.6.7:
-    resolution: {integrity: sha512-QBdhh1arIEUvPC0dQ5+nwWAxt7+N+oP/9jPwjJkGFoSk/sqxg32gJtSXGtFh8frAIcS6oC9cx2Q+7KYCQLOAeA==}
-    peerDependencies:
-      '@types/react': ^19.2.14
-      '@types/react-dom': ^19.2.3
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
 
@@ -11935,15 +11588,6 @@ snapshots:
 
   '@radix-ui/primitive@1.1.7': {}
 
-  '@radix-ui/react-accessible-icon@1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
   '@radix-ui/react-accordion@1.2.20(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -11961,60 +11605,9 @@ snapshots:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-alert-dialog@1.1.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
   '@radix-ui/react-arrow@1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-aspect-ratio@1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-avatar@1.2.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-checkbox@1.3.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
@@ -12060,19 +11653,6 @@ snapshots:
       react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.18
-
-  '@radix-ui/react-context-menu@2.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@radix-ui/react-context@1.2.2(@types/react@19.2.18)(react@19.2.8)':
     dependencies:
@@ -12122,21 +11702,6 @@ snapshots:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-dropdown-menu@2.1.24(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-id': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
   '@radix-ui/react-focus-guards@1.1.6(@types/react@19.2.18)(react@19.2.8)':
     dependencies:
       react: 19.2.8
@@ -12148,37 +11713,6 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-form@0.1.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-id': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-label': 2.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-hover-card@1.1.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
@@ -12199,59 +11733,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@radix-ui/react-label@2.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-menu@2.1.24(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-id': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      aria-hidden: 1.2.6
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-remove-scroll: 2.7.2(@types/react@19.2.18)(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-menubar@1.1.24(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-id': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
   '@radix-ui/react-navigation-menu@1.2.22(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -12268,42 +11749,6 @@ snapshots:
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.8)
       '@radix-ui/react-use-previous': 1.1.4(@types/react@19.2.18)(react@19.2.8)
       '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-one-time-password-field@0.1.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/number': 1.1.3
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-password-toggle-field@0.1.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-id': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
@@ -12388,33 +11833,6 @@ snapshots:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-progress@1.1.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-radio-group@1.4.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
   '@radix-ui/react-roving-focus@1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -12451,64 +11869,6 @@ snapshots:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-select@2.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/number': 1.1.3
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-id': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-previous': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      aria-hidden: 1.2.6
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-remove-scroll: 2.7.2(@types/react@19.2.18)(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-separator@1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-slider@1.4.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/number': 1.1.3
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-previous': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
   '@radix-ui/react-slot@1.2.4(@types/react@19.2.18)(react@19.2.8)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.8)
@@ -12523,20 +11883,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@radix-ui/react-switch@1.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
   '@radix-ui/react-tabs@1.1.21(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -12547,88 +11893,6 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-toast@1.2.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-toggle-group@1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-toggle': 1.1.18(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-toggle@1.1.18(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-toolbar@1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-separator': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-toggle-group': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-
-  '@radix-ui/react-tooltip@1.2.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-id': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
@@ -12653,13 +11917,6 @@ snapshots:
   '@radix-ui/react-use-effect-event@0.0.5(@types/react@19.2.18)(react@19.2.8)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      react: 19.2.8
-    optionalDependencies:
-      '@types/react': 19.2.18
-
-  '@radix-ui/react-use-escape-keydown@1.1.5(@types/react@19.2.18)(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.18
@@ -17875,69 +17132,6 @@ snapshots:
       '@jitl/quickjs-wasmfile-release-asyncify': 0.32.0
       '@jitl/quickjs-wasmfile-release-sync': 0.32.0
       quickjs-emscripten-core: 0.32.0
-
-  radix-ui@1.6.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-accessible-icon': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-accordion': 1.2.20(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-alert-dialog': 1.1.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-arrow': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-aspect-ratio': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-avatar': 1.2.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-checkbox': 1.3.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-collapsible': 1.1.20(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-context-menu': 2.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-dropdown-menu': 2.1.24(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-form': 0.1.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-hover-card': 1.1.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-label': 2.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-menubar': 1.1.24(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-navigation-menu': 1.2.22(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-one-time-password-field': 0.1.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-password-toggle-field': 0.1.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-popover': 1.1.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-progress': 1.1.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-radio-group': 1.4.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-scroll-area': 1.2.18(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-select': 2.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-separator': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-slider': 1.4.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-switch': 1.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-toast': 1.2.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-toggle': 1.1.18(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-toggle-group': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-toolbar': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-tooltip': 1.2.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-escape-keydown': 1.1.5(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   rc9@3.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,9 @@ importers:
 
   apps/www:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.7.0
+        version: 1.7.0(@date-fns/tz@1.5.0)(@types/react@19.2.18)(date-fns@4.3.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@fontsource/geist-mono':
         specifier: ^5.3.0
         version: 5.3.0

--- a/scripts/check-server-bundle.mjs
+++ b/scripts/check-server-bundle.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Fails when a Nitro server bundle still expects to resolve a package from disk
+ * at request time.
+ *
+ * The bundlers turn an unresolved CommonJS `require("x")` into a `__require("x")`
+ * that only runs when that module is first needed. Nothing complains at build
+ * time, the output looks complete, and the app dies on the first render in any
+ * environment that ships `.output` without a `node_modules` beside it — the
+ * Docker image and the Vercel function both do. Worse, whether it fires depends
+ * on which chunk the module lands in: the same unresolved require can sit
+ * harmlessly in a route nobody hits and then start taking down every page after
+ * an unrelated dependency change.
+ *
+ * Usage: node scripts/check-server-bundle.mjs <path-to-.output/server> [...]
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { builtinModules } from "node:module";
+import { join, relative } from "node:path";
+
+const BUILTINS = new Set([...builtinModules, ...builtinModules.map((m) => `node:${m}`)]);
+
+/** Rolldown emits this for a `require()` it could not link at build time. */
+const RUNTIME_REQUIRE = /__require\("([^"]+)"\)/g;
+
+function serverFiles(dir) {
+	const found = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const path = join(dir, entry.name);
+		// Traced dependencies really are resolved from disk; they are the
+		// supported escape hatch (see `traceDeps` in the app vite configs).
+		if (entry.isDirectory()) {
+			if (entry.name !== "node_modules") found.push(...serverFiles(path));
+		} else if (entry.name.endsWith(".mjs") || entry.name.endsWith(".js")) {
+			found.push(path);
+		}
+	}
+	return found;
+}
+
+function tracedPackages(serverDir) {
+	const dir = join(serverDir, "node_modules");
+	try {
+		if (!statSync(dir).isDirectory()) return new Set();
+	} catch {
+		return new Set();
+	}
+	const names = new Set();
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		if (entry.name.startsWith("@")) {
+			for (const scoped of readdirSync(join(dir, entry.name))) {
+				names.add(`${entry.name}/${scoped}`);
+			}
+		} else {
+			names.add(entry.name);
+		}
+	}
+	return names;
+}
+
+function unresolved(serverDir) {
+	const traced = tracedPackages(serverDir);
+	const problems = [];
+	for (const file of serverFiles(serverDir)) {
+		const source = readFileSync(file, "utf8");
+		for (const [, specifier] of source.matchAll(RUNTIME_REQUIRE)) {
+			if (BUILTINS.has(specifier)) continue;
+			const pkg = specifier.startsWith("@")
+				? specifier.split("/").slice(0, 2).join("/")
+				: specifier.split("/")[0];
+			if (traced.has(pkg)) continue;
+			problems.push({ file: relative(serverDir, file), specifier });
+		}
+	}
+	return problems;
+}
+
+const dirs = process.argv.slice(2);
+if (dirs.length === 0) {
+	console.error("usage: check-server-bundle.mjs <path-to-.output/server> [...]");
+	process.exit(2);
+}
+
+let failed = false;
+for (const dir of dirs) {
+	const problems = unresolved(dir);
+	if (problems.length === 0) continue;
+	failed = true;
+	console.error(`${dir}: server bundle expects packages it does not ship`);
+	for (const { file, specifier } of problems) {
+		console.error(`  ${file}: require("${specifier}")`);
+	}
+	const packages = [...new Set(problems.map((p) => p.specifier))].join(", ");
+	console.error(
+		`  Declare the dependency that pulls in ${packages} in this app's package.json so the` +
+			" bundler resolves it, or add it to the nitro plugin's traceDeps so it ships alongside.",
+	);
+}
+
+process.exit(failed ? 1 : 0);

--- a/scripts/check-server-bundle.mjs
+++ b/scripts/check-server-bundle.mjs
@@ -1,18 +1,18 @@
 #!/usr/bin/env node
 /**
- * Fails when a Nitro server bundle still expects to resolve a package from disk
- * at request time.
+ * Fails when a server bundle still expects to resolve a package from disk at
+ * request time.
  *
  * The bundlers turn an unresolved CommonJS `require("x")` into a `__require("x")`
  * that only runs when that module is first needed. Nothing complains at build
  * time, the output looks complete, and the app dies on the first render in any
- * environment that ships `.output` without a `node_modules` beside it — the
+ * environment that ships the bundle without a `node_modules` beside it — the
  * Docker image and the Vercel function both do. Worse, whether it fires depends
  * on which chunk the module lands in: the same unresolved require can sit
  * harmlessly in a route nobody hits and then start taking down every page after
  * an unrelated dependency change.
  *
- * Usage: node scripts/check-server-bundle.mjs <path-to-.output/server> [...]
+ * Usage: node scripts/check-server-bundle.mjs <app-dir> [...]
  */
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { builtinModules } from "node:module";
@@ -23,79 +23,112 @@ const BUILTINS = new Set([...builtinModules, ...builtinModules.map((m) => `node:
 /** Rolldown emits this for a `require()` it could not link at build time. */
 const RUNTIME_REQUIRE = /__require\("([^"]+)"\)/g;
 
-function serverFiles(dir) {
-	const found = [];
-	for (const entry of readdirSync(dir, { withFileTypes: true })) {
-		const path = join(dir, entry.name);
-		// Traced dependencies really are resolved from disk; they are the
-		// supported escape hatch (see `traceDeps` in the app vite configs).
-		if (entry.isDirectory()) {
-			if (entry.name !== "node_modules") found.push(...serverFiles(path));
-		} else if (entry.name.endsWith(".mjs") || entry.name.endsWith(".js")) {
-			found.push(path);
-		}
-	}
-	return found;
+function isDirectory(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
-function tracedPackages(serverDir) {
-	const dir = join(serverDir, "node_modules");
-	try {
-		if (!statSync(dir).isDirectory()) return new Set();
-	} catch {
-		return new Set();
-	}
-	const names = new Set();
-	for (const entry of readdirSync(dir, { withFileTypes: true })) {
-		if (!entry.isDirectory()) continue;
-		if (entry.name.startsWith("@")) {
-			for (const scoped of readdirSync(join(dir, entry.name))) {
-				names.add(`${entry.name}/${scoped}`);
-			}
-		} else {
-			names.add(entry.name);
-		}
-	}
-	return names;
+/**
+ * Where the server bundle lands depends on the Nitro preset: the node preset
+ * writes `.output/server`, the Vercel preset writes a function directory per
+ * entrypoint and no `.output` at all.
+ */
+function serverBundles(appDir) {
+  const bundles = [];
+
+  const node = join(appDir, ".output", "server");
+  if (isDirectory(node)) bundles.push(node);
+
+  const functions = join(appDir, ".vercel", "output", "functions");
+  if (isDirectory(functions)) {
+    for (const name of readdirSync(functions)) {
+      const dir = join(functions, name);
+      if (name.endsWith(".func") && isDirectory(dir)) bundles.push(dir);
+    }
+  }
+  return bundles;
 }
 
-function unresolved(serverDir) {
-	const traced = tracedPackages(serverDir);
-	const problems = [];
-	for (const file of serverFiles(serverDir)) {
-		const source = readFileSync(file, "utf8");
-		for (const [, specifier] of source.matchAll(RUNTIME_REQUIRE)) {
-			if (BUILTINS.has(specifier)) continue;
-			const pkg = specifier.startsWith("@")
-				? specifier.split("/").slice(0, 2).join("/")
-				: specifier.split("/")[0];
-			if (traced.has(pkg)) continue;
-			problems.push({ file: relative(serverDir, file), specifier });
-		}
-	}
-	return problems;
+function bundleFiles(dir) {
+  const found = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    // Traced dependencies really are resolved from disk; they are the
+    // supported escape hatch (see `traceDeps` in the app vite configs).
+    if (entry.isDirectory()) {
+      if (entry.name !== "node_modules") found.push(...bundleFiles(path));
+    } else if (entry.name.endsWith(".mjs") || entry.name.endsWith(".js")) {
+      found.push(path);
+    }
+  }
+  return found;
 }
 
-const dirs = process.argv.slice(2);
-if (dirs.length === 0) {
-	console.error("usage: check-server-bundle.mjs <path-to-.output/server> [...]");
-	process.exit(2);
+function tracedPackages(bundleDir) {
+  const dir = join(bundleDir, "node_modules");
+  if (!isDirectory(dir)) return new Set();
+  const names = new Set();
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith("@")) {
+      for (const scoped of readdirSync(join(dir, entry.name))) {
+        names.add(`${entry.name}/${scoped}`);
+      }
+    } else {
+      names.add(entry.name);
+    }
+  }
+  return names;
+}
+
+function unresolved(bundleDir) {
+  const traced = tracedPackages(bundleDir);
+  const problems = [];
+  for (const file of bundleFiles(bundleDir)) {
+    const source = readFileSync(file, "utf8");
+    for (const [, specifier] of source.matchAll(RUNTIME_REQUIRE)) {
+      if (BUILTINS.has(specifier)) continue;
+      const pkg = specifier.startsWith("@")
+        ? specifier.split("/").slice(0, 2).join("/")
+        : specifier.split("/")[0];
+      if (traced.has(pkg)) continue;
+      problems.push({ file: relative(bundleDir, file), specifier });
+    }
+  }
+  return problems;
+}
+
+const appDirs = process.argv.slice(2);
+if (appDirs.length === 0) {
+  console.error("usage: check-server-bundle.mjs <app-dir> [...]");
+  process.exit(2);
 }
 
 let failed = false;
-for (const dir of dirs) {
-	const problems = unresolved(dir);
-	if (problems.length === 0) continue;
-	failed = true;
-	console.error(`${dir}: server bundle expects packages it does not ship`);
-	for (const { file, specifier } of problems) {
-		console.error(`  ${file}: require("${specifier}")`);
-	}
-	const packages = [...new Set(problems.map((p) => p.specifier))].join(", ");
-	console.error(
-		`  Declare the dependency that pulls in ${packages} in this app's package.json so the` +
-			" bundler resolves it, or add it to the nitro plugin's traceDeps so it ships alongside.",
-	);
+for (const appDir of appDirs) {
+  const bundles = serverBundles(appDir);
+  if (bundles.length === 0) {
+    console.error(`${appDir}: no server bundle found — expected .output/server or .vercel/output/functions`);
+    failed = true;
+    continue;
+  }
+  for (const bundle of bundles) {
+    const problems = unresolved(bundle);
+    if (problems.length === 0) continue;
+    failed = true;
+    console.error(`${bundle}: server bundle expects packages it does not ship`);
+    for (const { file, specifier } of problems) {
+      console.error(`  ${file}: require("${specifier}")`);
+    }
+    const packages = [...new Set(problems.map((p) => p.specifier))].join(", ");
+    console.error(
+      `  Declare the dependency that pulls in ${packages} in this app's package.json so the` +
+        " bundler resolves it, or add it to the nitro plugin's traceDeps so it ships alongside.",
+    );
+  }
 }
 
 process.exit(failed ? 1 : 0);

--- a/scripts/check-server-bundle.test.mjs
+++ b/scripts/check-server-bundle.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(new URL("check-server-bundle.mjs", import.meta.url));
+
+/** Build a throwaway `.output/server` tree and run the check over it. */
+function check(files, { traced = [] } = {}) {
+	const dir = mkdtempSync(join(tmpdir(), "check-server-bundle-"));
+	for (const [name, source] of Object.entries(files)) {
+		const path = join(dir, name);
+		mkdirSync(join(path, ".."), { recursive: true });
+		writeFileSync(path, source);
+	}
+	for (const pkg of traced) {
+		mkdirSync(join(dir, "node_modules", pkg), { recursive: true });
+	}
+	const { status, stderr } = spawnSync(process.execPath, [SCRIPT, dir], { encoding: "utf8" });
+	return { status, stderr };
+}
+
+test("passes a bundle that resolves everything at build time", () => {
+	const { status } = check({
+		"index.mjs": 'import { x } from "./chunk.mjs";\nexport { x };\n',
+		"chunk.mjs": 'export const x = 1;\n',
+	});
+	assert.equal(status, 0);
+});
+
+test("passes requires of node builtins", () => {
+	const { status } = check({
+		"index.mjs": 'var fs = __require("node:fs");\nvar path = __require("path");\n',
+	});
+	assert.equal(status, 0);
+});
+
+test("fails a require of a package the bundle does not ship", () => {
+	const { status, stderr } = check({
+		"_ssr/footer.mjs": 'var React = __require("react");\n',
+	});
+	assert.equal(status, 1);
+	assert.match(stderr, /_ssr\/footer\.mjs/);
+	assert.match(stderr, /require\("react"\)/);
+});
+
+test("passes a require of a traced dependency, which does ship", () => {
+	const { status } = check(
+		{ "index.mjs": 'var resvg = __require("@resvg/resvg-js");\nvar pg = __require("pg/lib/native");\n' },
+		{ traced: ["@resvg/resvg-js", "pg"] },
+	);
+	assert.equal(status, 0);
+});
+
+test("ignores the traced dependencies' own sources", () => {
+	const { status } = check(
+		{ "node_modules/pg/index.js": 'var react = __require("react");\n' },
+		{ traced: ["pg"] },
+	);
+	assert.equal(status, 0);
+});

--- a/scripts/check-server-bundle.test.mjs
+++ b/scripts/check-server-bundle.test.mjs
@@ -8,57 +8,88 @@ import { fileURLToPath } from "node:url";
 
 const SCRIPT = fileURLToPath(new URL("check-server-bundle.mjs", import.meta.url));
 
-/** Build a throwaway `.output/server` tree and run the check over it. */
-function check(files, { traced = [] } = {}) {
-	const dir = mkdtempSync(join(tmpdir(), "check-server-bundle-"));
-	for (const [name, source] of Object.entries(files)) {
-		const path = join(dir, name);
-		mkdirSync(join(path, ".."), { recursive: true });
-		writeFileSync(path, source);
-	}
-	for (const pkg of traced) {
-		mkdirSync(join(dir, "node_modules", pkg), { recursive: true });
-	}
-	const { status, stderr } = spawnSync(process.execPath, [SCRIPT, dir], { encoding: "utf8" });
-	return { status, stderr };
+/** Build a throwaway app directory and run the check over it. */
+function check(files, { traced = [], tracedIn = ".output/server" } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "check-server-bundle-"));
+  for (const [name, source] of Object.entries(files)) {
+    const path = join(dir, name);
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, source);
+  }
+  for (const pkg of traced) {
+    mkdirSync(join(dir, tracedIn, "node_modules", pkg), { recursive: true });
+  }
+  const { status, stderr } = spawnSync(process.execPath, [SCRIPT, dir], { encoding: "utf8" });
+  return { status, stderr };
 }
 
 test("passes a bundle that resolves everything at build time", () => {
-	const { status } = check({
-		"index.mjs": 'import { x } from "./chunk.mjs";\nexport { x };\n',
-		"chunk.mjs": 'export const x = 1;\n',
-	});
-	assert.equal(status, 0);
+  const { status } = check({
+    ".output/server/index.mjs": 'import { x } from "./chunk.mjs";\nexport { x };\n',
+    ".output/server/chunk.mjs": "export const x = 1;\n",
+  });
+  assert.equal(status, 0);
 });
 
 test("passes requires of node builtins", () => {
-	const { status } = check({
-		"index.mjs": 'var fs = __require("node:fs");\nvar path = __require("path");\n',
-	});
-	assert.equal(status, 0);
+  const { status } = check({
+    ".output/server/index.mjs": 'var fs = __require("node:fs");\nvar path = __require("path");\n',
+  });
+  assert.equal(status, 0);
 });
 
 test("fails a require of a package the bundle does not ship", () => {
-	const { status, stderr } = check({
-		"_ssr/footer.mjs": 'var React = __require("react");\n',
-	});
-	assert.equal(status, 1);
-	assert.match(stderr, /_ssr\/footer\.mjs/);
-	assert.match(stderr, /require\("react"\)/);
+  const { status, stderr } = check({
+    ".output/server/_ssr/footer.mjs": 'var React = __require("react");\n',
+  });
+  assert.equal(status, 1);
+  assert.match(stderr, /_ssr\/footer\.mjs/);
+  assert.match(stderr, /require\("react"\)/);
 });
 
 test("passes a require of a traced dependency, which does ship", () => {
-	const { status } = check(
-		{ "index.mjs": 'var resvg = __require("@resvg/resvg-js");\nvar pg = __require("pg/lib/native");\n' },
-		{ traced: ["@resvg/resvg-js", "pg"] },
-	);
-	assert.equal(status, 0);
+  const { status } = check(
+    {
+      ".output/server/index.mjs":
+        'var resvg = __require("@resvg/resvg-js");\nvar pg = __require("pg/lib/native");\n',
+    },
+    { traced: ["@resvg/resvg-js", "pg"] },
+  );
+  assert.equal(status, 0);
 });
 
 test("ignores the traced dependencies' own sources", () => {
-	const { status } = check(
-		{ "node_modules/pg/index.js": 'var react = __require("react");\n' },
-		{ traced: ["pg"] },
-	);
-	assert.equal(status, 0);
+  const { status } = check(
+    { ".output/server/node_modules/pg/index.js": 'var react = __require("react");\n' },
+    { traced: ["pg"] },
+  );
+  assert.equal(status, 0);
+});
+
+// The Vercel preset writes function directories and no .output at all, which is
+// the layout that actually shipped the broken bundle.
+test("checks the vercel preset's function directories", () => {
+  const { status, stderr } = check({
+    ".vercel/output/functions/__server.func/_ssr/footer.mjs": 'var React = __require("react");\n',
+  });
+  assert.equal(status, 1);
+  assert.match(stderr, /__server\.func/);
+  assert.match(stderr, /require\("react"\)/);
+});
+
+test("passes a clean vercel preset build", () => {
+  const { status } = check(
+    {
+      ".vercel/output/functions/__server.func/index.mjs":
+        'var fs = __require("node:fs");\nvar resvg = __require("@resvg/resvg-js");\n',
+    },
+    { traced: ["@resvg/resvg-js"], tracedIn: ".vercel/output/functions/__server.func" },
+  );
+  assert.equal(status, 0);
+});
+
+test("fails when there is no server bundle to check at all", () => {
+  const { status, stderr } = check({ "package.json": "{}\n" });
+  assert.equal(status, 1);
+  assert.match(stderr, /no server bundle found/);
 });


### PR DESCRIPTION
Swaps `radix-ui` for `@base-ui/react@1.7.0` across `packages/ui` and every consumer, following shadcn's official [`migrate-radix-to-base`](https://github.com/shadcn-ui/ui/tree/main/skills/migrate-radix-to-base) guide.

This project is on the legacy `new-york` style, which has no `base-new-york` counterpart in the registry. Per the guide that means a **transformation-engine** migration rather than a golden-pair replay: every wrapper keeps its own class strings and public API, and only the primitives, part names, data-attribute hooks and CSS variables were rewired. The `base-lyra` registry was used as a reference for *shape* (positioner anatomy, `useRender` idiom, submenu defaults) but never for classes, so the app should look identical.

## What changed

20 wrappers: avatar, badge, breadcrumb, button, checkbox, collapsible, dialog, dropdown-menu, form, label, navigation-menu, popover, progress, select, separator, sheet, sidebar, switch, tabs, tooltip.

- Overlays gain the `Portal > Positioner > Popup` anatomy, with positioning props declared, destructured and forwarded to the Positioner.
- `dropdown-menu` maps onto Base UI's `Menu` (`Label` → `GroupLabel`, `ItemIndicator` → `Checkbox/RadioItemIndicator`, `Sub` → `SubmenuRoot`).
- `select`'s `Viewport` → `List`, `position="popper"` → `alignItemWithTrigger`.
- `label` becomes a native `<label>`; `breadcrumb`, `badge`, `form` and `sidebar` drop `Slot` for `useRender` + `mergeProps`.
- Class hooks follow: `data-[state=open]` → `data-open`, submenu/menu triggers → `data-popup-open`, `--radix-*-trigger-width` → `--anchor-width`, `--radix-*-content-available-height` → `--available-height`.
- 88 `asChild` call sites across 48 files became `render`.

### Links styled as buttons

31 of those call sites were `<Button asChild><Link/></Button>`. Base UI's Button documentation is explicit that a link must **not** go through `render`, because the component enforces button semantics — it applies `role="button"` and Space activation. Those now render the link directly with `buttonVariants(...)`, keeping `role="link"`.

The storybook suite caught this: "Provider setup guide" on Settings → LLMs stopped being announced as a link.

## Verification

All against a baseline captured before any dependency change:

| | |
|---|---|
| `pnpm turbo check-types` | 13/13 (baseline 13/13) |
| `pnpm turbo build` | 16/16 |
| `pnpm turbo test` | 13/13 |
| `pnpm --filter @workspace/web test:storybook` | **85/85** |
| `biome check` on the 51 touched app files | 61 diagnostics, down from 67 at the base commit — no new ones |

The storybook run is the load-bearing check: it renders the sidebar, tags input, selects, popovers, tooltips, dropdown menus and checkboxes in real Chromium. It started at 81/85 and surfaced both real problems in this PR.

A leftover scan for `radix-ui`, `@radix-ui`, `--radix-` and `asChild` across `apps/`, `packages/` and `e2e/` returns nothing.

## Follow-up: menu labels have to sit in a group

The second CI run got much further — 38 local, 1 worker, 37 cloud, 39/40 whitelabel — and failed on one test: the whitelabel optimize dropdown rendered no menu items.

Base UI's `Menu.GroupLabel` reads its group's context and **throws** outside one, which takes the whole popup down rather than just the label. `optimize-button.tsx` had its label in a plain `<div>` alongside the item it names, so the menu never rendered. Grouping the label with its entry is what the markup meant anyway.

I audited every Base UI part that throws on a missing ancestor against the repo after this: `Menu.GroupLabel` (3 sites, all grouped now), `Menu.RadioItem` (2 sites, both inside a `RadioGroup`), `Select.GroupLabel` and the submenu parts (unused), and the `Dialog`/`Tooltip`/`Popover`/`Avatar`/`Tabs`/`Collapsible` parts (structurally nested at every call site).

Added `apps/web/src/stories/optimize-button.stories.tsx`, which opens the dropdown and asserts the hand-off still fires. Verified it fails with the Base UI context error when the group is removed — the storybook suite covered every other migrated menu, this one just had no story.


## Follow-up: the marketing site had the same fault, and now the build catches it

The Vercel preview 500'd on every page with the same `Cannot find module 'react'`. That preview is **`apps/www`**, and it had the identical problem: `@base-ui/react` wasn't resolvable from `apps/www` either, so Vite inlined it and kept a runtime `require("react")` from its CJS `use-sync-external-store` dependency.

Which chunk it lands in decides how bad it is. On `main` the same unresolved require already sits in the docs layout — it just isn't on a path that executes, so production `/docs` returns 200. This branch moved it into the footer chunk, which every page renders, so every page died. Declaring the dependency in `apps/www` clears both.

**The build now fails on this.** `scripts/check-server-bundle.mjs` walks `.output/server` for `__require("pkg")` calls the bundle neither inlines nor traces, and runs at the end of `apps/web` and `apps/www`'s `build` scripts — so `pnpm build` and the `Build` job both catch it. It's covered by `pnpm test:scripts`, and I checked it against `main`'s `apps/www` output, where it correctly fails.

This is the gap worth naming: nothing else could have caught either failure. The require only runs when the module is first needed, so the build succeeds and the output looks complete.

## Follow-up: behaviour deltas fixed rather than documented

Two of the flagged deltas were visible to anyone using the app, so they're restored in the wrappers instead of left as differences:

- **Tabs switch on arrow keys again** (`TabsList activateOnFocus`). Base UI waits for Enter/Space.
- **Checkbox and radio menu items close the menu on select again** (`closeOnClick`). Base UI leaves it open. This affected the model filter and the prompts sort menu.

Both are pinned by `apps/web/src/stories/ui-primitives.stories.tsx`, verified to fail when the wrapper default comes back.

What remains is not user-visible: checkbox and switch render `<span role="checkbox|switch">` plus a hidden input rather than `<button>` (same keyboard and AT semantics, disabled state moves to `aria-disabled`); separators are now exposed to assistive tech, which is Base UI's considered default; the navigation-menu hover delay dropped from 200ms to 50ms on a popup nothing in the repo renders; and `PopoverAnchor` and `FormControl`'s child-to-`render` change touch API surface with no callers.

## `components.json` now points at `base-vega`

Previously flagged as a product call — resolving it here because leaving it meant the next `shadcn add` would hand back a Radix component to a codebase with no Radix in it.

The base is encoded in the style name, and there is no `base-new-york`. Of the eight `base-*` families, **vega** is nearest what's here: same `rounded-md`, same `text-sm`, same `h-9 / h-8 / h-10 / size-9` control heights. Nothing is restyled by this — existing components keep their own classes; it only changes what new ones arrive as, and `shadcn info` now reports `base: base`.

## Behaviour deltas — the full list, for the record

Per the guide's rule, these compile fine but act differently. None are silently worked around.

1. **Tabs activate manually.** Radix switched panels as you arrowed across the strip; Base UI moves focus and waits for Enter/Space. Opt back in with `<TabsList activateOnFocus>`.
2. **Radio and checkbox menu items no longer close the menu on select.** `closeOnClick` defaults to `false` on Base UI's `Menu.RadioItem` / `Menu.CheckboxItem`. Affects the model filter and the prompts sort menu — the most likely thing to want overridden.
3. **Checkbox and switch render `<span role="…">` plus a hidden input**, not `<button>`. Disabled state is `aria-disabled` / `data-disabled`. Five storybook assertions were updated to match what the control actually exposes.
4. **Separators are always semantic** — Radix's `decorative` prop is gone.
5. **Navigation-menu hover delay is 50ms**, down from 200ms. Latent: nothing in the repo renders a nav-menu popup.
6. **`PopoverAnchor` is no longer exported** (Base UI's Positioner takes an `anchor` prop instead). Nothing imported it.
7. **`FormControl` takes `render`** instead of a single child. `form.tsx` has no importers.

## Two fixes the migration forced

- `nav-user`'s account header is wrapped in a `DropdownMenuGroup`: Base UI's `GroupLabel` **throws** outside a group.
- The workspace and role selects pass `items` to `Select.Root`. Base UI's `Select.Value` renders the raw value, not the selected item's text, so without this the workspace picker would have shown a raw brand id.

## Not changed

`components.json` still reads `"style": "new-york"`, so a future `shadcn add` will hand back Radix variants. There is no separate `base` key in the schema — the primitive library is encoded in the style name — and no `base-new-york`, so fixing it means adopting a `base-<name>` style, which would restyle the whole app. That's a product call, left for a follow-up.

## Manual QA worth doing

- Open a dialog (Admin → Tools): focus trap, Escape, focus returns to trigger, fade/zoom on both open **and** close.
- Mobile-width sidebar: the sheet should slide in and back out, not vanish.
- Settings → Members and New Brand: the select trigger must show the label, not the raw value.
- Settings → LLMs at the pick limit: unchecked platforms dimmed, unclickable, not tab-reachable.
- Hover the info icons on the overview/citations cards: arrow points at the icon on every side.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e1572843-e940-439c-8547-f52c9d507f61)


## Follow-up: `@base-ui/react` declared in `apps/web`

The first CI run failed E2E with `Cannot find module 'react'` on every render. Cause: `packages/ui` ships source, so under pnpm its dependencies are not resolvable from `apps/web`. Vite responded by inlining `@base-ui/react` into the SSR pass rather than externalising it the way it does `@tanstack/*` and `recharts` — and that dragged in `use-sync-external-store` (CJS-only) with a `require("react")` that survived into `.output` as a runtime require. The web container copies `.output` and no `node_modules`, so it had nothing to resolve.

Radix never hit this because it has no CJS-only transitive dependency.

Declaring `@base-ui/react` in `apps/web` lets Vite externalise it and Nitro bundle it against the same React copy as everything else. `.output` now has no bare runtime imports and no non-builtin `__require` at all. Nothing imports it by name, hence the `knip.json` entry alongside the other build-only dependencies (`tailwindcss`, `tw-animate-css`, …).

Worth noting for reviewers: `pnpm build` passes either way. The failure only appears when the server output runs without `node_modules` beside it, which is exactly what the E2E container does — so the E2E job was the only thing that could have caught this.
