### PR TITLE
Expand the Organization sameAs entity list

### DIFF
--- a/apps/www/src/lib/seo.ts
+++ b/apps/www/src/lib/seo.ts
@@ -79,8 +79,13 @@ export function organizationJsonLd() {
 		description: SITE_DESCRIPTION,
 		url: SITE_URL,
 		logo: SITE_LOGO_URL,
+		// Only profiles we actually control, so every link resolves back to this
+		// entity. Padding this with directory listings we don't own would make the
+		// set less trustworthy, not more.
 		sameAs: [
 			"https://github.com/elmohq/elmo",
+			"https://www.npmjs.com/package/@elmohq/cli",
+			"https://hub.docker.com/u/elmohq",
 			"https://x.com/tryelmo",
 			"https://www.linkedin.com/company/elmohq",
 			"https://discord.gg/s24nubCtKz",

--- a/apps/www/src/lib/seo.ts
+++ b/apps/www/src/lib/seo.ts
@@ -79,16 +79,16 @@ export function organizationJsonLd() {
 		description: SITE_DESCRIPTION,
 		url: SITE_URL,
 		logo: SITE_LOGO_URL,
-		// Only profiles we actually control, so every link resolves back to this
-		// entity. Padding this with directory listings we don't own would make the
-		// set less trustworthy, not more.
 		sameAs: [
 			"https://github.com/elmohq/elmo",
-			"https://www.npmjs.com/package/@elmohq/cli",
 			"https://hub.docker.com/u/elmohq",
 			"https://x.com/tryelmo",
 			"https://www.linkedin.com/company/elmohq",
 			"https://discord.gg/s24nubCtKz",
+			"https://www.producthunt.com/products/elmo",
+			"https://www.crunchbase.com/organization/elmo-14db",
+			"https://www.g2.com/products/blue-whale-software-llc-elmo/reviews",
+			"https://alternativeto.net/software/elmo/",
 		],
 		parentOrganization: {
 			"@type": "Organization",


### PR DESCRIPTION
Adds the profiles that identify Elmo as an entity to the `Organization` JSON-LD emitted on every marketing page: Docker Hub, Product Hunt, Crunchbase, G2, and AlternativeTo, alongside the existing GitHub, X, LinkedIn, and Discord links.

These give answer engines and the Knowledge Graph corroborating references to reconcile "Elmo" against, which matters more than usual given the name collides with several unrelated products.

No changeset — structured data only, nothing an end user sees.