### PR TITLE
Build free AEO tools: llms.txt generator and AI crawler checker

### DIFF
--- a/.changeset/free-aeo-tools.md
+++ b/.changeset/free-aeo-tools.md
@@ -1,5 +1,0 @@
----
-"@workspace/www": patch
----
-
-Add free AEO tools at /tools: an llms.txt generator and an AI crawler checker.

--- a/.changeset/free-aeo-tools.md
+++ b/.changeset/free-aeo-tools.md
@@ -1,0 +1,5 @@
+---
+"@workspace/www": patch
+---
+
+Add free AEO tools at /tools: an llms.txt generator and an AI crawler checker.

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -10,6 +10,7 @@
 		"build": "vite build && node ../../scripts/check-server-bundle.mjs .",
 		"start": "node .output/server/index.mjs",
 		"check-types": "tsc --noEmit",
+		"test": "vitest run",
 		"generate-icons": "tsx scripts/generate-brand-icons.tsx"
 	},
 	"dependencies": {
@@ -56,6 +57,7 @@
 		"@vitejs/plugin-react": "^6.0.5",
 		"png-to-ico": "^3.0.2",
 		"typescript": "^7.0.2",
-		"vite": "^8.2.1"
+		"vite": "^8.2.1",
+		"vitest": "^4.1.10"
 	}
 }

--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
-import { Logo } from "./logo";
 import { externalRel } from "@/lib/external-link";
+import { Logo } from "./logo";
 
 // externalRel keeps the Referer for this owned domain; `ref` preserves
 // attribution when an intermediary strips that header.
@@ -39,6 +39,7 @@ const cols = [
 	{
 		heading: "Learn",
 		links: [
+			{ label: "Free AEO Tools", href: "/tools" },
 			{ label: "AEO Glossary", href: "/glossary" },
 			{ label: "AI Search Guides", href: "/ai-search" },
 			{ label: "AEO by Industry", href: "/aeo-for" },

--- a/apps/www/src/components/navbar.tsx
+++ b/apps/www/src/components/navbar.tsx
@@ -1,6 +1,5 @@
 import { Link, useLoaderData } from "@tanstack/react-router";
 import { CLOUD_SIGNUP_URL } from "@workspace/config/plans";
-import { ArrowRight } from "lucide-react";
 import { Button } from "@workspace/ui/components/button";
 import {
 	NavigationMenu,
@@ -9,11 +8,13 @@ import {
 	NavigationMenuList,
 } from "@workspace/ui/components/navigation-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "@workspace/ui/components/popover";
+import { ArrowRight } from "lucide-react";
 import { formatStarCount } from "@/lib/github-stars";
 import { Logo } from "./logo";
 
 const navigationLinks = [
 	{ href: "/pricing", label: "Pricing" },
+	{ href: "/tools", label: "Free Tools" },
 	{ href: "/changelog", label: "Changelog" },
 	{ href: "/roadmap", label: "Roadmap" },
 	{ href: "/vision", label: "Vision" },

--- a/apps/www/src/components/tools/ai-crawler-checker.tsx
+++ b/apps/www/src/components/tools/ai-crawler-checker.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { AlertTriangle, Check, X } from "lucide-react";
+import { useState } from "react";
+import { AI_CRAWLERS, CRAWLER_ROLE_LABELS } from "@/lib/tools/ai-crawlers";
+import { checkAiCrawlersFn } from "@/lib/tools/api";
+import type { CrawlerCheckResult, CrawlerVerdict } from "@/lib/tools/types";
+import { SiteUrlForm } from "./site-url-form";
+
+export function AiCrawlerChecker() {
+	const [input, setInput] = useState("");
+	const [pending, setPending] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [result, setResult] = useState<CrawlerCheckResult | null>(null);
+
+	async function check() {
+		setPending(true);
+		setError(null);
+		try {
+			const response = await checkAiCrawlersFn({ data: { url: input } });
+			if (response.ok) {
+				setResult(response.data);
+			} else {
+				setResult(null);
+				setError(response.error);
+			}
+		} catch {
+			setResult(null);
+			setError("Could not reach the checker. Try again in a moment.");
+		} finally {
+			setPending(false);
+		}
+	}
+
+	return (
+		<div>
+			<SiteUrlForm
+				value={input}
+				onChange={setInput}
+				onSubmit={check}
+				pending={pending}
+				label="Site to check"
+				placeholder="example.com"
+				submitLabel="Check robots.txt"
+				pendingLabel="Checking"
+				error={error}
+			/>
+			{result ? <CheckResult result={result} /> : null}
+		</div>
+	);
+}
+
+function OutcomeBanner({ result }: { result: CrawlerCheckResult }) {
+	if (result.outcome === "missing") {
+		return (
+			<div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+				<p className="font-semibold">No robots.txt found</p>
+				<p className="mt-1 leading-relaxed">
+					{result.siteUrl}/robots.txt returned HTTP {result.httpStatus}. With no file, every crawler is allowed
+					everywhere — which is fine for AI visibility, but you also have nowhere to point crawlers at your sitemap.
+				</p>
+			</div>
+		);
+	}
+
+	if (result.outcome === "server-error") {
+		return (
+			<div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-900">
+				<p className="font-semibold">robots.txt is returning a server error</p>
+				<p className="mt-1 leading-relaxed">
+					{result.robotsUrl} returned HTTP {result.httpStatus}. Google and other major crawlers treat a robots.txt that
+					keeps failing as a site-wide disallow, so this is stricter than having no file at all. Fix the error before
+					anything else on this page.
+				</p>
+			</div>
+		);
+	}
+
+	const blocked = result.crawlers.filter((crawler) => !crawler.allowed);
+	if (blocked.length === 0) {
+		return (
+			<div className="rounded-md border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-900">
+				<p className="font-semibold">
+					All {result.crawlers.length} AI crawlers can reach {result.path}
+				</p>
+				<p className="mt-1 leading-relaxed">
+					Nothing in {result.robotsUrl} blocks the crawlers that feed ChatGPT, Perplexity, Claude, or Google's AI
+					answers.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-900">
+			<p className="font-semibold">
+				{blocked.length} of {result.crawlers.length} AI crawlers are blocked from {result.path}
+			</p>
+			<p className="mt-1 leading-relaxed">
+				{blocked.map((crawler) => crawler.token).join(", ")} cannot fetch this path, so they have nothing of yours to
+				cite. Check each rule below before changing anything — some of these blocks may be deliberate.
+			</p>
+		</div>
+	);
+}
+
+function VerdictCell({ verdict }: { verdict: CrawlerVerdict }) {
+	const partial = verdict.allowed && verdict.disallowedPatterns.length > 0;
+
+	return (
+		<div>
+			<span
+				className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ${
+					verdict.allowed ? "bg-emerald-50 text-emerald-800" : "bg-red-50 text-red-800"
+				}`}
+			>
+				{verdict.allowed ? <Check className="size-3" /> : <X className="size-3" />}
+				{verdict.allowed ? "Allowed" : "Blocked"}
+			</span>
+			{verdict.matchedRule ? (
+				<p className="mt-1.5 font-mono text-[11px] text-zinc-500">
+					{verdict.matchedRule} · User-agent: {verdict.matchedAgent}
+				</p>
+			) : (
+				<p className="mt-1.5 text-[11px] text-zinc-500">
+					{verdict.matchedAgent ? `No rule matched in the "${verdict.matchedAgent}" group` : "No matching group"}
+				</p>
+			)}
+			{partial ? (
+				<p className="mt-1 inline-flex items-center gap-1 text-[11px] text-amber-700">
+					<AlertTriangle className="size-3" />
+					{verdict.disallowedPatterns.length} other path
+					{verdict.disallowedPatterns.length === 1 ? "" : "s"} blocked
+				</p>
+			) : null}
+			{verdict.crawlDelay !== undefined ? (
+				<p className="mt-1 text-[11px] text-zinc-500">Crawl-delay: {verdict.crawlDelay}s</p>
+			) : null}
+		</div>
+	);
+}
+
+function CheckResult({ result }: { result: CrawlerCheckResult }) {
+	const verdicts = new Map(result.crawlers.map((crawler) => [crawler.token, crawler]));
+
+	return (
+		<div className="mt-8 space-y-8">
+			<OutcomeBanner result={result} />
+
+			<div className="overflow-x-auto">
+				<table className="w-full min-w-[640px] text-sm">
+					<caption className="sr-only">
+						AI crawler access to {result.siteUrl}
+						{result.path}
+					</caption>
+					<thead>
+						<tr className="border-b border-zinc-200 text-left">
+							<th className="py-3 pr-4 font-semibold text-zinc-950">Crawler</th>
+							<th className="py-3 pr-4 font-semibold text-zinc-950">Run by</th>
+							<th className="py-3 pr-4 font-semibold text-zinc-950">Job</th>
+							<th className="py-3 font-semibold text-zinc-950">Verdict</th>
+						</tr>
+					</thead>
+					<tbody>
+						{AI_CRAWLERS.map((crawler) => {
+							const verdict = verdicts.get(crawler.token);
+							if (!verdict) return null;
+							return (
+								<tr key={crawler.token} className="border-b border-zinc-200 align-top">
+									<td className="py-3 pr-4">
+										<span className="font-mono text-xs text-zinc-950">{crawler.token}</span>
+										<p className="mt-1 max-w-[28ch] text-[11px] leading-snug text-zinc-500">{crawler.purpose}</p>
+									</td>
+									<td className="py-3 pr-4 text-zinc-600">{crawler.operator}</td>
+									<td className="py-3 pr-4 text-zinc-600">{CRAWLER_ROLE_LABELS[crawler.role]}</td>
+									<td className="py-3">
+										<VerdictCell verdict={verdict} />
+									</td>
+								</tr>
+							);
+						})}
+					</tbody>
+				</table>
+			</div>
+
+			<div className="grid gap-6 md:grid-cols-2">
+				<div>
+					<h3 className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">Declared sitemaps</h3>
+					{result.sitemaps.length > 0 ? (
+						<ul className="mt-3 space-y-1.5 text-sm">
+							{result.sitemaps.map((sitemap) => (
+								<li key={sitemap} className="break-all font-mono text-xs text-zinc-600">
+									{sitemap}
+								</li>
+							))}
+						</ul>
+					) : (
+						<p className="mt-3 text-sm leading-relaxed text-zinc-600">
+							No <code className="font-mono text-xs">Sitemap:</code> line. Adding one is the cheapest way to tell every
+							crawler what to read.
+						</p>
+					)}
+				</div>
+				<div>
+					<h3 className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">Path checked</h3>
+					<p className="mt-3 break-all font-mono text-xs text-zinc-600">
+						{result.siteUrl}
+						{result.path}
+					</p>
+					<p className="mt-2 text-sm leading-relaxed text-zinc-600">
+						Paste a full URL instead of a bare domain to check a specific page.
+					</p>
+				</div>
+			</div>
+
+			{result.robotsTxt ? (
+				<div>
+					<h3 className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">{result.robotsUrl}</h3>
+					<pre className="mt-3 max-h-96 overflow-auto rounded-md border border-zinc-200 bg-zinc-50 p-4 font-mono text-xs leading-relaxed text-zinc-700">
+						{result.robotsTxt}
+						{result.robotsTxtTruncated ? "\n… truncated" : ""}
+					</pre>
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/apps/www/src/components/tools/llms-txt-generator.tsx
+++ b/apps/www/src/components/tools/llms-txt-generator.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { Check, Copy, Download } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+import { describePagesFn, discoverSiteFn } from "@/lib/tools/api";
+import { SUMMARY_BATCH_SIZE } from "@/lib/tools/limits";
+import { buildLlmsTxt, type LlmsTxtPage } from "@/lib/tools/llms-txt";
+import type { SiteDiscovery } from "@/lib/tools/types";
+import { SiteUrlForm } from "./site-url-form";
+
+interface GeneratorState {
+	discovery: SiteDiscovery;
+	pages: LlmsTxtPage[];
+	/** How many pages have had their title and description fetched. */
+	described: number;
+}
+
+export function LlmsTxtGenerator() {
+	const [input, setInput] = useState("");
+	const [pending, setPending] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [state, setState] = useState<GeneratorState | null>(null);
+	// Bumped on every run so a slow batch from an abandoned run cannot write
+	// its titles over the results of the one the visitor is watching.
+	const runId = useRef(0);
+
+	const generate = useCallback(async () => {
+		const run = ++runId.current;
+		setPending(true);
+		setError(null);
+		setState(null);
+
+		try {
+			const discovered = await discoverSiteFn({ data: { url: input } });
+			if (run !== runId.current) return;
+			if (!discovered.ok) {
+				setError(discovered.error);
+				return;
+			}
+
+			const discovery = discovered.data;
+			// Show the file straight away with slug-derived titles, then upgrade
+			// each entry as its real title arrives.
+			let pages: LlmsTxtPage[] = discovery.urls.map((url) => ({ url, title: null, description: null }));
+			setState({ discovery, pages, described: 0 });
+
+			for (let start = 0; start < discovery.urls.length; start += SUMMARY_BATCH_SIZE) {
+				const batch = discovery.urls.slice(start, start + SUMMARY_BATCH_SIZE);
+				const described = await describePagesFn({ data: { urls: batch } });
+				if (run !== runId.current) return;
+				if (!described.ok) {
+					setError(described.error);
+					break;
+				}
+
+				const bySummaryUrl = new Map(described.data.map((summary) => [summary.url, summary]));
+				pages = pages.map((page) => bySummaryUrl.get(page.url) ?? page);
+				setState({ discovery, pages, described: Math.min(start + batch.length, discovery.urls.length) });
+			}
+		} catch {
+			if (run === runId.current) setError("Could not reach the generator. Try again in a moment.");
+		} finally {
+			if (run === runId.current) setPending(false);
+		}
+	}, [input]);
+
+	return (
+		<div>
+			<SiteUrlForm
+				value={input}
+				onChange={setInput}
+				onSubmit={generate}
+				pending={pending}
+				label="Site to read"
+				placeholder="example.com"
+				submitLabel="Generate llms.txt"
+				pendingLabel="Generating"
+				error={error}
+			/>
+			{state ? <GeneratedFile state={state} /> : null}
+		</div>
+	);
+}
+
+function GeneratedFile({ state }: { state: GeneratorState }) {
+	const { discovery, pages, described } = state;
+	const content = buildLlmsTxt({
+		siteName: discovery.siteName,
+		siteDescription: discovery.siteDescription,
+		pages,
+	});
+
+	return (
+		<div className="mt-8">
+			<div className="flex flex-wrap items-center justify-between gap-4">
+				<div>
+					<p className="text-sm text-zinc-600">
+						{pages.length} page{pages.length === 1 ? "" : "s"} from{" "}
+						<span className="break-all font-mono text-xs">{discovery.sitemapUrl}</span>
+						{described < pages.length ? ` · reading titles ${described}/${pages.length}` : ""}
+					</p>
+					{discovery.truncated ? (
+						<p className="mt-1 text-sm text-amber-700">
+							This site has more pages than the tool reads. Edit the file to cover the sections that matter most.
+						</p>
+					) : null}
+				</div>
+				<div className="flex gap-2">
+					<CopyButton content={content} />
+					<DownloadButton content={content} />
+				</div>
+			</div>
+
+			<pre className="mt-4 max-h-[32rem] overflow-auto rounded-md border border-zinc-200 bg-zinc-50 p-4 font-mono text-xs leading-relaxed text-zinc-700">
+				{content}
+			</pre>
+
+			<p className="mt-3 text-sm leading-relaxed text-zinc-600">
+				Read it before you publish it. The sections come from your URL structure and the notes come from your meta
+				descriptions, so the order and the wording are a starting point, not a finished document. Serve it at{" "}
+				<code className="font-mono text-xs">/llms.txt</code> as <code className="font-mono text-xs">text/plain</code>,
+				and link to it — an agent already on your site following a link is the most common way the file gets read at
+				all.
+			</p>
+		</div>
+	);
+}
+
+function CopyButton({ content }: { content: string }) {
+	const [copied, setCopied] = useState(false);
+
+	async function copy() {
+		try {
+			await navigator.clipboard.writeText(content);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch {
+			setCopied(false);
+		}
+	}
+
+	return (
+		<button
+			type="button"
+			onClick={copy}
+			className="inline-flex h-9 items-center gap-1.5 rounded-md border border-zinc-200 bg-white px-3 text-sm font-medium text-zinc-700 hover:border-zinc-300 hover:text-zinc-950"
+		>
+			{copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+			{copied ? "Copied" : "Copy"}
+		</button>
+	);
+}
+
+function DownloadButton({ content }: { content: string }) {
+	function download() {
+		const blob = new Blob([content], { type: "text/plain;charset=utf-8" });
+		const href = URL.createObjectURL(blob);
+		const anchor = document.createElement("a");
+		anchor.href = href;
+		anchor.download = "llms.txt";
+		anchor.click();
+		URL.revokeObjectURL(href);
+	}
+
+	return (
+		<button
+			type="button"
+			onClick={download}
+			className="inline-flex h-9 items-center gap-1.5 rounded-md bg-zinc-900 px-3 text-sm font-medium text-white hover:bg-zinc-800"
+		>
+			<Download className="size-3.5" />
+			Download
+		</button>
+	);
+}

--- a/apps/www/src/components/tools/site-url-form.tsx
+++ b/apps/www/src/components/tools/site-url-form.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Spinner } from "@workspace/ui/components/spinner";
+import { ArrowRight } from "lucide-react";
+
+/**
+ * The single input every free tool starts with. Type="text" rather than "url"
+ * so "example.com" submits without the browser demanding a scheme — the server
+ * normalizes whatever is pasted.
+ */
+export function SiteUrlForm({
+	value,
+	onChange,
+	onSubmit,
+	pending,
+	label,
+	placeholder,
+	submitLabel,
+	pendingLabel,
+	error,
+}: {
+	value: string;
+	onChange: (value: string) => void;
+	onSubmit: () => void;
+	pending: boolean;
+	label: string;
+	placeholder: string;
+	submitLabel: string;
+	pendingLabel: string;
+	error?: string | null;
+}) {
+	return (
+		<form
+			className="w-full"
+			onSubmit={(event) => {
+				event.preventDefault();
+				if (!pending) onSubmit();
+			}}
+		>
+			<label htmlFor="site-url" className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">
+				{label}
+			</label>
+			<div className="mt-2 flex flex-col gap-2 sm:flex-row">
+				<input
+					id="site-url"
+					name="site-url"
+					type="text"
+					inputMode="url"
+					autoComplete="url"
+					autoCapitalize="none"
+					autoCorrect="off"
+					spellCheck={false}
+					value={value}
+					onChange={(event) => onChange(event.target.value)}
+					placeholder={placeholder}
+					aria-invalid={error ? true : undefined}
+					aria-describedby={error ? "site-url-error" : undefined}
+					className="h-11 w-full rounded-md border border-zinc-300 bg-white px-3 text-base text-zinc-950 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 sm:text-sm"
+				/>
+				<button
+					type="submit"
+					disabled={pending}
+					className="inline-flex h-11 shrink-0 items-center justify-center gap-1.5 rounded-md bg-blue-600 px-5 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+				>
+					{pending ? (
+						<>
+							<Spinner className="size-3.5" />
+							{pendingLabel}
+						</>
+					) : (
+						<>
+							{submitLabel}
+							<ArrowRight className="size-3.5" />
+						</>
+					)}
+				</button>
+			</div>
+			{error ? (
+				<p id="site-url-error" role="alert" className="mt-3 text-sm text-red-700">
+					{error}
+				</p>
+			) : null}
+		</form>
+	);
+}

--- a/apps/www/src/components/tools/tool-shell.tsx
+++ b/apps/www/src/components/tools/tool-shell.tsx
@@ -1,0 +1,61 @@
+import { ArrowRight } from "lucide-react";
+import type { ReactNode } from "react";
+
+export function ToolHero({ eyebrow, title, lead }: { eyebrow: string; title: string; lead: string }) {
+	return (
+		<section className="border-b border-zinc-200 bg-white py-12 lg:py-16">
+			<div className="mx-auto max-w-6xl px-4 md:px-6">
+				<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">{eyebrow}</p>
+				<h1 className="font-heading mt-2 text-4xl text-balance text-zinc-950 md:text-5xl">{title}</h1>
+				<p className="mt-4 max-w-3xl text-lg text-balance text-zinc-600">{lead}</p>
+			</div>
+		</section>
+	);
+}
+
+/** The interactive part, set on a tinted band so it reads as the point of the page. */
+export function ToolPanel({ children }: { children: ReactNode }) {
+	return (
+		<section className="border-b border-zinc-200 bg-zinc-50 py-10">
+			<div className="mx-auto max-w-6xl px-4 md:px-6">
+				<div className="rounded-md border border-zinc-200 bg-white p-6">{children}</div>
+			</div>
+		</section>
+	);
+}
+
+export function ToolSection({ title, children }: { title: string; children: ReactNode }) {
+	return (
+		<section className="border-b border-zinc-200 bg-white py-12">
+			<div className="mx-auto max-w-6xl px-4 md:px-6">
+				<h2 className="font-heading text-2xl text-zinc-950 md:text-3xl">{title}</h2>
+				<div className="mt-6">{children}</div>
+			</div>
+		</section>
+	);
+}
+
+export function RelatedReading({ links }: { links: { label: string; href: string; blurb: string }[] }) {
+	return (
+		<section className="border-b border-zinc-200 bg-zinc-50 py-12">
+			<div className="mx-auto max-w-6xl px-4 md:px-6">
+				<h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">Keep reading</h2>
+				<div className="mt-5 grid gap-5 sm:grid-cols-2">
+					{links.map((link) => (
+						<a
+							key={link.href}
+							href={link.href}
+							className="flex flex-col rounded-md border border-zinc-200 bg-white p-5 transition-colors hover:border-zinc-300"
+						>
+							<span className="inline-flex items-center gap-1 font-semibold text-zinc-950">
+								{link.label}
+								<ArrowRight className="size-3.5" />
+							</span>
+							<span className="mt-2 text-sm leading-relaxed text-zinc-600">{link.blurb}</span>
+						</a>
+					))}
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/www/src/data/tools.ts
+++ b/apps/www/src/data/tools.ts
@@ -1,0 +1,97 @@
+import type { FaqItem } from "@/lib/faqs";
+
+/**
+ * The free tools at /tools. One entry drives the index card, the page metadata,
+ * the SoftwareApplication JSON-LD, and the sitemap, so a new tool is a data
+ * change plus a route.
+ */
+export interface FreeTool {
+	slug: string;
+	/** Product name, used in JSON-LD and on the index. */
+	name: string;
+	/** SERP title. These queries are won by tools, so it leads with the tool. */
+	metaTitle: string;
+	description: string;
+	/** One line for the index card. */
+	short: string;
+	faqs: FaqItem[];
+}
+
+export const freeTools: FreeTool[] = [
+	{
+		slug: "llms-txt-generator",
+		name: "llms.txt Generator",
+		metaTitle: "Free llms.txt Generator: Any Site, No Signup · Elmo",
+		description:
+			"Paste a domain and get an llms.txt file built from its sitemap, with real page titles and descriptions. Free, no signup, copy or download in one click.",
+		short: "Build an llms.txt from any site's sitemap, with real page titles and descriptions.",
+		faqs: [
+			{
+				question: "What is an llms.txt file?",
+				answer:
+					"llms.txt is a plain-Markdown file at the root of a site that gives AI agents a map of its contents: an H1 with the site name, a one-line summary, and sections of annotated links to the pages that matter. It is a convention proposed at llmstxt.org, not a standard any engine is required to follow.",
+			},
+			{
+				question: "How does this generator build the file?",
+				answer:
+					"It reads your robots.txt for a Sitemap line (falling back to /sitemap.xml and the other conventional paths), collects up to 60 same-origin page URLs, then fetches each page for its title and meta description. Pages are grouped into sections by their top-level path, so /blog/ pages land under Blog.",
+			},
+			{
+				question: "Do llms.txt files actually help AI visibility?",
+				answer:
+					"Mostly indirectly. Models are not trained to look for llms.txt, and it appears in no major system prompt, so the common case is an agent already on your site following a link to it. The downside is close to zero and the upside is real for agentic browsing, which is why we serve one and recommend linking to it.",
+			},
+			{
+				question: "Where do I put the file?",
+				answer:
+					"At the root of your domain, served as text/plain at /llms.txt, and linked from your pages so an agent browsing your site can find it. Review the generated file before you publish it — it is a starting point built from your sitemap, not a finished document.",
+			},
+			{
+				question: "Is there a limit on site size?",
+				answer:
+					"The generator reads up to 60 URLs from up to four sitemap files. Larger sites get the first 60 and a note saying so; edit the result to cover the sections that matter most to you.",
+			},
+		],
+	},
+	{
+		slug: "ai-crawler-checker",
+		name: "AI Crawler Checker",
+		metaTitle: "AI Crawler & robots.txt Checker: Free Test · Elmo",
+		description:
+			"Check whether GPTBot, ClaudeBot, PerplexityBot, Googlebot and 10 more AI crawlers are allowed or blocked by your robots.txt. Free, instant, no signup.",
+		short: "See which AI crawlers your robots.txt allows, and which ones it quietly blocks.",
+		faqs: [
+			{
+				question: "How does this checker work?",
+				answer:
+					"It fetches your robots.txt and evaluates it the way a compliant crawler does, following RFC 9309: each bot obeys the most specific user-agent group that matches its name, the longest matching path pattern wins, and Allow beats Disallow on a tie. No JavaScript is executed and nothing is stored.",
+			},
+			{
+				question: "Which AI crawlers does it check?",
+				answer:
+					"Fourteen: GPTBot, OAI-SearchBot, ChatGPT-User, PerplexityBot, Perplexity-User, ClaudeBot, Claude-User, Googlebot, Google-Extended, Bingbot, Amazonbot, Applebot-Extended, Meta-ExternalAgent, and CCBot. They cover model training, search indexing, and live per-query fetches.",
+			},
+			{
+				question: "Does blocking Google-Extended remove me from AI Overviews?",
+				answer:
+					"No. Google-Extended only governs whether your content trains Gemini and grounds Vertex AI. AI Overviews and AI Mode are part of Google Search and use Googlebot, so blocking Googlebot is what removes you from Google's AI answers — along with classic search.",
+			},
+			{
+				question: "My robots.txt returns a server error. Does that matter?",
+				answer:
+					"Yes. A robots.txt that keeps answering with a 5xx is treated as a site-wide disallow by Google and other major crawlers, which is stricter than having no file at all. A missing file (404) means everything is allowed; a broken one means nothing is.",
+			},
+			{
+				question: "Is robots.txt enough to keep a page out of AI answers?",
+				answer:
+					"No. Robots.txt controls crawling, not indexing or training already done. To keep a page out of results entirely, leave it crawlable and use a noindex directive — a crawler that is blocked from the URL can never read the noindex on it.",
+			},
+		],
+	},
+];
+
+export function requireFreeTool(slug: string): FreeTool {
+	const tool = freeTools.find((entry) => entry.slug === slug);
+	if (!tool) throw new Error(`Unknown free tool: ${slug}`);
+	return tool;
+}

--- a/apps/www/src/lib/seo.ts
+++ b/apps/www/src/lib/seo.ts
@@ -109,6 +109,35 @@ export function softwareApplicationJsonLd() {
 	});
 }
 
+/**
+ * SoftwareApplication schema for one of the free tools at /tools. Separate from
+ * softwareApplicationJsonLd(), which describes Elmo itself: these are browser
+ * utilities that need no account, and saying so is the differentiator on SERPs
+ * where every other result is gated.
+ */
+export function freeToolJsonLd({ name, description, path }: { name: string; description: string; path: string }) {
+	return jsonLd({
+		"@type": "SoftwareApplication",
+		name,
+		description,
+		applicationCategory: "DeveloperApplication",
+		operatingSystem: "Any",
+		browserRequirements: "Requires a modern web browser",
+		isAccessibleForFree: true,
+		offers: {
+			"@type": "Offer",
+			price: "0",
+			priceCurrency: "USD",
+		},
+		url: canonicalUrl(path),
+		provider: {
+			"@type": "Organization",
+			name: SITE_NAME,
+			url: SITE_URL,
+		},
+	});
+}
+
 export function articleJsonLd({ title, description, path }: { title: string; description: string; path: string }) {
 	return jsonLd({
 		"@type": "TechArticle",

--- a/apps/www/src/lib/tools/ai-crawlers.ts
+++ b/apps/www/src/lib/tools/ai-crawlers.ts
@@ -1,0 +1,125 @@
+/**
+ * The AI crawlers the crawler checker reports on. Pure data, safe to import from
+ * client components — the checker renders this list before a check runs, and the
+ * blog post at /blog/robots-txt-ai-crawlers documents the same set.
+ */
+export type CrawlerRole = "training" | "search" | "live" | "training-control";
+
+export interface AiCrawler {
+	/** robots.txt product token, matched case-insensitively. */
+	token: string;
+	operator: string;
+	role: CrawlerRole;
+	/** What the bot does, one short sentence. */
+	purpose: string;
+	/** What you give up by disallowing it. */
+	blockingCosts: string;
+}
+
+export const CRAWLER_ROLE_LABELS: Record<CrawlerRole, string> = {
+	training: "Model training",
+	search: "Search index",
+	live: "Live fetch",
+	"training-control": "Training opt-out",
+};
+
+export const AI_CRAWLERS: AiCrawler[] = [
+	{
+		token: "GPTBot",
+		operator: "OpenAI",
+		role: "training",
+		purpose: "Crawls pages to train models and improve OpenAI products.",
+		blockingCosts: "Use of your content in OpenAI model training",
+	},
+	{
+		token: "OAI-SearchBot",
+		operator: "OpenAI",
+		role: "search",
+		purpose: "Indexes pages so ChatGPT search can cite them.",
+		blockingCosts: "Citations in ChatGPT search",
+	},
+	{
+		token: "ChatGPT-User",
+		operator: "OpenAI",
+		role: "live",
+		purpose: "Fetches a page live when someone asks ChatGPT about it.",
+		blockingCosts: "Live, user-prompted answers in ChatGPT",
+	},
+	{
+		token: "PerplexityBot",
+		operator: "Perplexity",
+		role: "search",
+		purpose: "Indexes pages for Perplexity answers.",
+		blockingCosts: "Citations in Perplexity",
+	},
+	{
+		token: "Perplexity-User",
+		operator: "Perplexity",
+		role: "live",
+		purpose: "Fetches a page live for a specific Perplexity query.",
+		blockingCosts: "Live answers in Perplexity",
+	},
+	{
+		token: "ClaudeBot",
+		operator: "Anthropic",
+		role: "training",
+		purpose: "Crawls for Claude training and retrieval.",
+		blockingCosts: "Use of your content in Claude training and retrieval",
+	},
+	{
+		token: "Claude-User",
+		operator: "Anthropic",
+		role: "live",
+		purpose: "Fetches a page live for a Claude user request.",
+		blockingCosts: "Live answers in Claude",
+	},
+	{
+		token: "Googlebot",
+		operator: "Google",
+		role: "search",
+		purpose: "Crawls for Google Search, including AI Overviews and AI Mode.",
+		blockingCosts: "All of Google Search and Google's AI answers",
+	},
+	{
+		token: "Google-Extended",
+		operator: "Google",
+		role: "training-control",
+		purpose: "Controls use of your content for Gemini training and Vertex grounding.",
+		blockingCosts: "Gemini training only — not Search or AI Overviews",
+	},
+	{
+		token: "Bingbot",
+		operator: "Microsoft",
+		role: "search",
+		purpose: "Crawls for Bing, which powers Microsoft Copilot.",
+		blockingCosts: "Bing results and Copilot answers",
+	},
+	{
+		token: "Amazonbot",
+		operator: "Amazon",
+		role: "training",
+		purpose: "Crawls for Amazon services and AI.",
+		blockingCosts: "Amazon AI surfaces",
+	},
+	{
+		token: "Applebot-Extended",
+		operator: "Apple",
+		role: "training-control",
+		purpose: "Controls use of your content for Apple Intelligence training.",
+		blockingCosts: "Apple Intelligence training only",
+	},
+	{
+		token: "Meta-ExternalAgent",
+		operator: "Meta",
+		role: "training",
+		purpose: "Crawls for Meta's AI products.",
+		blockingCosts: "Meta AI",
+	},
+	{
+		token: "CCBot",
+		operator: "Common Crawl",
+		role: "training",
+		purpose: "Crawls for an open dataset many model makers train on.",
+		blockingCosts: "A wide range of third-party training sets",
+	},
+];

--- a/apps/www/src/lib/tools/api.ts
+++ b/apps/www/src/lib/tools/api.ts
@@ -1,0 +1,65 @@
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+import { SUMMARY_BATCH_SIZE } from "./limits";
+import { ToolError } from "./site-url";
+import type { CrawlerCheckResult, PageSummary, SiteDiscovery } from "./types";
+
+/**
+ * Server entry points for the free tools.
+ *
+ * Failures come back as data rather than thrown errors: every one of these is a
+ * message about somebody else's website ("no sitemap found", "took too long"),
+ * and that is the answer the visitor came for, not a crash.
+ *
+ * The handlers import their implementations lazily so the fetcher and its
+ * node:dns dependency stay out of the client bundle, the same way the blog and
+ * docs routes keep their sources server-side.
+ */
+export type ToolResponse<T> = { ok: true; data: T } | { ok: false; error: string };
+
+/** Long enough for any real URL, short enough that nothing here is a payload. */
+const urlString = z.string().max(2048);
+const siteInput = z.object({ url: urlString });
+const pagesInput = z.object({ urls: z.array(urlString).max(SUMMARY_BATCH_SIZE) });
+
+async function run<T>(bucket: string, limit: number, work: () => Promise<T>): Promise<ToolResponse<T>> {
+	try {
+		const { enforceRateLimit } = await import("./rate-limit");
+		await enforceRateLimit(bucket, limit);
+		return { ok: true, data: await work() };
+	} catch (error) {
+		if (error instanceof ToolError) return { ok: false, error: error.message };
+		console.error(`tool ${bucket} failed`, error);
+		return { ok: false, error: "Something went wrong on our side. Try again in a moment." };
+	}
+}
+
+export const checkAiCrawlersFn = createServerFn({ method: "POST" })
+	.inputValidator((data: unknown) => siteInput.parse(data))
+	.handler(
+		async ({ data }): Promise<ToolResponse<CrawlerCheckResult>> =>
+			run("crawler-check", 20, async () => {
+				const { checkAiCrawlers } = await import("./crawler-check");
+				return checkAiCrawlers(data.url);
+			}),
+	);
+
+export const discoverSiteFn = createServerFn({ method: "POST" })
+	.inputValidator((data: unknown) => siteInput.parse(data))
+	.handler(
+		async ({ data }): Promise<ToolResponse<SiteDiscovery>> =>
+			run("discover-site", 10, async () => {
+				const { discoverSite } = await import("./site-discovery");
+				return discoverSite(data.url);
+			}),
+	);
+
+export const describePagesFn = createServerFn({ method: "POST" })
+	.inputValidator((data: unknown) => pagesInput.parse(data))
+	.handler(
+		async ({ data }): Promise<ToolResponse<PageSummary[]>> =>
+			run("describe-pages", 20, async () => {
+				const { describePages } = await import("./site-discovery");
+				return describePages(data.urls);
+			}),
+	);

--- a/apps/www/src/lib/tools/crawler-check.ts
+++ b/apps/www/src/lib/tools/crawler-check.ts
@@ -1,0 +1,68 @@
+import { AI_CRAWLERS } from "./ai-crawlers";
+import { fetchRemoteText } from "./fetch-remote";
+import { evaluate, parseRobotsTxt } from "./robots";
+import { normalizeSiteUrl } from "./site-url";
+import type { CrawlerCheckResult, CrawlerVerdict, RobotsOutcome } from "./types";
+
+/** Enough robots.txt to show in full on the page; the rest is elided. */
+const MAX_DISPLAY_BYTES = 20_000;
+
+/**
+ * Plenty of sites answer /robots.txt with their HTML 404 page and a 200 status.
+ * Parsing that produces a confident "everything is allowed" from a file that
+ * does not exist, so treat it as missing instead.
+ */
+function looksLikeHtml(body: string, contentType: string | null): boolean {
+	if (contentType?.toLowerCase().includes("text/html")) return true;
+	return /^\s*(?:<!doctype html|<html\b)/i.test(body);
+}
+
+export async function checkAiCrawlers(input: string): Promise<CrawlerCheckResult> {
+	const target = normalizeSiteUrl(input);
+	const path = target.pathname || "/";
+	const robotsUrl = new URL("/robots.txt", target.origin);
+
+	const response = await fetchRemoteText(robotsUrl, {
+		accept: "text/plain,*/*;q=0.8",
+		maxBytes: 512 * 1024,
+	});
+
+	let outcome: RobotsOutcome;
+	if (response.status >= 500) outcome = "server-error";
+	else if (!response.ok || looksLikeHtml(response.body, response.contentType)) outcome = "missing";
+	else outcome = "found";
+
+	const robots = outcome === "found" ? parseRobotsTxt(response.body) : { groups: [], sitemaps: [] };
+
+	const crawlers: CrawlerVerdict[] = AI_CRAWLERS.map((crawler) => {
+		const verdict = evaluate(robots, crawler.token, path);
+		return {
+			token: crawler.token,
+			// A robots.txt that keeps returning a server error is treated as a
+			// site-wide disallow by Google and others, so report it as blocked.
+			allowed: outcome === "server-error" ? false : verdict.allowed,
+			matchedAgent: verdict.matchedAgent,
+			matchedRule: verdict.matchedRule
+				? `${verdict.matchedRule.type === "allow" ? "Allow" : "Disallow"}: ${verdict.matchedRule.pattern}`
+				: null,
+			disallowedPatterns: verdict.disallowedPatterns,
+			crawlDelay: verdict.crawlDelay,
+		};
+	});
+
+	const body = outcome === "found" ? response.body : "";
+
+	return {
+		// The origin that actually answered, so an apex-to-www redirect is
+		// reported against the host whose rules were read.
+		siteUrl: new URL(response.url).origin,
+		robotsUrl: response.url,
+		path,
+		outcome,
+		httpStatus: response.status,
+		robotsTxt: body.slice(0, MAX_DISPLAY_BYTES),
+		robotsTxtTruncated: response.truncated || body.length > MAX_DISPLAY_BYTES,
+		sitemaps: robots.sitemaps,
+		crawlers,
+	};
+}

--- a/apps/www/src/lib/tools/fetch-remote.ts
+++ b/apps/www/src/lib/tools/fetch-remote.ts
@@ -1,0 +1,133 @@
+import { lookup } from "node:dns/promises";
+import { isBlockedHostname, isIpLiteral, isPrivateAddress, ToolError } from "./site-url";
+
+/**
+ * The only way these tools reach the network. Server-only.
+ *
+ * Every hop is checked before it is requested: redirects are followed by hand so
+ * a public hostname cannot bounce us onto localhost or a cloud metadata endpoint,
+ * responses are capped so a huge file cannot exhaust the function, and the whole
+ * call shares one deadline.
+ *
+ * Residual risk worth naming: a hostname can resolve to a public address for our
+ * check and a private one for the request that follows (DNS rebinding). Pinning
+ * the resolved address would need a custom dispatcher; the checks here stop the
+ * straightforward attacks, and neither tool has credentials to leak.
+ */
+
+const USER_AGENT = "ElmoBot/1.0 (+https://www.elmohq.com/tools)";
+const MAX_REDIRECTS = 5;
+const DEFAULT_TIMEOUT_MS = 8_000;
+const DEFAULT_MAX_BYTES = 512 * 1024;
+
+export interface RemoteResponse {
+	/** The URL that actually served the body, after redirects. */
+	url: string;
+	status: number;
+	ok: boolean;
+	contentType: string | null;
+	body: string;
+	/** True when the response hit the byte cap and was cut short. */
+	truncated: boolean;
+}
+
+async function assertPublicHost(hostname: string): Promise<void> {
+	if (isIpLiteral(hostname)) throw new ToolError("Enter a domain name rather than an IP address.");
+	if (isBlockedHostname(hostname)) throw new ToolError(`"${hostname}" is not a public domain.`);
+
+	let addresses: { address: string }[];
+	try {
+		addresses = await lookup(hostname, { all: true });
+	} catch {
+		throw new ToolError(`Could not resolve "${hostname}". Check the spelling and try again.`);
+	}
+
+	if (addresses.length === 0) throw new ToolError(`Could not resolve "${hostname}".`);
+	if (addresses.some((entry) => isPrivateAddress(entry.address))) {
+		throw new ToolError(`"${hostname}" points at a private address, so it cannot be checked.`);
+	}
+}
+
+async function readCapped(response: Response, maxBytes: number): Promise<{ body: string; truncated: boolean }> {
+	if (!response.body) return { body: "", truncated: false };
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder("utf-8");
+	let received = 0;
+	let body = "";
+	let truncated = false;
+
+	try {
+		while (received < maxBytes) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (!value) continue;
+			received += value.byteLength;
+			if (received > maxBytes) {
+				body += decoder.decode(value.subarray(0, value.byteLength - (received - maxBytes)), { stream: false });
+				truncated = true;
+				break;
+			}
+			body += decoder.decode(value, { stream: true });
+		}
+		if (!truncated) body += decoder.decode();
+	} finally {
+		await reader.cancel().catch(() => {});
+	}
+
+	return { body, truncated };
+}
+
+export async function fetchRemoteText(
+	target: URL,
+	options: { timeoutMs?: number; maxBytes?: number; accept?: string } = {},
+): Promise<RemoteResponse> {
+	const { timeoutMs = DEFAULT_TIMEOUT_MS, maxBytes = DEFAULT_MAX_BYTES, accept = "*/*" } = options;
+	const signal = AbortSignal.timeout(timeoutMs);
+	let current = target;
+
+	for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+		await assertPublicHost(current.hostname);
+
+		let response: Response;
+		try {
+			response = await fetch(current, {
+				redirect: "manual",
+				signal,
+				headers: { "user-agent": USER_AGENT, accept },
+			});
+		} catch (error) {
+			if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
+				throw new ToolError(`${current.hostname} took too long to respond.`);
+			}
+			throw new ToolError(`Could not reach ${current.hostname}.`);
+		}
+
+		const location = response.headers.get("location");
+		if (response.status >= 300 && response.status < 400 && location) {
+			let next: URL;
+			try {
+				next = new URL(location, current);
+			} catch {
+				throw new ToolError(`${current.hostname} returned a redirect we could not follow.`);
+			}
+			if (next.protocol !== "http:" && next.protocol !== "https:") {
+				throw new ToolError(`${current.hostname} redirected to an address we do not follow.`);
+			}
+			current = next;
+			continue;
+		}
+
+		const { body, truncated } = await readCapped(response, maxBytes);
+		return {
+			url: current.toString(),
+			status: response.status,
+			ok: response.ok,
+			contentType: response.headers.get("content-type"),
+			body,
+			truncated,
+		};
+	}
+
+	throw new ToolError(`${target.hostname} redirected too many times.`);
+}

--- a/apps/www/src/lib/tools/html-meta.test.ts
+++ b/apps/www/src/lib/tools/html-meta.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { extractPageMeta, titleFromUrl } from "./html-meta";
+
+describe("extractPageMeta", () => {
+	it("reads the title and meta description", () => {
+		const html = `<html><head><title>Pricing · Example</title>
+			<meta name="description" content="What Example costs."></head><body>…</body></html>`;
+		expect(extractPageMeta(html)).toEqual({ title: "Pricing · Example", description: "What Example costs." });
+	});
+
+	it("falls back to Open Graph tags", () => {
+		const html = `<head><meta property="og:title" content="OG title">
+			<meta property="og:description" content="OG description"></head>`;
+		expect(extractPageMeta(html)).toEqual({ title: "OG title", description: "OG description" });
+	});
+
+	it("prefers the name=description meta over Open Graph", () => {
+		const html = `<head><meta property="og:description" content="OG">
+			<meta name="description" content="Real"></head>`;
+		expect(extractPageMeta(html).description).toBe("Real");
+	});
+
+	it("decodes entities and collapses whitespace", () => {
+		const html = "<head><title>Tools\n  &amp; toys &#8212; Example</title></head>";
+		expect(extractPageMeta(html).title).toBe("Tools & toys — Example");
+	});
+
+	it("returns nulls when the page says nothing", () => {
+		expect(extractPageMeta("<html><body>hi</body></html>")).toEqual({ title: null, description: null });
+	});
+
+	it("treats an empty title as missing", () => {
+		expect(extractPageMeta("<head><title>   </title></head>").title).toBeNull();
+	});
+});
+
+describe("titleFromUrl", () => {
+	it("humanizes the last path segment", () => {
+		expect(titleFromUrl("https://example.com/blog/ai-crawler-checker")).toBe("Ai crawler checker");
+	});
+
+	it("ignores a trailing slash and a file extension", () => {
+		expect(titleFromUrl("https://example.com/docs/getting-started/")).toBe("Getting started");
+		expect(titleFromUrl("https://example.com/about.html")).toBe("About");
+	});
+
+	it("calls the root Home", () => {
+		expect(titleFromUrl("https://example.com/")).toBe("Home");
+	});
+});

--- a/apps/www/src/lib/tools/html-meta.ts
+++ b/apps/www/src/lib/tools/html-meta.ts
@@ -1,0 +1,86 @@
+/**
+ * The few facts the llms.txt generator needs from a page: what it is called and
+ * what it is about. Regex rather than a parser because we only ever read a
+ * truncated `<head>` and never render the result as HTML.
+ *
+ * Pure — no network, no Node built-ins.
+ */
+
+export interface PageMeta {
+	title: string | null;
+	description: string | null;
+}
+
+const NAMED_ENTITIES: Record<string, string> = {
+	amp: "&",
+	lt: "<",
+	gt: ">",
+	quot: '"',
+	apos: "'",
+	nbsp: " ",
+	mdash: "—",
+	ndash: "–",
+	hellip: "…",
+	rsquo: "’",
+	lsquo: "‘",
+	rdquo: "”",
+	ldquo: "“",
+};
+
+function decodeHtmlEntities(value: string): string {
+	return value.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (match, entity: string) => {
+		if (entity.startsWith("#")) {
+			const code = entity[1]?.toLowerCase() === "x" ? Number.parseInt(entity.slice(2), 16) : Number(entity.slice(1));
+			return Number.isFinite(code) && code > 0 ? String.fromCodePoint(code) : match;
+		}
+		return NAMED_ENTITIES[entity.toLowerCase()] ?? match;
+	});
+}
+
+function clean(value: string | undefined): string | null {
+	if (!value) return null;
+	const text = decodeHtmlEntities(value).replace(/\s+/g, " ").trim();
+	return text || null;
+}
+
+function findMetaContent(html: string, attribute: "name" | "property", value: string): string | null {
+	const pattern = new RegExp(`<meta\\b[^>]*\\b${attribute}\\s*=\\s*["']${value}["'][^>]*>`, "i");
+	const tag = html.match(pattern)?.[0];
+	if (!tag) return null;
+	return clean(tag.match(/\bcontent\s*=\s*["']([^"']*)["']/i)?.[1]);
+}
+
+export function extractPageMeta(html: string): PageMeta {
+	const head = html.slice(0, 200_000);
+	const title =
+		clean(head.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1]) ?? findMetaContent(head, "property", "og:title");
+	const description =
+		findMetaContent(head, "name", "description") ?? findMetaContent(head, "property", "og:description");
+
+	return { title, description };
+}
+
+/**
+ * Fallback title for a page we could not fetch: the last path segment, made
+ * readable. `/blog/ai-crawler-checker/` becomes "Ai crawler checker" — worse
+ * than the real `<title>`, still better than a bare URL in a link list.
+ */
+export function titleFromUrl(url: string): string {
+	let pathname: string;
+	try {
+		pathname = new URL(url).pathname;
+	} catch {
+		pathname = url;
+	}
+
+	const segment = pathname.split("/").filter(Boolean).pop();
+	if (!segment) return "Home";
+
+	const words = decodeURIComponent(segment)
+		.replace(/\.(html?|php|aspx?)$/i, "")
+		.replace(/[-_]+/g, " ")
+		.trim();
+
+	if (!words) return "Home";
+	return words.charAt(0).toUpperCase() + words.slice(1);
+}

--- a/apps/www/src/lib/tools/limits.ts
+++ b/apps/www/src/lib/tools/limits.ts
@@ -1,0 +1,11 @@
+/**
+ * How much of a site the llms.txt generator will read. Deliberately modest: the
+ * output is a starting file a human edits, and every extra page is another
+ * request we make to someone else's server on a stranger's say-so.
+ *
+ * Shared with the browser, which batches its own requests to match.
+ */
+export const MAX_PAGES = 60;
+export const MAX_SITEMAPS = 4;
+/** Pages per describePages call — small enough that no single request runs long. */
+export const SUMMARY_BATCH_SIZE = 12;

--- a/apps/www/src/lib/tools/llms-txt.test.ts
+++ b/apps/www/src/lib/tools/llms-txt.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { buildLlmsTxt, groupPages } from "./llms-txt";
+
+const page = (url: string, title: string | null = null, description: string | null = null) => ({
+	url,
+	title,
+	description,
+});
+
+describe("groupPages", () => {
+	it("puts top-level pages under Main and the rest under their first path segment", () => {
+		const sections = groupPages([
+			page("https://example.com/"),
+			page("https://example.com/pricing"),
+			page("https://example.com/blog/one"),
+			page("https://example.com/blog/two"),
+		]);
+
+		expect(sections.map((section) => section.name)).toEqual(["Main", "Blog"]);
+		expect(sections[1].pages).toHaveLength(2);
+	});
+
+	it("orders sections by size after Main", () => {
+		const sections = groupPages([
+			page("https://example.com/guides/a"),
+			page("https://example.com/blog/a"),
+			page("https://example.com/blog/b"),
+		]);
+		expect(sections.map((section) => section.name)).toEqual(["Blog", "Guides"]);
+	});
+
+	it("humanizes an unfamiliar path segment", () => {
+		const sections = groupPages([page("https://example.com/case-studies/acme")]);
+		expect(sections[0].name).toBe("Case Studies");
+	});
+});
+
+describe("buildLlmsTxt", () => {
+	it("writes the site name, summary, and annotated sections", () => {
+		const output = buildLlmsTxt({
+			siteName: "Example",
+			siteDescription: "A site about examples.",
+			pages: [
+				page("https://example.com/", "Example — Home", "The homepage."),
+				page("https://example.com/blog/hello", "Hello world", "Our first post."),
+			],
+		});
+
+		expect(output).toBe(
+			[
+				"# Example",
+				"",
+				"> A site about examples.",
+				"",
+				"## Main",
+				"",
+				"- [Example — Home](https://example.com/): The homepage.",
+				"",
+				"## Blog",
+				"",
+				"- [Hello world](https://example.com/blog/hello): Our first post.",
+				"",
+			].join("\n"),
+		);
+	});
+
+	it("omits the blockquote when the site has no description", () => {
+		const output = buildLlmsTxt({ siteName: "Example", siteDescription: null, pages: [page("https://example.com/")] });
+		expect(output).not.toContain(">");
+	});
+
+	it("falls back to a slug-derived title for a page it could not read", () => {
+		const output = buildLlmsTxt({
+			siteName: "Example",
+			siteDescription: null,
+			pages: [page("https://example.com/docs/getting-started")],
+		});
+		expect(output).toContain("- [Getting started](https://example.com/docs/getting-started)\n");
+	});
+
+	it("truncates a long description to one line", () => {
+		const output = buildLlmsTxt({
+			siteName: "Example",
+			siteDescription: null,
+			pages: [page("https://example.com/a", "A", `${"word ".repeat(60)}\nsecond line`)],
+		});
+
+		const entry = output.split("\n").find((line) => line.startsWith("- [A]"));
+		expect(entry).toBeDefined();
+		expect(entry).toContain("…");
+		expect(entry?.length).toBeLessThan(220);
+	});
+});

--- a/apps/www/src/lib/tools/llms-txt.ts
+++ b/apps/www/src/lib/tools/llms-txt.ts
@@ -1,0 +1,108 @@
+/**
+ * Renders the llms.txt file itself, in the format described at llmstxt.org: an
+ * H1 with the site name, an optional blockquote summary, then H2 sections of
+ * annotated links.
+ *
+ * Pure — no network, no Node built-ins.
+ */
+import { titleFromUrl } from "./html-meta";
+
+export interface LlmsTxtPage {
+	url: string;
+	title: string | null;
+	description: string | null;
+}
+
+export interface LlmsTxtSection {
+	name: string;
+	pages: LlmsTxtPage[];
+}
+
+const MAX_NOTE_LENGTH = 160;
+/** Top-level segments worth naming outright rather than title-casing blindly. */
+const SECTION_NAMES: Record<string, string> = {
+	docs: "Docs",
+	doc: "Docs",
+	documentation: "Docs",
+	blog: "Blog",
+	posts: "Blog",
+	news: "News",
+	guides: "Guides",
+	api: "API",
+	faq: "FAQ",
+};
+
+function humanize(segment: string): string {
+	return decodeURIComponent(segment)
+		.replace(/[-_]+/g, " ")
+		.split(" ")
+		.filter(Boolean)
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(" ");
+}
+
+function sectionFor(url: string): string {
+	let segments: string[];
+	try {
+		segments = new URL(url).pathname.split("/").filter(Boolean);
+	} catch {
+		return "Pages";
+	}
+
+	if (segments.length <= 1) return "Main";
+	const key = segments[0].toLowerCase();
+	return SECTION_NAMES[key] ?? humanize(segments[0]);
+}
+
+function truncateNote(note: string): string {
+	const single = note.replace(/\s+/g, " ").trim();
+	if (single.length <= MAX_NOTE_LENGTH) return single;
+	return `${single.slice(0, MAX_NOTE_LENGTH - 1).trimEnd()}…`;
+}
+
+/** "Main" leads; the rest are ordered by size so the biggest areas come first. */
+export function groupPages(pages: LlmsTxtPage[]): LlmsTxtSection[] {
+	const sections = new Map<string, LlmsTxtPage[]>();
+
+	for (const page of pages) {
+		const name = sectionFor(page.url);
+		const bucket = sections.get(name);
+		if (bucket) bucket.push(page);
+		else sections.set(name, [page]);
+	}
+
+	return [...sections.entries()]
+		.map(([name, sectionPages]) => ({
+			name,
+			pages: [...sectionPages].sort((a, b) => a.url.localeCompare(b.url)),
+		}))
+		.sort((a, b) => {
+			if (a.name === "Main") return -1;
+			if (b.name === "Main") return 1;
+			if (a.pages.length !== b.pages.length) return b.pages.length - a.pages.length;
+			return a.name.localeCompare(b.name);
+		});
+}
+
+export function buildLlmsTxt(input: {
+	siteName: string;
+	siteDescription: string | null;
+	pages: LlmsTxtPage[];
+}): string {
+	const lines: string[] = [`# ${input.siteName}`];
+
+	if (input.siteDescription) {
+		lines.push("", `> ${truncateNote(input.siteDescription)}`);
+	}
+
+	for (const section of groupPages(input.pages)) {
+		lines.push("", `## ${section.name}`, "");
+		for (const page of section.pages) {
+			const title = page.title?.trim() || titleFromUrl(page.url);
+			const note = page.description ? `: ${truncateNote(page.description)}` : "";
+			lines.push(`- [${title}](${page.url})${note}`);
+		}
+	}
+
+	return `${lines.join("\n")}\n`;
+}

--- a/apps/www/src/lib/tools/rate-limit.ts
+++ b/apps/www/src/lib/tools/rate-limit.ts
@@ -1,0 +1,49 @@
+import { getRequest } from "@tanstack/react-start/server";
+import { Redis } from "@upstash/redis";
+import { ToolError } from "./site-url";
+
+/**
+ * A per-IP cap on the free tools. They cost nothing per run, but they do fetch
+ * arbitrary URLs on request, and an uncapped endpoint that does that is a
+ * crawler someone else gets to point.
+ *
+ * Fails open: when Upstash is not configured (local dev) or is unreachable, the
+ * request proceeds. Losing the limiter should not take the tools down with it.
+ */
+
+const WINDOW_SECONDS = 60;
+
+let client: Redis | null | undefined;
+
+function redis(): Redis | null {
+	if (client !== undefined) return client;
+
+	const url = process.env.UPSTASH_REDIS_REST_URL;
+	const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+	client = url && token ? new Redis({ url, token }) : null;
+	return client;
+}
+
+function clientIp(): string {
+	const headers = getRequest().headers;
+	// The left-most entry is the original client; the rest are proxies.
+	const forwarded = headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+	return forwarded || headers.get("x-real-ip") || "unknown";
+}
+
+export async function enforceRateLimit(bucket: string, limit: number): Promise<void> {
+	const store = redis();
+	if (!store) return;
+
+	const key = `tools:rate:${bucket}:${clientIp()}`;
+
+	try {
+		const used = await store.incr(key);
+		if (used === 1) await store.expire(key, WINDOW_SECONDS);
+		if (used <= limit) return;
+	} catch {
+		return;
+	}
+
+	throw new ToolError("You're going a bit fast for our free tools. Wait a minute and try again.");
+}

--- a/apps/www/src/lib/tools/robots.test.ts
+++ b/apps/www/src/lib/tools/robots.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { evaluate, parseRobotsTxt } from "./robots";
+
+const check = (robotsTxt: string, agent: string, path = "/") => evaluate(parseRobotsTxt(robotsTxt), agent, path);
+
+describe("robots.txt evaluation", () => {
+	it("allows everything when the file has no rules", () => {
+		expect(check("", "GPTBot").allowed).toBe(true);
+		expect(check("# just a comment\n", "GPTBot").allowed).toBe(true);
+	});
+
+	it("blocks every crawler on a blanket disallow", () => {
+		const robotsTxt = "User-agent: *\nDisallow: /";
+		expect(check(robotsTxt, "GPTBot").allowed).toBe(false);
+		expect(check(robotsTxt, "Googlebot").allowed).toBe(false);
+	});
+
+	it("treats an empty Disallow as allowing everything", () => {
+		expect(check("User-agent: *\nDisallow:", "ClaudeBot").allowed).toBe(true);
+	});
+
+	it("makes a named group override the catch-all entirely", () => {
+		const robotsTxt = ["User-agent: *", "Allow: /", "", "User-agent: GPTBot", "Disallow: /"].join("\n");
+		expect(check(robotsTxt, "GPTBot").allowed).toBe(false);
+		expect(check(robotsTxt, "PerplexityBot").allowed).toBe(true);
+	});
+
+	it("lets a named group escape a catch-all disallow", () => {
+		const robotsTxt = ["User-agent: *", "Disallow: /", "", "User-agent: OAI-SearchBot", "Allow: /"].join("\n");
+		expect(check(robotsTxt, "OAI-SearchBot").allowed).toBe(true);
+		expect(check(robotsTxt, "CCBot").allowed).toBe(false);
+	});
+
+	it("matches user-agents case-insensitively", () => {
+		expect(check("User-Agent: gptbot\nDisallow: /", "GPTBot").allowed).toBe(false);
+	});
+
+	it("applies a group to every user-agent in its header", () => {
+		const robotsTxt = ["User-agent: GPTBot", "User-agent: CCBot", "Disallow: /"].join("\n");
+		expect(check(robotsTxt, "GPTBot").allowed).toBe(false);
+		expect(check(robotsTxt, "CCBot").allowed).toBe(false);
+		expect(check(robotsTxt, "ClaudeBot").allowed).toBe(true);
+	});
+
+	it("prefers the longest matching path rule", () => {
+		const robotsTxt = ["User-agent: *", "Disallow: /", "Allow: /blog/"].join("\n");
+		expect(check(robotsTxt, "Googlebot", "/blog/post").allowed).toBe(true);
+		expect(check(robotsTxt, "Googlebot", "/pricing").allowed).toBe(false);
+	});
+
+	it("resolves an equal-length tie in favor of allowing", () => {
+		const robotsTxt = ["User-agent: *", "Disallow: /docs", "Allow: /docs"].join("\n");
+		expect(check(robotsTxt, "Googlebot", "/docs").allowed).toBe(true);
+	});
+
+	it("honors wildcards and end-of-path anchors", () => {
+		const robotsTxt = ["User-agent: *", "Disallow: /*.pdf$"].join("\n");
+		expect(check(robotsTxt, "Googlebot", "/files/report.pdf").allowed).toBe(false);
+		expect(check(robotsTxt, "Googlebot", "/files/report.pdf.html").allowed).toBe(true);
+	});
+
+	it("keeps Google-Extended and Googlebot independent", () => {
+		const robotsTxt = ["User-agent: Google-Extended", "Disallow: /"].join("\n");
+		expect(check(robotsTxt, "Google-Extended").allowed).toBe(false);
+		expect(check(robotsTxt, "Googlebot").allowed).toBe(true);
+	});
+
+	it("falls back to a prefix group when a bot has none of its own", () => {
+		const robotsTxt = ["User-agent: Googlebot", "Disallow: /"].join("\n");
+		expect(check(robotsTxt, "Googlebot-News").matchedAgent).toBe("googlebot");
+		expect(check(robotsTxt, "Googlebot-News").allowed).toBe(false);
+	});
+
+	it("merges rules from repeated groups for the same agent", () => {
+		const robotsTxt = [
+			"User-agent: GPTBot",
+			"Disallow: /private/",
+			"",
+			"User-agent: GPTBot",
+			"Disallow: /",
+			"Allow: /blog/",
+		].join("\n");
+		expect(check(robotsTxt, "GPTBot", "/blog/post").allowed).toBe(true);
+		expect(check(robotsTxt, "GPTBot", "/private/x").allowed).toBe(false);
+	});
+
+	it("reports the rule and the other blocked paths behind a verdict", () => {
+		const robotsTxt = ["User-agent: *", "Disallow: /admin/", "Disallow: /cart/"].join("\n");
+		const verdict = check(robotsTxt, "PerplexityBot", "/");
+		expect(verdict.allowed).toBe(true);
+		expect(verdict.matchedRule).toBeNull();
+		expect(verdict.disallowedPatterns).toEqual(["/admin/", "/cart/"]);
+
+		const blocked = check(robotsTxt, "PerplexityBot", "/admin/users");
+		expect(blocked.matchedRule).toEqual({ type: "disallow", pattern: "/admin/" });
+	});
+
+	it("ignores comments and blank lines", () => {
+		const robotsTxt = ["# staging leftovers", "User-agent: * # everyone", "Disallow: / # whole site"].join("\n");
+		expect(check(robotsTxt, "ClaudeBot").allowed).toBe(false);
+	});
+
+	it("collects sitemap declarations regardless of grouping", () => {
+		const robotsTxt = [
+			"Sitemap: https://example.com/sitemap.xml",
+			"User-agent: *",
+			"Disallow:",
+			"sitemap: https://example.com/news.xml",
+		].join("\n");
+		expect(parseRobotsTxt(robotsTxt).sitemaps).toEqual([
+			"https://example.com/sitemap.xml",
+			"https://example.com/news.xml",
+		]);
+	});
+
+	it("reads crawl-delay for the governing group", () => {
+		const robotsTxt = ["User-agent: CCBot", "Crawl-delay: 10", "Disallow:"].join("\n");
+		expect(check(robotsTxt, "CCBot").crawlDelay).toBe(10);
+	});
+});

--- a/apps/www/src/lib/tools/robots.ts
+++ b/apps/www/src/lib/tools/robots.ts
@@ -1,0 +1,160 @@
+/**
+ * A robots.txt parser and matcher following RFC 9309: groups are keyed by
+ * user-agent product token, the longest matching path pattern wins, and Allow
+ * beats Disallow on a tie. `*` and `$` in patterns are honored.
+ *
+ * Pure — no network, no Node built-ins — so both the server handler and the
+ * tests can use it directly.
+ */
+
+export interface RobotsRule {
+	type: "allow" | "disallow";
+	/** The raw pattern as written, e.g. `/admin/` or `/*.php$`. */
+	pattern: string;
+}
+
+export interface RobotsGroup {
+	/** Lowercased product tokens this group applies to. */
+	agents: string[];
+	rules: RobotsRule[];
+	crawlDelay?: number;
+}
+
+export interface ParsedRobots {
+	groups: RobotsGroup[];
+	sitemaps: string[];
+}
+
+export interface AgentVerdict {
+	allowed: boolean;
+	/**
+	 * The user-agent token whose group governs this bot, `*` for the catch-all,
+	 * or null when no group matches (nothing constrains the bot).
+	 */
+	matchedAgent: string | null;
+	/** The winning rule, or null when no pattern matched the path. */
+	matchedRule: RobotsRule | null;
+	/** Every disallow pattern in the governing group, for "partially blocked". */
+	disallowedPatterns: string[];
+	crawlDelay?: number;
+}
+
+export function parseRobotsTxt(text: string): ParsedRobots {
+	const groups: RobotsGroup[] = [];
+	const sitemaps: string[] = [];
+
+	let current: RobotsGroup | null = null;
+	// Consecutive User-agent lines share one group; the first rule line closes
+	// the header, so a later User-agent starts a new group.
+	let headerOpen = false;
+
+	for (const rawLine of text.split(/\r?\n/)) {
+		const line = rawLine.split("#")[0].trim();
+		if (!line) continue;
+
+		const separator = line.indexOf(":");
+		if (separator === -1) continue;
+
+		const field = line.slice(0, separator).trim().toLowerCase();
+		const value = line.slice(separator + 1).trim();
+
+		switch (field) {
+			case "user-agent": {
+				if (!value) break;
+				if (!current || !headerOpen) {
+					current = { agents: [], rules: [] };
+					groups.push(current);
+					headerOpen = true;
+				}
+				current.agents.push(value.toLowerCase());
+				break;
+			}
+			case "allow":
+			case "disallow": {
+				if (!current) break;
+				headerOpen = false;
+				// An empty value is a no-op: "Disallow:" disallows nothing.
+				if (!value) break;
+				current.rules.push({ type: field, pattern: value });
+				break;
+			}
+			case "crawl-delay": {
+				if (!current) break;
+				headerOpen = false;
+				const delay = Number.parseFloat(value);
+				if (Number.isFinite(delay)) current.crawlDelay = delay;
+				break;
+			}
+			case "sitemap": {
+				if (value) sitemaps.push(value);
+				break;
+			}
+		}
+	}
+
+	return { groups, sitemaps };
+}
+
+/**
+ * The group a bot obeys: the longest user-agent token that prefix-matches its
+ * name, falling back to `*`. This is why `Googlebot-News` follows a `Googlebot`
+ * group when it has none of its own, and why a named group makes the crawler
+ * ignore `User-agent: *` entirely.
+ */
+function selectAgent(groups: RobotsGroup[], userAgent: string): string | null {
+	const bot = userAgent.toLowerCase();
+	let best: string | null = null;
+
+	for (const group of groups) {
+		for (const agent of group.agents) {
+			if (agent === "*") continue;
+			if (!bot.startsWith(agent)) continue;
+			if (!best || agent.length > best.length) best = agent;
+		}
+	}
+
+	if (best) return best;
+	return groups.some((group) => group.agents.includes("*")) ? "*" : null;
+}
+
+function patternMatches(pattern: string, path: string): boolean {
+	const anchored = pattern.endsWith("$");
+	const body = anchored ? pattern.slice(0, -1) : pattern;
+	const escaped = body.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+	return new RegExp(`^${escaped}${anchored ? "$" : ""}`).test(path);
+}
+
+export function evaluate(robots: ParsedRobots, userAgent: string, path: string): AgentVerdict {
+	const matchedAgent = selectAgent(robots.groups, userAgent);
+	if (!matchedAgent) {
+		return { allowed: true, matchedAgent: null, matchedRule: null, disallowedPatterns: [] };
+	}
+
+	// Groups repeating the same token are merged, per RFC 9309.
+	const applicable = robots.groups.filter((group) => group.agents.includes(matchedAgent));
+	const rules = applicable.flatMap((group) => group.rules);
+	const crawlDelay = applicable.find((group) => group.crawlDelay !== undefined)?.crawlDelay;
+
+	let winner: RobotsRule | null = null;
+	for (const rule of rules) {
+		if (!patternMatches(rule.pattern, path)) continue;
+		if (!winner) {
+			winner = rule;
+			continue;
+		}
+		if (rule.pattern.length > winner.pattern.length) {
+			winner = rule;
+		} else if (rule.pattern.length === winner.pattern.length && rule.type === "allow") {
+			// Equal specificity: the permissive rule wins.
+			winner = rule;
+		}
+	}
+
+	return {
+		allowed: winner ? winner.type === "allow" : true,
+		matchedAgent,
+		matchedRule: winner,
+		disallowedPatterns: rules.filter((rule) => rule.type === "disallow").map((rule) => rule.pattern),
+		crawlDelay,
+	};
+}

--- a/apps/www/src/lib/tools/site-discovery.ts
+++ b/apps/www/src/lib/tools/site-discovery.ts
@@ -1,0 +1,119 @@
+import { fetchRemoteText } from "./fetch-remote";
+import { extractPageMeta } from "./html-meta";
+import { MAX_PAGES, MAX_SITEMAPS, SUMMARY_BATCH_SIZE } from "./limits";
+import { parseRobotsTxt } from "./robots";
+import { normalizeSiteUrl, ToolError } from "./site-url";
+import { canonicalizeUrl, collectSitemapUrls, isContentUrl } from "./sitemap";
+import type { PageSummary, SiteDiscovery } from "./types";
+
+const SITEMAP_GUESSES = ["/sitemap.xml", "/sitemap_index.xml", "/sitemap-index.xml", "/wp-sitemap.xml"];
+/** Total wall-clock budget for one discovery, comfortably inside any function limit. */
+const DISCOVERY_BUDGET_MS = 25_000;
+
+async function sitemapCandidates(origin: string): Promise<URL[]> {
+	const candidates: URL[] = [];
+
+	try {
+		const robots = await fetchRemoteText(new URL("/robots.txt", origin), {
+			accept: "text/plain,*/*;q=0.8",
+			timeoutMs: 5_000,
+		});
+		if (robots.ok) {
+			for (const declared of parseRobotsTxt(robots.body).sitemaps) {
+				try {
+					const url = new URL(declared);
+					if (url.origin === origin) candidates.push(url);
+				} catch {
+					// Ignore a malformed Sitemap: line and fall through to the guesses.
+				}
+			}
+		}
+	} catch {
+		// robots.txt is only a hint here — the conventional paths still apply.
+	}
+
+	for (const guess of SITEMAP_GUESSES) candidates.push(new URL(guess, origin));
+	return candidates;
+}
+
+export async function discoverSite(input: string): Promise<SiteDiscovery> {
+	const deadline = Date.now() + DISCOVERY_BUDGET_MS;
+	const target = normalizeSiteUrl(input);
+	// A pasted sitemap URL is used as-is; otherwise we go looking for one.
+	const pastedSitemap = /\.xml$/i.test(target.pathname) ? target : null;
+
+	let origin = target.origin;
+	let siteName = target.hostname.replace(/^www\./, "");
+	let siteDescription: string | null = null;
+	try {
+		const home = await fetchRemoteText(new URL("/", origin), {
+			accept: "text/html,*/*;q=0.8",
+			maxBytes: 256 * 1024,
+			timeoutMs: 6_000,
+		});
+		if (home.ok) {
+			// Adopt the origin the homepage redirected to. Apex-to-www is the
+			// common case, and a sitemap declared on www is not same-origin with
+			// the apex the visitor typed.
+			origin = new URL(home.url).origin;
+			const meta = extractPageMeta(home.body);
+			if (meta.title) siteName = meta.title;
+			siteDescription = meta.description;
+		}
+	} catch {
+		// A homepage we cannot read costs us the title, not the run.
+	}
+
+	const candidates = pastedSitemap ? [pastedSitemap] : await sitemapCandidates(origin);
+
+	for (const candidate of candidates) {
+		const { urls, truncated } = await collectSitemapUrls(candidate, origin, {
+			maxUrls: MAX_PAGES,
+			maxSitemaps: MAX_SITEMAPS,
+			deadline,
+		});
+		if (urls.length === 0) continue;
+
+		const home = canonicalizeUrl(origin);
+		const ordered = urls.includes(home) ? urls : [home, ...urls].slice(0, MAX_PAGES);
+
+		return {
+			origin,
+			siteName,
+			siteDescription,
+			sitemapUrl: candidate.toString(),
+			urls: ordered,
+			truncated,
+		};
+	}
+
+	throw new ToolError(
+		`No sitemap found for ${origin}. Add one at /sitemap.xml, or paste the full sitemap URL to generate from it directly.`,
+	);
+}
+
+export async function describePages(urls: string[]): Promise<PageSummary[]> {
+	const batch = urls.slice(0, SUMMARY_BATCH_SIZE);
+
+	return Promise.all(
+		batch.map(async (raw): Promise<PageSummary> => {
+			try {
+				const url = normalizeSiteUrl(raw);
+				if (!isContentUrl(url.toString(), url.origin)) return { url: raw, title: null, description: null };
+
+				const response = await fetchRemoteText(url, {
+					accept: "text/html,*/*;q=0.8",
+					maxBytes: 256 * 1024,
+					timeoutMs: 6_000,
+				});
+				if (!response.ok) return { url: raw, title: null, description: null };
+
+				const meta = extractPageMeta(response.body);
+				return { url: raw, title: meta.title, description: meta.description };
+			} catch {
+				// One unreachable page falls back to a slug-derived title.
+				return { url: raw, title: null, description: null };
+			}
+		}),
+	);
+}

--- a/apps/www/src/lib/tools/site-url.test.ts
+++ b/apps/www/src/lib/tools/site-url.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { isPrivateAddress, normalizeSiteUrl, ToolError } from "./site-url";
+
+describe("normalizeSiteUrl", () => {
+	it("accepts a bare domain and assumes https", () => {
+		expect(normalizeSiteUrl("example.com").toString()).toBe("https://example.com/");
+	});
+
+	it("keeps the path so a specific page can be checked", () => {
+		expect(normalizeSiteUrl("example.com/blog/post").pathname).toBe("/blog/post");
+	});
+
+	it("keeps an explicit http scheme", () => {
+		expect(normalizeSiteUrl("http://example.com").protocol).toBe("http:");
+	});
+
+	it("trims surrounding whitespace and drops the fragment", () => {
+		expect(normalizeSiteUrl("  https://example.com/docs#intro  ").toString()).toBe("https://example.com/docs");
+	});
+
+	it.each(["", "   ", "not a domain", "javascript:alert(1)", "file:///etc/passwd", "ftp://example.com"])(
+		"rejects %j",
+		(input) => {
+			expect(() => normalizeSiteUrl(input)).toThrow(ToolError);
+		},
+	);
+
+	it("rejects URLs carrying credentials", () => {
+		expect(() => normalizeSiteUrl("https://user:pass@example.com")).toThrow(ToolError);
+	});
+
+	it("rejects IP literals so the tools stay domain-only", () => {
+		expect(() => normalizeSiteUrl("127.0.0.1")).toThrow(ToolError);
+		expect(() => normalizeSiteUrl("https://169.254.169.254/latest/meta-data")).toThrow(ToolError);
+		expect(() => normalizeSiteUrl("http://[::1]/")).toThrow(ToolError);
+	});
+
+	it("rejects hostnames that cannot be public", () => {
+		expect(() => normalizeSiteUrl("localhost")).toThrow(ToolError);
+		expect(() => normalizeSiteUrl("http://localhost:3000")).toThrow(ToolError);
+		expect(() => normalizeSiteUrl("printer.local")).toThrow(ToolError);
+		expect(() => normalizeSiteUrl("db.internal")).toThrow(ToolError);
+		expect(() => normalizeSiteUrl("intranet")).toThrow(ToolError);
+	});
+});
+
+describe("isPrivateAddress", () => {
+	it.each([
+		"127.0.0.1",
+		"10.1.2.3",
+		"172.16.0.1",
+		"172.31.255.255",
+		"192.168.1.1",
+		"169.254.169.254",
+		"100.64.0.1",
+		"0.0.0.0",
+		"::1",
+		"::",
+		"fd00::1",
+		"fe80::1",
+		"::ffff:127.0.0.1",
+	])("treats %s as private", (address) => {
+		expect(isPrivateAddress(address)).toBe(true);
+	});
+
+	it.each(["8.8.8.8", "1.1.1.1", "172.32.0.1", "192.169.0.1", "2606:4700:4700::1111"])(
+		"treats %s as public",
+		(address) => {
+			expect(isPrivateAddress(address)).toBe(false);
+		},
+	);
+
+	it("treats anything unparseable as private", () => {
+		expect(isPrivateAddress("")).toBe(true);
+		expect(isPrivateAddress("999.1.1.1")).toBe(true);
+	});
+});

--- a/apps/www/src/lib/tools/site-url.ts
+++ b/apps/www/src/lib/tools/site-url.ts
@@ -1,0 +1,135 @@
+/**
+ * Turning whatever someone pastes into a URL we are willing to fetch.
+ *
+ * These tools fetch a URL the visitor supplies, which makes the server a
+ * potential proxy into anything it can reach. Everything here is the first half
+ * of the defense — syntax, scheme, and address-range checks. The second half
+ * (resolving the hostname and re-checking every redirect hop) lives in
+ * fetch-remote.ts, because it needs DNS.
+ *
+ * Pure: no network, no Node built-ins.
+ */
+
+/** An error whose message is safe to show the visitor verbatim. */
+export class ToolError extends Error {}
+
+/**
+ * Hostnames that never point anywhere public. `.local`/`.internal` and friends
+ * are reserved for private networks, and a hostname with no dot is a LAN name.
+ */
+const BLOCKED_TLDS = ["local", "localhost", "internal", "intranet", "corp", "home", "lan", "test", "invalid", "onion"];
+
+export function isBlockedHostname(hostname: string): boolean {
+	const host = hostname.toLowerCase().replace(/\.$/, "");
+	if (!host) return true;
+	if (!host.includes(".")) return true;
+	if (host.endsWith(".home.arpa") || host.endsWith(".in-addr.arpa") || host.endsWith(".ip6.arpa")) return true;
+	const tld = host.slice(host.lastIndexOf(".") + 1);
+	return BLOCKED_TLDS.includes(tld);
+}
+
+function ipv4ToNumber(ip: string): number | null {
+	const parts = ip.split(".");
+	if (parts.length !== 4) return null;
+	let value = 0;
+	for (const part of parts) {
+		if (!/^\d{1,3}$/.test(part)) return null;
+		const octet = Number(part);
+		if (octet > 255) return null;
+		value = value * 256 + octet;
+	}
+	return value;
+}
+
+/** CIDR blocks that are not routable on the public internet. */
+const PRIVATE_V4_BLOCKS: [string, number][] = [
+	["0.0.0.0", 8],
+	["10.0.0.0", 8],
+	["100.64.0.0", 10],
+	["127.0.0.0", 8],
+	["169.254.0.0", 16], // link-local, including cloud metadata at 169.254.169.254
+	["172.16.0.0", 12],
+	["192.0.0.0", 24],
+	["192.0.2.0", 24],
+	["192.88.99.0", 24],
+	["192.168.0.0", 16],
+	["198.18.0.0", 15],
+	["198.51.100.0", 24],
+	["203.0.113.0", 24],
+	["224.0.0.0", 4],
+	["240.0.0.0", 4],
+];
+
+export function isPrivateAddress(address: string): boolean {
+	const ip = address
+		.trim()
+		.toLowerCase()
+		.replace(/^\[|\]$/g, "")
+		.split("%")[0];
+	if (!ip) return true;
+
+	if (ip.includes(":")) {
+		// IPv4-mapped and IPv4-compatible forms smuggle a v4 address through v6.
+		const embedded = ip.match(/(\d{1,3}(?:\.\d{1,3}){3})$/);
+		if (embedded) return isPrivateAddress(embedded[1]);
+		if (ip === "::" || ip === "::1") return true;
+		const head = ip.split(":")[0];
+		if (!head) return true; // "::something" — unspecified prefix
+		const group = Number.parseInt(head, 16);
+		if (Number.isNaN(group)) return true;
+		if ((group & 0xfe00) === 0xfc00) return true; // fc00::/7 unique local
+		if ((group & 0xffc0) === 0xfe80) return true; // fe80::/10 link local
+		if ((group & 0xff00) === 0xff00) return true; // ff00::/8 multicast
+		return false;
+	}
+
+	const value = ipv4ToNumber(ip);
+	if (value === null) return true;
+	return PRIVATE_V4_BLOCKS.some(([base, bits]) => {
+		const baseValue = ipv4ToNumber(base);
+		if (baseValue === null) return false;
+		const mask = bits === 0 ? 0 : (-1 << (32 - bits)) >>> 0;
+		return (value & mask) >>> 0 === (baseValue & mask) >>> 0;
+	});
+}
+
+export function isIpLiteral(hostname: string): boolean {
+	const host = hostname.replace(/^\[|\]$/g, "");
+	return host.includes(":") || /^\d{1,3}(\.\d{1,3}){3}$/.test(host);
+}
+
+/**
+ * Accepts "example.com", "example.com/blog", or a full URL, and returns the URL
+ * we will actually request. Throws ToolError with a message meant for the
+ * visitor.
+ */
+export function normalizeSiteUrl(input: string): URL {
+	const trimmed = input.trim();
+	if (!trimmed) throw new ToolError("Enter a domain, like example.com");
+	if (/\s/.test(trimmed)) throw new ToolError("That does not look like a domain — remove the spaces and try again.");
+
+	const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+
+	let url: URL;
+	try {
+		url = new URL(withScheme);
+	} catch {
+		throw new ToolError(`Could not read "${trimmed}" as a domain.`);
+	}
+
+	if (url.protocol !== "https:" && url.protocol !== "http:") {
+		throw new ToolError("Only http and https addresses can be checked.");
+	}
+	if (url.username || url.password) {
+		throw new ToolError("Remove the credentials from the URL and try again.");
+	}
+	if (isIpLiteral(url.hostname)) {
+		throw new ToolError("Enter a domain name rather than an IP address.");
+	}
+	if (isBlockedHostname(url.hostname)) {
+		throw new ToolError(`"${url.hostname}" is not a public domain.`);
+	}
+
+	url.hash = "";
+	return url;
+}

--- a/apps/www/src/lib/tools/sitemap.test.ts
+++ b/apps/www/src/lib/tools/sitemap.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { canonicalizeUrl, isContentUrl, parseSitemap } from "./sitemap";
+
+describe("parseSitemap", () => {
+	it("reads page URLs from a urlset", () => {
+		const xml = `<?xml version="1.0"?>
+			<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+				<url><loc>https://example.com/</loc><lastmod>2026-01-01</lastmod></url>
+				<url><loc>https://example.com/blog/hello</loc></url>
+			</urlset>`;
+		expect(parseSitemap(xml)).toEqual({
+			urls: ["https://example.com/", "https://example.com/blog/hello"],
+			sitemaps: [],
+		});
+	});
+
+	it("reads child sitemaps from an index", () => {
+		const xml = `<sitemapindex>
+				<sitemap><loc>https://example.com/posts.xml</loc></sitemap>
+				<sitemap><loc>https://example.com/pages.xml</loc></sitemap>
+			</sitemapindex>`;
+		expect(parseSitemap(xml).sitemaps).toEqual(["https://example.com/posts.xml", "https://example.com/pages.xml"]);
+	});
+
+	it("unwraps CDATA and namespace prefixes are not required", () => {
+		const xml = "<urlset><url><loc><![CDATA[https://example.com/a]]></loc></url></urlset>";
+		expect(parseSitemap(xml).urls).toEqual(["https://example.com/a"]);
+	});
+
+	it("returns nothing for a non-sitemap body", () => {
+		expect(parseSitemap("<html><body>Not found</body></html>")).toEqual({ urls: [], sitemaps: [] });
+	});
+});
+
+describe("isContentUrl", () => {
+	const origin = "https://example.com";
+
+	it("keeps same-origin pages", () => {
+		expect(isContentUrl("https://example.com/blog/post", origin)).toBe(true);
+	});
+
+	it("drops other origins, including the www variant", () => {
+		expect(isContentUrl("https://other.com/page", origin)).toBe(false);
+		expect(isContentUrl("https://www.example.com/page", origin)).toBe(false);
+	});
+
+	it("drops assets that are not pages", () => {
+		expect(isContentUrl("https://example.com/logo.png", origin)).toBe(false);
+		expect(isContentUrl("https://example.com/feed.xml", origin)).toBe(false);
+		expect(isContentUrl("https://example.com/app.js", origin)).toBe(false);
+	});
+
+	it("drops anything unparseable", () => {
+		expect(isContentUrl("not-a-url", origin)).toBe(false);
+	});
+});
+
+describe("canonicalizeUrl", () => {
+	it("drops the query and fragment and the trailing slash", () => {
+		expect(canonicalizeUrl("https://example.com/blog/?utm_source=x#top")).toBe("https://example.com/blog");
+	});
+
+	it("leaves the root path alone", () => {
+		expect(canonicalizeUrl("https://example.com/")).toBe("https://example.com/");
+	});
+});

--- a/apps/www/src/lib/tools/sitemap.ts
+++ b/apps/www/src/lib/tools/sitemap.ts
@@ -1,0 +1,131 @@
+/**
+ * Sitemap XML reading, split into the pure part (parsing) and the part that
+ * needs the network (walking a sitemap index). Regex over a real XML parser
+ * because sitemaps are a fixed, shallow shape and the bodies are byte-capped.
+ */
+import { fetchRemoteText } from "./fetch-remote";
+
+export interface ParsedSitemap {
+	/** `<loc>` values from `<url>` entries. */
+	urls: string[];
+	/** `<loc>` values from `<sitemap>` entries — this file is an index. */
+	sitemaps: string[];
+}
+
+const LOC_PATTERN = /<loc>\s*(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?\s*<\/loc>/gi;
+
+function locsWithin(xml: string, container: "url" | "sitemap"): string[] {
+	const blocks = xml.match(new RegExp(`<${container}\\b[^>]*>[\\s\\S]*?</${container}>`, "gi")) ?? [];
+	const found: string[] = [];
+
+	for (const block of blocks) {
+		LOC_PATTERN.lastIndex = 0;
+		const match = LOC_PATTERN.exec(block);
+		const loc = match?.[1]?.trim();
+		if (loc) found.push(loc);
+	}
+
+	return found;
+}
+
+export function parseSitemap(xml: string): ParsedSitemap {
+	return { urls: locsWithin(xml, "url"), sitemaps: locsWithin(xml, "sitemap") };
+}
+
+/** Paths that are never worth listing in an llms.txt. */
+const SKIPPED_EXTENSIONS =
+	/\.(?:png|jpe?g|gif|webp|avif|svg|ico|css|js|mjs|json|xml|txt|zip|gz|mp4|webm|mp3|wav|woff2?|ttf|eot)$/i;
+
+export function isContentUrl(candidate: string, origin: string): boolean {
+	let url: URL;
+	try {
+		url = new URL(candidate);
+	} catch {
+		return false;
+	}
+
+	if (url.origin !== origin) return false;
+	if (url.protocol !== "https:" && url.protocol !== "http:") return false;
+	return !SKIPPED_EXTENSIONS.test(url.pathname);
+}
+
+export function canonicalizeUrl(candidate: string): string {
+	const url = new URL(candidate);
+	url.hash = "";
+	url.search = "";
+	if (url.pathname.length > 1 && url.pathname.endsWith("/")) url.pathname = url.pathname.slice(0, -1);
+	return url.toString();
+}
+
+const SITEMAP_TIMEOUT_MS = 6_000;
+
+/**
+ * Reads a sitemap, descending into an index up to `maxSitemaps` children, and
+ * returns same-origin content URLs. Bounded three ways — request count, URL
+ * count, and a wall-clock deadline — because this runs in a serverless function
+ * that will be killed mid-flight rather than return a partial answer, and a
+ * partial answer is exactly what we want from a slow site.
+ */
+export async function collectSitemapUrls(
+	entry: URL,
+	origin: string,
+	limits: { maxUrls: number; maxSitemaps: number; deadline: number },
+): Promise<{ urls: string[]; truncated: boolean }> {
+	const queue: URL[] = [entry];
+	const seenSitemaps = new Set<string>([entry.toString()]);
+	const urls = new Set<string>();
+	let fetched = 0;
+	let truncated = false;
+
+	while (queue.length > 0 && fetched < limits.maxSitemaps) {
+		const remaining = limits.deadline - Date.now();
+		if (remaining < 1_000) {
+			truncated = true;
+			break;
+		}
+
+		const next = queue.shift();
+		if (!next) break;
+		fetched++;
+
+		let xml: string;
+		try {
+			const response = await fetchRemoteText(next, {
+				accept: "application/xml,text/xml;q=0.9,*/*;q=0.8",
+				timeoutMs: Math.min(SITEMAP_TIMEOUT_MS, remaining),
+			});
+			if (!response.ok) continue;
+			xml = response.body;
+		} catch {
+			continue;
+		}
+
+		const parsed = parseSitemap(xml);
+
+		for (const child of parsed.sitemaps) {
+			if (seenSitemaps.has(child)) continue;
+			seenSitemaps.add(child);
+			try {
+				const childUrl = new URL(child);
+				if (childUrl.origin === origin) queue.push(childUrl);
+			} catch {
+				// A malformed <loc> in someone else's sitemap is not our problem.
+			}
+		}
+
+		for (const candidate of parsed.urls) {
+			if (!isContentUrl(candidate, origin)) continue;
+			if (urls.size >= limits.maxUrls) {
+				truncated = true;
+				break;
+			}
+			urls.add(canonicalizeUrl(candidate));
+		}
+
+		if (truncated) break;
+	}
+
+	if (queue.length > 0) truncated = true;
+
+	return { urls: [...urls], truncated };
+}

--- a/apps/www/src/lib/tools/types.ts
+++ b/apps/www/src/lib/tools/types.ts
@@ -1,0 +1,51 @@
+/**
+ * The shapes the free tools return to the browser. Kept apart from the handlers
+ * so route components can import the types without pulling server-only modules
+ * (node:dns, the fetcher) into the client bundle.
+ */
+
+export interface CrawlerVerdict {
+	/** robots.txt product token, e.g. `GPTBot`. */
+	token: string;
+	allowed: boolean;
+	/** The user-agent group that governs this bot, `*`, or null when none does. */
+	matchedAgent: string | null;
+	/** The winning rule as written, e.g. `Disallow: /`. */
+	matchedRule: string | null;
+	/** Every disallow pattern in the governing group. */
+	disallowedPatterns: string[];
+	crawlDelay?: number;
+}
+
+export type RobotsOutcome = "found" | "missing" | "server-error";
+
+export interface CrawlerCheckResult {
+	siteUrl: string;
+	/** The robots.txt URL that answered, after redirects. */
+	robotsUrl: string;
+	/** The path the verdicts were evaluated against. */
+	path: string;
+	outcome: RobotsOutcome;
+	httpStatus: number;
+	robotsTxt: string;
+	robotsTxtTruncated: boolean;
+	sitemaps: string[];
+	crawlers: CrawlerVerdict[];
+}
+
+export interface SiteDiscovery {
+	origin: string;
+	siteName: string;
+	siteDescription: string | null;
+	/** The sitemap the URLs came from. */
+	sitemapUrl: string;
+	urls: string[];
+	/** True when the site has more pages than the tool will read. */
+	truncated: boolean;
+}
+
+export interface PageSummary {
+	url: string;
+	title: string | null;
+	description: string | null;
+}

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -40,6 +40,9 @@ import { Route as DocsSplatRouteImport } from './routes/docs/$'
 import { Route as GlossaryIndexRouteImport } from './routes/glossary/index'
 import { Route as GlossarySlugRouteImport } from './routes/glossary/$slug'
 import { Route as OgStatusDotpngRouteImport } from './routes/og/status[.]png'
+import { Route as ToolsIndexRouteImport } from './routes/tools/index'
+import { Route as ToolsAiCrawlerCheckerRouteImport } from './routes/tools/ai-crawler-checker'
+import { Route as ToolsLlmsTxtGeneratorRouteImport } from './routes/tools/llms-txt-generator'
 import { Route as AiVisibilityToolsAlternativesIndexRouteImport } from './routes/ai-visibility-tools/alternatives/index'
 import { Route as AiVisibilityToolsAlternativesSlugRouteImport } from './routes/ai-visibility-tools/alternatives/$slug'
 import { Route as AiVisibilityToolsCategoryIndexRouteImport } from './routes/ai-visibility-tools/category/index'
@@ -210,6 +213,21 @@ const OgStatusDotpngRoute = OgStatusDotpngRouteImport.update({
   path: '/og/status.png',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ToolsIndexRoute = ToolsIndexRouteImport.update({
+  id: '/tools/',
+  path: '/tools/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ToolsAiCrawlerCheckerRoute = ToolsAiCrawlerCheckerRouteImport.update({
+  id: '/tools/ai-crawler-checker',
+  path: '/tools/ai-crawler-checker',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ToolsLlmsTxtGeneratorRoute = ToolsLlmsTxtGeneratorRouteImport.update({
+  id: '/tools/llms-txt-generator',
+  path: '/tools/llms-txt-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AiVisibilityToolsAlternativesIndexRoute =
   AiVisibilityToolsAlternativesIndexRouteImport.update({
     id: '/ai-visibility-tools/alternatives/',
@@ -317,12 +335,15 @@ export interface FileRoutesByFullPath {
   '/docs/$': typeof DocsSplatRoute
   '/glossary/$slug': typeof GlossarySlugRoute
   '/og/status.png': typeof OgStatusDotpngRoute
+  '/tools/ai-crawler-checker': typeof ToolsAiCrawlerCheckerRoute
+  '/tools/llms-txt-generator': typeof ToolsLlmsTxtGeneratorRoute
   '/aeo-for/': typeof AeoForIndexRoute
   '/ai-search/': typeof AiSearchIndexRoute
   '/ai-visibility-tools/': typeof AiVisibilityToolsIndexRoute
   '/blog/': typeof BlogIndexRoute
   '/docs/': typeof DocsIndexRoute
   '/glossary/': typeof GlossaryIndexRoute
+  '/tools/': typeof ToolsIndexRoute
   '/ai-visibility-tools/alternatives/$slug': typeof AiVisibilityToolsAlternativesSlugRoute
   '/ai-visibility-tools/category/$slug': typeof AiVisibilityToolsCategorySlugRoute
   '/ai-visibility-tools/category/open-source': typeof AiVisibilityToolsCategoryOpenSourceRoute
@@ -364,12 +385,15 @@ export interface FileRoutesByTo {
   '/docs/$': typeof DocsSplatRoute
   '/glossary/$slug': typeof GlossarySlugRoute
   '/og/status.png': typeof OgStatusDotpngRoute
+  '/tools/ai-crawler-checker': typeof ToolsAiCrawlerCheckerRoute
+  '/tools/llms-txt-generator': typeof ToolsLlmsTxtGeneratorRoute
   '/aeo-for': typeof AeoForIndexRoute
   '/ai-search': typeof AiSearchIndexRoute
   '/ai-visibility-tools': typeof AiVisibilityToolsIndexRoute
   '/blog': typeof BlogIndexRoute
   '/docs': typeof DocsIndexRoute
   '/glossary': typeof GlossaryIndexRoute
+  '/tools': typeof ToolsIndexRoute
   '/ai-visibility-tools/alternatives/$slug': typeof AiVisibilityToolsAlternativesSlugRoute
   '/ai-visibility-tools/category/$slug': typeof AiVisibilityToolsCategorySlugRoute
   '/ai-visibility-tools/category/open-source': typeof AiVisibilityToolsCategoryOpenSourceRoute
@@ -412,12 +436,15 @@ export interface FileRoutesById {
   '/docs/$': typeof DocsSplatRoute
   '/glossary/$slug': typeof GlossarySlugRoute
   '/og/status.png': typeof OgStatusDotpngRoute
+  '/tools/ai-crawler-checker': typeof ToolsAiCrawlerCheckerRoute
+  '/tools/llms-txt-generator': typeof ToolsLlmsTxtGeneratorRoute
   '/aeo-for/': typeof AeoForIndexRoute
   '/ai-search/': typeof AiSearchIndexRoute
   '/ai-visibility-tools/': typeof AiVisibilityToolsIndexRoute
   '/blog/': typeof BlogIndexRoute
   '/docs/': typeof DocsIndexRoute
   '/glossary/': typeof GlossaryIndexRoute
+  '/tools/': typeof ToolsIndexRoute
   '/ai-visibility-tools/alternatives/$slug': typeof AiVisibilityToolsAlternativesSlugRoute
   '/ai-visibility-tools/category/$slug': typeof AiVisibilityToolsCategorySlugRoute
   '/ai-visibility-tools/category/open-source': typeof AiVisibilityToolsCategoryOpenSourceRoute
@@ -461,12 +488,15 @@ export interface FileRouteTypes {
     | '/docs/$'
     | '/glossary/$slug'
     | '/og/status.png'
+    | '/tools/ai-crawler-checker'
+    | '/tools/llms-txt-generator'
     | '/aeo-for/'
     | '/ai-search/'
     | '/ai-visibility-tools/'
     | '/blog/'
     | '/docs/'
     | '/glossary/'
+    | '/tools/'
     | '/ai-visibility-tools/alternatives/$slug'
     | '/ai-visibility-tools/category/$slug'
     | '/ai-visibility-tools/category/open-source'
@@ -508,12 +538,15 @@ export interface FileRouteTypes {
     | '/docs/$'
     | '/glossary/$slug'
     | '/og/status.png'
+    | '/tools/ai-crawler-checker'
+    | '/tools/llms-txt-generator'
     | '/aeo-for'
     | '/ai-search'
     | '/ai-visibility-tools'
     | '/blog'
     | '/docs'
     | '/glossary'
+    | '/tools'
     | '/ai-visibility-tools/alternatives/$slug'
     | '/ai-visibility-tools/category/$slug'
     | '/ai-visibility-tools/category/open-source'
@@ -555,12 +588,15 @@ export interface FileRouteTypes {
     | '/docs/$'
     | '/glossary/$slug'
     | '/og/status.png'
+    | '/tools/ai-crawler-checker'
+    | '/tools/llms-txt-generator'
     | '/aeo-for/'
     | '/ai-search/'
     | '/ai-visibility-tools/'
     | '/blog/'
     | '/docs/'
     | '/glossary/'
+    | '/tools/'
     | '/ai-visibility-tools/alternatives/$slug'
     | '/ai-visibility-tools/category/$slug'
     | '/ai-visibility-tools/category/open-source'
@@ -603,12 +639,15 @@ export interface RootRouteChildren {
   DocsSplatRoute: typeof DocsSplatRoute
   GlossarySlugRoute: typeof GlossarySlugRoute
   OgStatusDotpngRoute: typeof OgStatusDotpngRoute
+  ToolsAiCrawlerCheckerRoute: typeof ToolsAiCrawlerCheckerRoute
+  ToolsLlmsTxtGeneratorRoute: typeof ToolsLlmsTxtGeneratorRoute
   AeoForIndexRoute: typeof AeoForIndexRoute
   AiSearchIndexRoute: typeof AiSearchIndexRoute
   AiVisibilityToolsIndexRoute: typeof AiVisibilityToolsIndexRoute
   BlogIndexRoute: typeof BlogIndexRoute
   DocsIndexRoute: typeof DocsIndexRoute
   GlossaryIndexRoute: typeof GlossaryIndexRoute
+  ToolsIndexRoute: typeof ToolsIndexRoute
   AiVisibilityToolsAlternativesSlugRoute: typeof AiVisibilityToolsAlternativesSlugRoute
   AiVisibilityToolsCategorySlugRoute: typeof AiVisibilityToolsCategorySlugRoute
   AiVisibilityToolsCategoryOpenSourceRoute: typeof AiVisibilityToolsCategoryOpenSourceRoute
@@ -844,6 +883,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OgStatusDotpngRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/tools/': {
+      id: '/tools/'
+      path: '/tools'
+      fullPath: '/tools/'
+      preLoaderRoute: typeof ToolsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tools/ai-crawler-checker': {
+      id: '/tools/ai-crawler-checker'
+      path: '/tools/ai-crawler-checker'
+      fullPath: '/tools/ai-crawler-checker'
+      preLoaderRoute: typeof ToolsAiCrawlerCheckerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tools/llms-txt-generator': {
+      id: '/tools/llms-txt-generator'
+      path: '/tools/llms-txt-generator'
+      fullPath: '/tools/llms-txt-generator'
+      preLoaderRoute: typeof ToolsLlmsTxtGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/ai-visibility-tools/alternatives/': {
       id: '/ai-visibility-tools/alternatives/'
       path: '/ai-visibility-tools/alternatives'
@@ -971,12 +1031,15 @@ const rootRouteChildren: RootRouteChildren = {
   DocsSplatRoute: DocsSplatRoute,
   GlossarySlugRoute: GlossarySlugRoute,
   OgStatusDotpngRoute: OgStatusDotpngRoute,
+  ToolsAiCrawlerCheckerRoute: ToolsAiCrawlerCheckerRoute,
+  ToolsLlmsTxtGeneratorRoute: ToolsLlmsTxtGeneratorRoute,
   AeoForIndexRoute: AeoForIndexRoute,
   AiSearchIndexRoute: AiSearchIndexRoute,
   AiVisibilityToolsIndexRoute: AiVisibilityToolsIndexRoute,
   BlogIndexRoute: BlogIndexRoute,
   DocsIndexRoute: DocsIndexRoute,
   GlossaryIndexRoute: GlossaryIndexRoute,
+  ToolsIndexRoute: ToolsIndexRoute,
   AiVisibilityToolsAlternativesSlugRoute:
     AiVisibilityToolsAlternativesSlugRoute,
   AiVisibilityToolsCategorySlugRoute: AiVisibilityToolsCategorySlugRoute,

--- a/apps/www/src/routes/ai-visibility-tools/index.tsx
+++ b/apps/www/src/routes/ai-visibility-tools/index.tsx
@@ -66,6 +66,11 @@ const browseLinks = [
 		description: "Trackers, content platforms, APIs, SEO suites, and open source.",
 		href: "/ai-visibility-tools/category",
 	},
+	{
+		title: "Free AEO tools",
+		description: "Generate an llms.txt, or check which AI crawlers your robots.txt allows.",
+		href: "/tools",
+	},
 ];
 
 function AiVisibilitySoftwarePage() {
@@ -82,7 +87,7 @@ function AiVisibilitySoftwarePage() {
 							Compare tools head-to-head, find alternatives to one you're evaluating, or filter the field by feature and
 							category.
 						</p>
-						<div className="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+						<div className="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
 							{browseLinks.map((link) => (
 								<a
 									key={link.href}

--- a/apps/www/src/routes/sitemap[.]xml.ts
+++ b/apps/www/src/routes/sitemap[.]xml.ts
@@ -1,23 +1,24 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { source } from "@/lib/source";
+import { aeoVerticals } from "@/data/aeo-verticals";
+import { aiSearchEngines } from "@/data/ai-search-engines";
+import { glossaryTerms } from "@/data/glossary";
+import { freeTools } from "@/data/tools";
 import { blogSource } from "@/lib/blog";
 import {
-	competitors,
-	getComparisonSlug,
-	isLowDR,
-	comparePairs,
-	comparePairSlug,
-	compareSets,
-	compareSetSlug,
-	indexedCompetitors,
-	indexableFeatureKeys,
-	FEATURE_SLUGS,
-	indexableCategories,
 	CATEGORY_SLUGS,
+	comparePairSlug,
+	comparePairs,
+	compareSetSlug,
+	compareSets,
+	competitors,
+	FEATURE_SLUGS,
+	getComparisonSlug,
+	indexableCategories,
+	indexableFeatureKeys,
+	indexedCompetitors,
+	isLowDR,
 } from "@/lib/competitors";
-import { glossaryTerms } from "@/data/glossary";
-import { aiSearchEngines } from "@/data/ai-search-engines";
-import { aeoVerticals } from "@/data/aeo-verticals";
+import { source } from "@/lib/source";
 
 const SITE_URL = "https://www.elmohq.com";
 
@@ -43,6 +44,7 @@ const staticPages: SitemapEntry[] = [
 	{ path: "/docs", changefreq: "weekly", priority: 0.9 },
 	{ path: "/blog", changefreq: "weekly", priority: 0.7 },
 	{ path: "/ai-visibility-tools", changefreq: "weekly", priority: 0.8 },
+	{ path: "/tools", changefreq: "monthly", priority: 0.8 },
 	{ path: "/vision", changefreq: "monthly", priority: 0.6 },
 	{ path: "/brand", changefreq: "monthly", priority: 0.5 },
 	{ path: "/status", changefreq: "daily", priority: 0.5 },
@@ -135,6 +137,12 @@ export const Route = createFileRoute("/sitemap.xml")({
 					})),
 				];
 
+				const toolPages: SitemapEntry[] = freeTools.map((tool) => ({
+					path: `/tools/${tool.slug}`,
+					changefreq: "monthly",
+					priority: 0.8,
+				}));
+
 				const allPages: SitemapEntry[] = [
 					...staticPages,
 					...docsPages,
@@ -144,6 +152,7 @@ export const Route = createFileRoute("/sitemap.xml")({
 					...glossaryPages,
 					...aiSearchPages,
 					...aeoForPages,
+					...toolPages,
 				];
 
 				const sitemap = `<?xml version="1.0" encoding="UTF-8"?>

--- a/apps/www/src/routes/tools/ai-crawler-checker.tsx
+++ b/apps/www/src/routes/tools/ai-crawler-checker.tsx
@@ -1,0 +1,158 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ElmoCta } from "@/components/directory-shell";
+import { Faq } from "@/components/faq";
+import { Footer } from "@/components/footer";
+import { Navbar } from "@/components/navbar";
+import { AiCrawlerChecker } from "@/components/tools/ai-crawler-checker";
+import { RelatedReading, ToolHero, ToolPanel, ToolSection } from "@/components/tools/tool-shell";
+import { requireFreeTool } from "@/data/tools";
+import { breadcrumbJsonLd, canonicalUrl, faqJsonLd, freeToolJsonLd, ogMeta } from "@/lib/seo";
+import { AI_CRAWLERS, CRAWLER_ROLE_LABELS } from "@/lib/tools/ai-crawlers";
+
+const tool = requireFreeTool("ai-crawler-checker");
+const path = `/tools/${tool.slug}`;
+
+export const Route = createFileRoute("/tools/ai-crawler-checker")({
+	head: () => ({
+		meta: [
+			{ title: tool.metaTitle },
+			{ name: "description", content: tool.description },
+			...ogMeta({ title: tool.metaTitle, description: tool.description, path }),
+		],
+		links: [{ rel: "canonical", href: canonicalUrl(path) }],
+		scripts: [
+			breadcrumbJsonLd([
+				{ name: "Home", path: "/" },
+				{ name: "Free tools", path: "/tools" },
+				{ name: tool.name, path },
+			]),
+			freeToolJsonLd({ name: tool.name, description: tool.description, path }),
+			faqJsonLd(tool.faqs),
+		],
+	}),
+	component: AiCrawlerCheckerPage,
+});
+
+function AiCrawlerCheckerPage() {
+	return (
+		<div className="min-h-screen">
+			<Navbar />
+			<main>
+				<ToolHero
+					eyebrow="/ Free tools"
+					title="AI crawler checker"
+					lead="Paste a domain to see which AI crawlers your robots.txt allows and which it blocks — GPTBot, ClaudeBot, PerplexityBot, Googlebot, and ten more. Free, no signup, nothing stored."
+				/>
+
+				<ToolPanel>
+					<AiCrawlerChecker />
+				</ToolPanel>
+
+				<ToolSection title="How the check works">
+					<div className="max-w-3xl space-y-5 leading-relaxed text-zinc-600">
+						<p>
+							The checker fetches <code className="font-mono text-xs">/robots.txt</code> and evaluates it the way a
+							compliant crawler does, following RFC 9309. Three rules decide every verdict on this page, and all three
+							are places people guess wrong.
+						</p>
+						<ul className="list-disc space-y-3 pl-5">
+							<li>
+								<strong className="text-zinc-950">The most specific user-agent group wins, and it wins alone.</strong> A
+								bot that has its own named group ignores <code className="font-mono text-xs">User-agent: *</code>{" "}
+								entirely — a global <code className="font-mono text-xs">Allow: /</code> does not rescue a crawler that
+								is disallowed in its own block.
+							</li>
+							<li>
+								<strong className="text-zinc-950">The longest matching path pattern wins.</strong>{" "}
+								<code className="font-mono text-xs">Disallow: /</code> loses to{" "}
+								<code className="font-mono text-xs">Allow: /blog/</code> for a URL under /blog/, because the more
+								specific rule is the one that applies.
+							</li>
+							<li>
+								<strong className="text-zinc-950">On a tie, Allow beats Disallow.</strong> Two rules of equal length
+								matching the same path resolve in favor of crawling.
+							</li>
+						</ul>
+						<p>
+							Paste a bare domain to check the site root, or a full URL to check one page. Nothing is executed and
+							nothing is saved — the check is a single request to a file that is already public.
+						</p>
+					</div>
+				</ToolSection>
+
+				<ToolSection title="The crawlers it checks">
+					<div className="overflow-x-auto">
+						<table className="w-full min-w-[720px] text-sm">
+							<thead>
+								<tr className="border-b border-zinc-200 text-left">
+									<th className="py-3 pr-4 font-semibold text-zinc-950">Crawler</th>
+									<th className="py-3 pr-4 font-semibold text-zinc-950">Run by</th>
+									<th className="py-3 pr-4 font-semibold text-zinc-950">Job</th>
+									<th className="py-3 font-semibold text-zinc-950">Blocking it costs you</th>
+								</tr>
+							</thead>
+							<tbody>
+								{AI_CRAWLERS.map((crawler) => (
+									<tr key={crawler.token} className="border-b border-zinc-200 align-top">
+										<td className="py-3 pr-4 font-mono text-xs text-zinc-950">{crawler.token}</td>
+										<td className="py-3 pr-4 text-zinc-600">{crawler.operator}</td>
+										<td className="py-3 pr-4 text-zinc-600">{CRAWLER_ROLE_LABELS[crawler.role]}</td>
+										<td className="py-3 text-zinc-600">{crawler.blockingCosts}</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+					<p className="mt-5 max-w-3xl leading-relaxed text-zinc-600">
+						User-agent names change. Treat this as a starting map and check each company's published crawler docs before
+						writing strict rules.
+					</p>
+				</ToolSection>
+
+				<ToolSection title="What a block actually costs">
+					<div className="max-w-3xl space-y-5 leading-relaxed text-zinc-600">
+						<p>
+							The crawlers above do three different jobs, and blocking the wrong one has consequences people rarely
+							intend. Training crawlers decide whether your writing feeds a model. Search crawlers decide whether an
+							assistant can cite you. Live-fetch crawlers decide whether a page can be read at the moment a user asks
+							about it.
+						</p>
+						<p>
+							The most expensive single mistake involves Google. There is no separate AI Overviews bot to block: AI
+							Overviews and AI Mode are features of Google Search and run on{" "}
+							<code className="font-mono text-xs">Googlebot</code>, so disallowing it removes you from AI answers and
+							classic search at once. <code className="font-mono text-xs">Google-Extended</code> is narrower than its
+							name suggests — it governs Gemini training and Vertex grounding only, and blocking it does not affect AI
+							Overviews.
+						</p>
+						<p>
+							A robots.txt that returns a 5xx is worse than one that returns a 404. A missing file means everything is
+							allowed; a file that keeps erroring is treated as a site-wide disallow by major crawlers. The checker
+							calls that out separately for exactly this reason.
+						</p>
+					</div>
+				</ToolSection>
+
+				<Faq items={tool.faqs} eyebrow="/ FAQ" />
+
+				<RelatedReading
+					links={[
+						{
+							label: "Robots.txt and AI crawlers",
+							href: "/blog/robots-txt-ai-crawlers",
+							blurb: "Which crawlers to allow, which to block, and two copy-paste robots.txt configurations.",
+						},
+						{
+							label: "llms.txt generator",
+							href: "/tools/llms-txt-generator",
+							blurb: "Once crawlers are in, give them a map: build an llms.txt from your sitemap.",
+						},
+					]}
+				/>
+
+				<ElmoCta />
+			</main>
+			<Footer />
+		</div>
+	);
+}

--- a/apps/www/src/routes/tools/index.tsx
+++ b/apps/www/src/routes/tools/index.tsx
@@ -1,0 +1,100 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ArrowRight } from "lucide-react";
+import { ElmoCta } from "@/components/directory-shell";
+import { Footer } from "@/components/footer";
+import { Navbar } from "@/components/navbar";
+import { freeTools } from "@/data/tools";
+import { breadcrumbJsonLd, canonicalUrl, itemListJsonLd, ogMeta } from "@/lib/seo";
+
+const title = "Free AEO Tools: llms.txt & AI Crawler Checkers · Elmo";
+const description =
+	"Free tools for AI search visibility: generate an llms.txt from any sitemap, and check which AI crawlers your robots.txt allows. No signup, nothing stored.";
+
+export const Route = createFileRoute("/tools/")({
+	head: () => ({
+		meta: [{ title }, { name: "description", content: description }, ...ogMeta({ title, description, path: "/tools" })],
+		links: [{ rel: "canonical", href: canonicalUrl("/tools") }],
+		scripts: [
+			breadcrumbJsonLd([
+				{ name: "Home", path: "/" },
+				{ name: "Free tools", path: "/tools" },
+			]),
+			itemListJsonLd(
+				freeTools.map((tool) => ({
+					name: tool.name,
+					path: `/tools/${tool.slug}`,
+					description: tool.short,
+				})),
+			),
+		],
+	}),
+	component: ToolsIndex,
+});
+
+function ToolsIndex() {
+	return (
+		<div className="min-h-screen">
+			<Navbar />
+			<main>
+				<section className="border-b border-zinc-200 bg-white py-12 lg:py-20">
+					<div className="mx-auto max-w-6xl px-4 md:px-6">
+						<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">/ Free tools</p>
+						<h1 className="font-heading mt-2 text-4xl text-balance text-zinc-950 md:text-5xl">Free AEO tools</h1>
+						<p className="mt-4 max-w-3xl text-lg text-balance text-zinc-600">
+							Small utilities for the technical side of answer engine optimization. Paste a domain, get an answer. No
+							account, no email, nothing stored.
+						</p>
+					</div>
+				</section>
+
+				<section className="border-b border-zinc-200 bg-zinc-50 py-10">
+					<div className="mx-auto max-w-6xl px-4 md:px-6">
+						<div className="grid gap-5 sm:grid-cols-2">
+							{freeTools.map((tool) => (
+								<a
+									key={tool.slug}
+									href={`/tools/${tool.slug}`}
+									className="flex flex-col rounded-md border border-zinc-200 bg-white p-6 transition-colors hover:border-zinc-300"
+								>
+									<h2 className="inline-flex items-center gap-1.5 font-heading text-xl text-zinc-950">
+										{tool.name}
+										<ArrowRight className="size-4" />
+									</h2>
+									<p className="mt-2 text-sm leading-relaxed text-zinc-600">{tool.short}</p>
+								</a>
+							))}
+						</div>
+					</div>
+				</section>
+
+				<section className="border-b border-zinc-200 bg-white py-12">
+					<div className="mx-auto max-w-6xl px-4 md:px-6">
+						<h2 className="font-heading text-2xl text-zinc-950 md:text-3xl">Why these two first</h2>
+						<div className="mt-6 max-w-3xl space-y-5 leading-relaxed text-zinc-600">
+							<p>
+								Both answer a question you cannot eyeball reliably. Reading a robots.txt and working out whether{" "}
+								<code className="font-mono text-xs">ClaudeBot</code> is actually blocked means applying the group
+								selection and longest-match rules in RFC 9309 in your head, and the common mistakes — assuming a global{" "}
+								<code className="font-mono text-xs">Allow</code> overrides a named block, or that Google-Extended
+								controls AI Overviews — are exactly the ones a careful reader still makes.
+							</p>
+							<p>
+								An llms.txt is the same shape of problem in reverse: the format is trivial, and assembling one by hand
+								across a few hundred URLs is not. The generator reads your sitemap and your own page titles, so what
+								comes out is your site described in your words.
+							</p>
+							<p>
+								Neither tool costs anything to run and neither needs your email, which is the whole point: they should
+								be usable in the ten seconds between wondering and knowing. Elmo itself is open source, so if you want
+								to see how a check works, the code is on GitHub.
+							</p>
+						</div>
+					</div>
+				</section>
+
+				<ElmoCta />
+			</main>
+			<Footer />
+		</div>
+	);
+}

--- a/apps/www/src/routes/tools/llms-txt-generator.tsx
+++ b/apps/www/src/routes/tools/llms-txt-generator.tsx
@@ -1,0 +1,145 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ElmoCta } from "@/components/directory-shell";
+import { Faq } from "@/components/faq";
+import { Footer } from "@/components/footer";
+import { Navbar } from "@/components/navbar";
+import { LlmsTxtGenerator } from "@/components/tools/llms-txt-generator";
+import { RelatedReading, ToolHero, ToolPanel, ToolSection } from "@/components/tools/tool-shell";
+import { requireFreeTool } from "@/data/tools";
+import { breadcrumbJsonLd, canonicalUrl, faqJsonLd, freeToolJsonLd, howToJsonLd, ogMeta } from "@/lib/seo";
+
+const tool = requireFreeTool("llms-txt-generator");
+const path = `/tools/${tool.slug}`;
+
+const steps = [
+	{
+		name: "Enter your domain",
+		text: "Paste a domain such as example.com, or a full sitemap URL if your sitemap lives somewhere unconventional.",
+	},
+	{
+		name: "The generator finds your sitemap",
+		text: "It reads your robots.txt for a Sitemap line, then falls back to /sitemap.xml and the other conventional paths, following a sitemap index into its children.",
+	},
+	{
+		name: "It reads your pages",
+		text: "Up to 60 same-origin URLs are fetched for their title and meta description, so the link list is written in your own words rather than guessed from slugs.",
+	},
+	{
+		name: "Review and edit the result",
+		text: "Sections come from your URL structure, so reorder them, drop anything low-value, and sharpen the one-line summary at the top.",
+	},
+	{
+		name: "Publish it at /llms.txt",
+		text: "Serve the file at the root of your domain as text/plain, and link to it from your pages so an agent browsing your site can find it.",
+	},
+];
+
+export const Route = createFileRoute("/tools/llms-txt-generator")({
+	head: () => ({
+		meta: [
+			{ title: tool.metaTitle },
+			{ name: "description", content: tool.description },
+			...ogMeta({ title: tool.metaTitle, description: tool.description, path }),
+		],
+		links: [{ rel: "canonical", href: canonicalUrl(path) }],
+		scripts: [
+			breadcrumbJsonLd([
+				{ name: "Home", path: "/" },
+				{ name: "Free tools", path: "/tools" },
+				{ name: tool.name, path },
+			]),
+			freeToolJsonLd({ name: tool.name, description: tool.description, path }),
+			howToJsonLd({
+				name: "How to generate an llms.txt file",
+				description: "Build an llms.txt from a site's sitemap and page metadata, then publish it at the domain root.",
+				steps,
+			}),
+			faqJsonLd(tool.faqs),
+		],
+	}),
+	component: LlmsTxtGeneratorPage,
+});
+
+function LlmsTxtGeneratorPage() {
+	return (
+		<div className="min-h-screen">
+			<Navbar />
+			<main>
+				<ToolHero
+					eyebrow="/ Free tools"
+					title="llms.txt generator"
+					lead="Paste a domain and get an llms.txt built from its sitemap, with real page titles and descriptions rather than guesses from slugs. Free, no signup, copy or download in one click."
+				/>
+
+				<ToolPanel>
+					<LlmsTxtGenerator />
+				</ToolPanel>
+
+				<ToolSection title="How it builds the file">
+					<ol className="max-w-3xl space-y-4">
+						{steps.map((step, index) => (
+							<li key={step.name} className="flex gap-4">
+								<span className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-zinc-100 font-mono text-[11px] text-zinc-600">
+									{index + 1}
+								</span>
+								<div>
+									<p className="font-semibold text-zinc-950">{step.name}</p>
+									<p className="mt-1 leading-relaxed text-zinc-600">{step.text}</p>
+								</div>
+							</li>
+						))}
+					</ol>
+				</ToolSection>
+
+				<ToolSection title="What llms.txt is, and what it is not">
+					<div className="max-w-3xl space-y-5 leading-relaxed text-zinc-600">
+						<p>
+							An llms.txt is a Markdown file at the root of your site that gives an AI agent a map of your contents: an
+							H1 with the site name, a one-line summary, and sections of annotated links. It is a convention proposed at{" "}
+							<a
+								href="https://llmstxt.org/"
+								target="_blank"
+								rel="noopener noreferrer"
+								className="text-blue-700 hover:text-blue-900"
+							>
+								llmstxt.org
+							</a>
+							, not a standard any engine is obliged to follow.
+						</p>
+						<p>
+							Being straight about the value: models are not trained to look for llms.txt, it appears in no major
+							assistant's system prompt, and most agent harnesses never request it. The realistic path to it being read
+							is an agent already on your site that follows a link to a file it knows is meant for agents. That is why
+							the file matters less than linking to it, and why a plain-text version of your important pages is usually
+							the higher-leverage change.
+						</p>
+						<p>
+							The downside, though, is close to zero: one static file, generated in seconds. Publish it, link it, and
+							spend the rest of your effort on making the pages themselves easy for a model to read and quote.
+						</p>
+					</div>
+				</ToolSection>
+
+				<Faq items={tool.faqs} eyebrow="/ FAQ" />
+
+				<RelatedReading
+					links={[
+						{
+							label: "Do llms.txt files matter for AEO?",
+							href: "/blog/do-llms-txt-files-matter-for-aeo",
+							blurb: "The five ways an AI agent could encounter your llms.txt, and which one actually happens.",
+						},
+						{
+							label: "AI crawler checker",
+							href: "/tools/ai-crawler-checker",
+							blurb: "A map is no use to a crawler your robots.txt turns away. Check which bots can read your site.",
+						},
+					]}
+				/>
+
+				<ElmoCta />
+			</main>
+			<Footer />
+		</div>
+	);
+}

--- a/apps/www/vitest.config.ts
+++ b/apps/www/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/packages/docs/content/blog/do-llms-txt-files-matter-for-aeo.mdx
+++ b/packages/docs/content/blog/do-llms-txt-files-matter-for-aeo.mdx
@@ -50,6 +50,8 @@ The most likely case that leads to an AI agent loading your llms.txt file is loa
 
 Should you add llms.txt files? I'd generally say yes, since the downside is very low. However, the more important thing is to make sure your website is easy for LLMs to consume. Offering a plaintext version to agents browsing your site is possible via some CMSes and frameworks like [Fumadocs](https://www.fumadocs.dev/docs/integrations/llms). And if you do add an llms.txt file, make sure to link to it!
 
+If you want one to edit rather than write from scratch, our free [llms.txt generator](/tools/llms-txt-generator) builds a draft from your sitemap and your own page titles.
+
 So it turns out that this space is pretty nuanced. Google Search can reasonably say that it doesn't use llms.txt, and Chrome can reasonably say it's recommended for agentic browsing. And an AEO like Peec can reasonably serve pages like [docs.peec.ai/intro-to-peec-ai.md](https://docs.peec.ai/intro-to-peec-ai.md) to agents without an llms.txt.
 
 For Elmo, we do both: [elmohq.com/llms.txt](https://www.elmohq.com/llms.txt) and [a markdown version of every docs page](https://www.elmohq.com/docs/getting-started.md) (with links on every docs page to the markdown version).

--- a/packages/docs/content/blog/robots-txt-ai-crawlers.mdx
+++ b/packages/docs/content/blog/robots-txt-ai-crawlers.mdx
@@ -41,6 +41,8 @@ faq:
 
 This guide covers what robots.txt does and does not control for AI, the crawlers worth knowing by name, and two copy-paste configurations: one for maximum AI visibility, and one for blocking model training while staying in AI search.
 
+If you would rather see the answer for your own site first, our free [AI crawler checker](/tools/ai-crawler-checker) reads your robots.txt and reports which of these bots it allows and which it blocks.
+
 **Key takeaways**
 
 - Robots.txt controls crawling, not training. Compliant AI crawlers obey it; it does not erase content a model already learned or stop datasets that already copied you.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,6 +462,9 @@ importers:
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   e2e:
     dependencies:
@@ -8734,10 +8737,6 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
-    engines: {node: '>=18'}
 
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
@@ -17929,8 +17928,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.2.4: {}
-
   tinyexec@1.3.0: {}
 
   tinyglobby@0.2.16:
@@ -18254,7 +18251,7 @@ snapshots:
       picomatch: 4.0.5
       std-env: 4.2.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)


### PR DESCRIPTION
Closes #612 — the first pass: tools 1 and 2 only, both pure fetch-and-parse with no per-use cost.

## What ships

- **`/tools`** — index, linked from the navbar, the footer's Learn column, and the tool directory's browse grid.
- **`/tools/llms-txt-generator`** — paste a domain, get an llms.txt built from the sitemap, with copy and download.
- **`/tools/ai-crawler-checker`** — paste a domain, get a per-bot allow/block table for the 14 crawlers in `robots-txt-ai-crawlers`.

Both pages server-render their whole shell (hero, explanation, reference table, FAQ) with `SoftwareApplication`, `BreadcrumbList`, and `FAQPage` JSON-LD; the generator also emits `HowTo`. Only the results are client-rendered. Titles follow the format that wins these SERPs — `Free llms.txt Generator: Any Site, No Signup · Elmo`, `AI Crawler & robots.txt Checker: Free Test · Elmo`. All three URLs are in the sitemap, and the two related posts now link to their tool.

## How the checker decides

`src/lib/tools/robots.ts` implements RFC 9309 rather than grepping for `Disallow: /`, because all three of its rules are places people guess wrong: the most specific user-agent group wins *alone* (a named block makes the bot ignore `User-agent: *`), the longest matching path pattern wins, and Allow beats Disallow on a tie. `*` and `$` are honored, repeated groups for the same token are merged, and a bot with no group of its own falls back to a prefix match — so `Googlebot-News` obeys a `Googlebot` group.

Two outcomes are reported separately from the verdicts, because the naive reading of each is backwards:

- **404** → everything is allowed. Fine for visibility.
- **5xx** → every crawler is reported blocked. A robots.txt that keeps failing is treated as a site-wide disallow by Google and others, which is stricter than having no file. A robots.txt served as an HTML 404 page with a 200 status is treated as missing, not as a permissive file.

Spot-checked against live sites: nytimes.com blocks 11 of 14 while keeping Googlebot, Bingbot, and Amazonbot; reddit.com blocks all 14; anthropic.com blocks none.

## How the generator builds the file

Homepage for the title and summary, `robots.txt` for a `Sitemap:` line (falling back to `/sitemap.xml` and three other conventional paths), then up to 60 same-origin URLs across up to 4 sitemap files, then each page's real `<title>` and meta description. Sections come from the first path segment. The browser gets the file immediately with slug-derived titles and upgrades entries as batches of 12 come back, so a slow site shows progress instead of a spinner.

The homepage fetch also decides the canonical origin: apex-to-www is common enough that without it, `anthropic.com` finds no sitemap at all, because the `Sitemap:` line points at `www.` and is not same-origin with what was typed.

## Fetching URLs a stranger supplies

`src/lib/tools/fetch-remote.ts` is the only path to the network. Before any request: http/https only, no credentials in the URL, no IP literals, no hostname that cannot be public (`.local`, `.internal`, no-dot names), and a DNS lookup that rejects loopback, link-local (including `169.254.169.254`), CGNAT, ULA, and the rest. Redirects are followed by hand so every hop is re-checked rather than trusted. Responses are byte-capped and share one deadline; discovery has a 25s wall-clock budget so a slow site returns a partial sitemap rather than a killed function.

Per-IP rate limits run through the Upstash client the site already uses, and fail open when it is not configured. Neither endpoint costs anything per run, but an uncapped endpoint that fetches arbitrary URLs is a crawler someone else gets to point.

## Tests

`apps/www` had no vitest project, so this adds one: 75 tests over the parsing and rendering logic — group selection and path matching, private-address classification and input normalization, sitemap and metadata extraction, and the llms.txt output. The fetching and route wiring are covered by hand: both tools driven in a real browser against live sites, and a Vercel-preset build checked for `node:dns` leaking into the client bundle (it does not).

## Not in scope

Tools 3 and 4 from the issue (AI Overview checker, AI visibility checker) are held, as the issue suggests — both spend real money per request and want a caching story first.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0c650859-d039-4515-ad18-a17f2c8538c8)
