### PR TITLE
Right-align the G2 stars in the hero badge row

### DIFF
--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -1,6 +1,6 @@
 import MuxPlayer from "@mux/mux-player-react";
 import { CLOUD_ENTRY_PRICE_USD } from "@workspace/config/plans";
-import { G2Rating } from "@workspace/ui/brand/g2-rating";
+import { G2Stars } from "@workspace/ui/brand/g2-rating";
 import { ArrowUpRight } from "lucide-react";
 import { CloudSignupCTA, QuietCTA, SelfHostCTA } from "./cta-buttons";
 import { CustomerLogosInline } from "./customer-logos";
@@ -52,7 +52,7 @@ export function Hero() {
 								Star on GitHub
 								<ArrowUpRight className="size-3 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
 							</a>
-							<G2Rating className="text-zinc-600 hover:text-zinc-950" />
+							<G2Stars className="ml-auto" />
 						</div>
 						<h1 className="mt-7 max-w-[18ch] text-5xl font-semibold leading-[1.05] tracking-tight text-balance text-zinc-950 sm:text-6xl lg:text-[4.25rem] lg:leading-[1.0]">
 							Know How AI Talks About Your Brand

--- a/packages/ui/src/brand/g2-rating.tsx
+++ b/packages/ui/src/brand/g2-rating.tsx
@@ -10,7 +10,6 @@ import { SiG2 } from "react-icons/si";
 
 const G2_RATING = 4.7;
 const G2_MAX_RATING = 5;
-const G2_PROFILE_URL = "https://www.g2.com/products/blue-whale-software-llc-elmo/reviews";
 
 const RATING_LABEL = `Rated ${G2_RATING} out of ${G2_MAX_RATING} on G2`;
 
@@ -48,9 +47,8 @@ function Stars() {
 /**
  * The mark and the stars, unlinked and unlabelled.
  *
- * For places that want the rating as a mark of quality rather than as
- * something to click — sitting in the corner of a sign-in page, it should
- * reassure, not offer a way off the page mid-signup.
+ * The rating reads as a mark of quality rather than as something to click — it
+ * should reassure in place, not offer a way off the page.
  */
 export function G2Stars({ className = "" }: { className?: string }) {
 	return (
@@ -58,27 +56,5 @@ export function G2Stars({ className = "" }: { className?: string }) {
 			<SiG2 className="size-4 shrink-0" style={{ color: G2_RED }} aria-hidden="true" />
 			<Stars />
 		</span>
-	);
-}
-
-/**
- * The same rating with the score spelled out, linking to the reviews.
- *
- * @param className tone for the label; the mark and stars keep their own colors.
- */
-export function G2Rating({ className = "" }: { className?: string }) {
-	return (
-		<a
-			href={G2_PROFILE_URL}
-			target="_blank"
-			rel="noopener noreferrer"
-			className={`inline-flex items-center gap-2 text-xs transition-opacity hover:opacity-80 ${className}`}
-		>
-			<SiG2 className="size-4 shrink-0" style={{ color: G2_RED }} aria-hidden="true" />
-			<Stars />
-			<span>
-				{G2_RATING}/{G2_MAX_RATING} stars on G2
-			</span>
-		</a>
 	);
 }


### PR DESCRIPTION
On the marketing home page, the G2 rating now sits at the right edge of the hero badge row as just the mark and stars — no score text, no link off to the reviews page.

`G2Rating` (the linked, labelled variant) had no other callers, so it's gone; `G2Stars` is the only variant left and the sign-in sales panel already used it.

No changeset: the unreleased `g2-rating-badge` changeset already says the home page shows the rating, and this only changes how it's presented.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/be625818-ae27-4270-9fcd-c99c45c3b424)
