### PR TITLE
sort the brand switcher alphabetically

### DIFF
--- a/.changeset/sort-brand-switcher.md
+++ b/.changeset/sort-brand-switcher.md
@@ -2,4 +2,4 @@
 "@workspace/web": patch
 ---
 
-Sort the brand switcher alphabetically so the list stays in the same order between visits.
+Sorts the brands in the brand switcher alphabetically.

--- a/.changeset/sort-brand-switcher.md
+++ b/.changeset/sort-brand-switcher.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Sort the brand switcher alphabetically so the list stays in the same order between visits.

--- a/apps/web/src/routes/_authed/app/index.tsx
+++ b/apps/web/src/routes/_authed/app/index.tsx
@@ -56,7 +56,14 @@ const getBrandSwitcherData = createServerFn({ method: "GET" }).handler(
 		const provisioned = new Set(scopedBrands.map((b) => b.organizationId));
 
 		return {
-			brands: scopedBrands.map((brand) => ({ id: brand.id, name: brand.name })),
+			// Alphabetical, with the id breaking ties between brands that share a
+			// name: an unordered select leaves the order up to Postgres, which is
+			// free to hand back a different one after any row rewrite or plan
+			// change. Sorted here rather than in SQL so the result doesn't depend
+			// on the deployment's database collation.
+			brands: scopedBrands
+				.map((brand) => ({ id: brand.id, name: brand.name }))
+				.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id)),
 			unprovisionedOrgs: canCreateBrands ? [] : orgs.filter((o) => !provisioned.has(o.id)),
 			canCreateBrands,
 		};


### PR DESCRIPTION
The brand switcher list at `/app` had no `ORDER BY`, so Postgres returned brands in whatever order it liked — an order that can shift after a row rewrite, a vacuum, or a plan change, with no code change involved.

It looked stable before because `/app` used to list *organizations* via `listUserOrganizations()`, which orders by `member.created_at, organization.id`. #536 rewrote the page to list brands instead, via a bare `select().from(brands).where(inArray(...))`, and the deterministic ordering was dropped in that swap. That's why the demo site's order changed between the last release and main.

Sorts alphabetically by name, with `id` breaking ties since brand names aren't unique. Done in JS with `localeCompare` rather than a SQL `ORDER BY` so self-hosted installs don't get different orderings from their database's collation — and it matches how the rest of the app sorts user-facing name lists (`lib/prompt-order.ts`, `chart-utils.ts`).

`unprovisionedOrgs` keeps its existing order: it comes from `listUserOrganizations`, whose oldest-membership-first ordering is deliberate (your own workspace ahead of ones you were invited into) and renders as a separate group below the brands.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/673fb831-5ddd-4c0a-81a3-0c7d933c4daa)
