### PR TITLE
refer to getcito as a fork

### DIFF
--- a/apps/www/src/lib/competitors/content.ts
+++ b/apps/www/src/lib/competitors/content.ts
@@ -72,11 +72,11 @@ export function getComparisonFaqs(competitor: Competitor): FaqItem[] {
 			},
 			{
 				question: `Is ${name} open source?`,
-				answer: `Yes, ${name} carries an MIT license. Elmo is open source too — audit the code, self-host it, and skip the fork.`,
+				answer: `Yes, ${name} is an MIT licensed fork of Elmo.`,
 			},
 			{
 				question: `Is Elmo a free, open-source alternative to ${name}?`,
-				answer: `Elmo is not an alternative to ${name} so much as the project ${name} forked from. It is free to self-host under MIT, with unlimited prompts and every model, covering ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews. There is little reason to run a fork when the upstream project is free and moving faster.`,
+				answer: `${name} is actually a fork of Elmo, which is free to self-host and developing faster than ${name}. If you want to self-host under MIT, with unlimited prompts and every model, covering ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews, you should use Elmo instead of a fork.`,
 			},
 		];
 	}

--- a/apps/www/src/lib/competitors/content.ts
+++ b/apps/www/src/lib/competitors/content.ts
@@ -22,9 +22,6 @@ export function isOpenSource(competitor: Competitor): boolean {
 	return (competitor.features.openSource ?? false) || competitor.category === "open-source";
 }
 
-/**
- * GetCito forked from Elmo's codebase on this date.
- */
 const GETCITO_FORK_DATE = "July 10, 2026";
 
 /**

--- a/apps/www/src/lib/competitors/content.ts
+++ b/apps/www/src/lib/competitors/content.ts
@@ -23,9 +23,7 @@ export function isOpenSource(competitor: Competitor): boolean {
 }
 
 /**
- * GetCito replaced its codebase with a copy of Elmo's on this date. The generic
- * open-source copy below frames the two as peers you might pick between, which
- * is the wrong answer for a rebranded fork, so it gets its own wording.
+ * GetCito forked from Elmo's codebase on this date.
  */
 const GETCITO_FORK_DATE = "July 10, 2026";
 
@@ -38,7 +36,7 @@ export function getComparisonVerdict(competitor: Competitor): string {
 	const name = competitor.name;
 
 	if (competitor.slug === "getcito") {
-		return `If you are considering ${name}, use Elmo instead. ${name} is running a copy of Elmo's codebase, which it adopted on ${GETCITO_FORK_DATE} and shipped with Elmo's copyright notice replaced by its own. Everything it offers today it inherited from Elmo, and it has shipped far less since — 17 commits to Elmo's 98 in the month after the copy — so it is drifting further behind rather than building past it. Elmo is the original, and it is free to self-host.`;
+		return `If you are considering ${name}, use Elmo instead. ${name} is a fork of Elmo's codebase since ${GETCITO_FORK_DATE}. Everything it offers today it inherited from Elmo, and it has shipped less since — 17 commits to Elmo's 98 in the month after the fork. Elmo is the original, and it is free to self-host.`;
 	}
 
 	if (isOpenSource(competitor)) {
@@ -65,23 +63,23 @@ export function getComparisonFaqs(competitor: Competitor): FaqItem[] {
 		return [
 			{
 				question: `Should I use ${name} or Elmo?`,
-				answer: `Use Elmo. If you are considering ${name}, Elmo is the tool you actually want, because ${name} is a copy of it. On ${GETCITO_FORK_DATE}, ${name} replaced its entire codebase with Elmo's in a single pull request of 847 files, self-merged 62 seconds after it opened. Running ${name} means running an older snapshot of Elmo, maintained by people who did not write it.`,
+				answer: `Use Elmo. If you are considering ${name}, Elmo is the tool you actually want, because ${name} is a fork of it. On ${GETCITO_FORK_DATE}, ${name} replaced its codebase with Elmo's in a single pull request of 847 files. Running ${name} means running an older snapshot of Elmo.`,
 			},
 			{
 				question: `What is the difference between Elmo and ${name}?`,
-				answer: `Elmo is the original codebase and ${name} is a copy of it, taken on ${GETCITO_FORK_DATE}. Everything ${name} offers today it inherited from Elmo. A fork is free to diverge from there, but ${name} has shipped far less than the project it copied — 98 commits to its 17 in the month after the copy, from two contributors working on code they did not write — so the gap is widening rather than closing.`,
+				answer: `Elmo is the original codebase and ${name} is a fork of it, taken on ${GETCITO_FORK_DATE}. Everything ${name} offers today it inherited from Elmo. A fork is free to diverge from there, but ${name} has shipped less than the project it forked — 98 commits to its 17 in the month after — so the gap is widening rather than closing.`,
 			},
 			{
 				question: `Is ${name} a fork of Elmo?`,
-				answer: `Yes, and the evidence is still in its public repository. ${name}'s AGENTS.md opens with the sentence "Elmo is an open-source AI visibility tracking platform." Its contributor license agreement names Elmo's parent company, Blue Whale Software, LLC. Its CODEOWNERS file assigns every path to Elmo's founder, and its contributor registry lists Elmo's contributors.`,
+				answer: `Yes, ${name} is a fork of Elmo since ${GETCITO_FORK_DATE}. Its codebase is based on Elmo's, which is MIT-licensed and freely available to self-host.`,
 			},
 			{
 				question: `Is ${name} open source?`,
-				answer: `It carries the MIT license, but that license file is Elmo's with the copyright line changed from Blue Whale Software, LLC to ${name}. MIT permits anyone to fork, modify, and sell the software; the one condition it sets is that the original copyright notice be kept. Elmo is open source at the source — audit it, self-host it, and skip the copy.`,
+				answer: `Yes, ${name} carries an MIT license. Elmo is open source too — audit the code, self-host it, and skip the fork.`,
 			},
 			{
 				question: `Is Elmo a free, open-source alternative to ${name}?`,
-				answer: `Elmo is not an alternative to ${name} so much as the thing ${name} is a copy of. It is free to self-host under MIT, with unlimited prompts and every model, covering ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews. There is no reason to run a rebranded fork when the upstream project is free and moving faster.`,
+				answer: `Elmo is not an alternative to ${name} so much as the project ${name} forked from. It is free to self-host under MIT, with unlimited prompts and every model, covering ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews. There is little reason to run a fork when the upstream project is free and moving faster.`,
 			},
 		];
 	}

--- a/apps/www/src/lib/competitors/data.ts
+++ b/apps/www/src/lib/competitors/data.ts
@@ -1343,9 +1343,9 @@ export const competitors: Competitor[] = [
 		name: "GetCito",
 		domain: "getcito.com",
 		url: "https://getcito.com/",
-		tagline: "A copy of Elmo's codebase — if you are considering GetCito, use Elmo instead",
+		tagline: "A fork of Elmo — if you are considering GetCito, use Elmo instead",
 		description:
-			"If you are considering GetCito, use Elmo instead: GetCito is a copy of Elmo. It launched in November 2025 as its own Next.js and Firebase application, then on July 10, 2026 replaced that codebase wholesale — 847 files, +131,716/-50,931 lines, self-merged 62 seconds after the pull request opened — with Elmo's. The copy is still visible in the repository: its AGENTS.md opens \"Elmo is an open-source AI visibility tracking platform,\" its CLA names Elmo's parent company Blue Whale Software, LLC, its CODEOWNERS file assigns every path to Elmo's founder, and its contributor registry lists Elmo's contributors. Its LICENSE.md is Elmo's MIT text with the copyright holder swapped to GetCito — the one condition the MIT license imposes on a derivative work is that the original copyright notice be retained. Its feature set was Elmo's as of the copy, and it has shipped far less since — 17 commits to Elmo's 98 in the following month, against 27 human commits across its entire history — so it is falling further behind rather than diverging into something competitive.",
+			"If you are considering GetCito, use Elmo instead: GetCito is a fork of Elmo. It launched in November 2025 as its own Next.js and Firebase application, then on July 10, 2026 replaced that codebase with Elmo's — 847 files, +131,716/-50,931 lines — in a single pull request. Its feature set was Elmo's as of the fork date, and it has shipped less since — 17 commits to Elmo's 98 in the following month — so it is falling further behind rather than diverging into something competitive.",
 		category: "open-source",
 		ahrefsDR: 34,
 		ahrefsTraffic: 34,
@@ -1362,12 +1362,11 @@ export const competitors: Competitor[] = [
 		},
 		pricing: { hasFree: true, hasEnterprise: true },
 		highlights: [
-			"If you are considering GetCito, use Elmo instead — GetCito is a copy of it",
-			"Codebase replaced with a copy of Elmo's on July 10, 2026",
-			"Attribution to Elmo removed from LICENSE.md but left intact in AGENTS.md, CLA.md, and CODEOWNERS",
-			"Ships far less than the project it copied — 17 commits to Elmo's 98 in the first month after",
+			"If you are considering GetCito, use Elmo instead — GetCito is a fork of it",
+			"Codebase replaced with Elmo's on July 10, 2026",
+			"Ships less than the project it forked — 17 commits to Elmo's 98 in the first month after",
 		],
-		notes: "Fork of Elmo with the copyright notice replaced. See the getcito-vs-elmo post for the evidence.",
+		notes: "Fork of Elmo's codebase since July 2026.",
 	},
 	{
 		slug: "meridian",
@@ -6240,7 +6239,7 @@ const aeoPopularityRanking: string[] = [
 	"llmwatcher", // Polish-language tracker with full response history; DR 2.4
 	"lorelight", // Shutting down — public postmortem
 	"jarts", // Acquired and shut down May 2026 — persona-based tracking, entity in liquidation
-	"getcito", // Ranked on name recognition only — since Jul 2026 it is a rebranded fork of Elmo's codebase
+	"getcito", // Fork of Elmo's codebase since Jul 2026
 	"geo-aeo-tracker", // Open-source self-hosted AEO dashboard, 80 GitHub stars
 	"canonry", // Open-source self-hosted AEO platform, server-log ingestion + MCP, 52 stars
 	"gego", // GPL-3.0 self-hosted GEO tracker, Docker + CLI + REST API, Ollama support

--- a/apps/www/src/routes/ai-visibility-tools/category/open-source.tsx
+++ b/apps/www/src/routes/ai-visibility-tools/category/open-source.tsx
@@ -27,7 +27,7 @@ const FAQS: FaqItem[] = [
 	{
 		question: "What are the best open-source AEO tools?",
 		answer:
-			"Elmo is the most complete open-source answer engine optimization tool: MIT-licensed, free to self-host, and covering ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews. Public GitHub data as of 11 August 2026 backs this up — Elmo leads the field on stars, contributors, and releases, and is the only project with a meaningful number of contributors beyond one person. Smaller projects fill out the rest of the space, including OneGlanse, GEO/AEO Tracker, and Gego, most of them single-developer efforts. Canonry is actively developed but source-available rather than fully open source. GetCito is not a separate option at all: it replaced its codebase with Elmo's in July 2026 and swapped the copyright notice, so running it means running an out-of-date copy of Elmo.",
+			"Elmo is the most complete open-source answer engine optimization tool: MIT-licensed, free to self-host, and covering ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews. Public GitHub data as of 11 August 2026 backs this up — Elmo leads the field on stars, contributors, and releases, and is the only project with a meaningful number of contributors beyond one person. Smaller projects fill out the rest of the space, including OneGlanse, GEO/AEO Tracker, and Gego, most of them single-developer efforts. Canonry is actively developed but source-available rather than fully open source. GetCito replaced its codebase with Elmo's in July 2026, so running it means running a lagging fork of Elmo.",
 	},
 	{
 		question: "Which open-source AEO tool is the most actively maintained?",
@@ -47,7 +47,7 @@ const FAQS: FaqItem[] = [
 	{
 		question: "Should I use GetCito or Elmo?",
 		answer:
-			"Use Elmo. If you are considering GetCito, Elmo is what you actually want, because GetCito is a copy of it — on 10 July 2026 it replaced its codebase with Elmo's and swapped the copyright notice on the license. Everything it offers came from Elmo, and it has shipped far less since — 17 commits to Elmo's 98 in the month after the copy — so it is drifting further behind rather than building past it.",
+			"Use Elmo. If you are considering GetCito, Elmo is what you actually want, because GetCito is a fork of it — on 10 July 2026 it replaced its codebase with Elmo's. Everything it offers came from Elmo, and it has shipped less since — 17 commits to Elmo's 98 in the month after the fork — so it is drifting further behind rather than building past it.",
 	},
 	{
 		question: "Can I self-host an AEO tool?",
@@ -102,10 +102,10 @@ const AT_A_GLANCE: { tool: string; license: string; selfHost: string; tracks: st
 	},
 	{
 		tool: "GetCito",
-		license: "MIT, but Elmo's copyright notice replaced with its own",
+		license: "MIT",
 		selfHost: "Yes",
-		tracks: "Whatever Elmo tracked as of July 2026",
-		bestFor: "Nothing — it is a copy of Elmo, run Elmo instead",
+		tracks: "Elmo's engine set as of July 2026",
+		bestFor: "Nothing — it is a fork of Elmo, run Elmo instead",
 	},
 	{
 		tool: "Gego",
@@ -299,10 +299,7 @@ function OpenSourcePage() {
 							The rest of the field is small. OneGlanse, GEO/AEO Tracker, and Gego are real but early, mostly
 							single-developer projects.
 						</li>
-						<li>
-							GetCito is not an independent option. In July 2026 it replaced its codebase with Elmo's and put its own
-							copyright notice on the license, so it is a lagging copy of another tool on this list.
-						</li>
+						<li>GetCito is a fork of Elmo since July 2026, so it is a lagging fork of another tool on this list.</li>
 						<li>
 							Canonry is capable but source-available under the FSL, not fully open source until it converts to Apache
 							2.0.
@@ -488,7 +485,7 @@ function OpenSourcePage() {
 							<h3 className="font-heading mb-3 text-lg text-zinc-950">GetCito</h3>
 							<p>
 								<strong className="font-medium text-zinc-900">If you are considering GetCito, use Elmo instead.</strong>{" "}
-								It is not its own project. On 10 July 2026, GetCito replaced its codebase with Elmo's in{" "}
+								GetCito is a fork of Elmo. On 10 July 2026, it replaced its codebase with Elmo's in{" "}
 								<a
 									href="https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/pull/19"
 									target="_blank"
@@ -497,15 +494,11 @@ function OpenSourcePage() {
 								>
 									one pull request
 								</a>{" "}
-								that changed 847 files and was self-merged 62 seconds after opening. Its LICENSE.md is Elmo's, with
-								"Copyright (c) 2026 Blue Whale Software, LLC" changed to "Copyright (c) 2026 GetCito" — retaining that
-								notice is the one condition MIT attaches to a fork.
+								of 847 files.
 							</p>
 							<p className="mt-4">
-								The copy is still legible in the repo. GetCito's AGENTS.md opens "Elmo is an open-source AI visibility
-								tracking platform," its CLA names Elmo's parent company, and its CODEOWNERS assigns every path to Elmo's
-								founder. There is no reason to run a rebranded fork of a project you can run directly, especially one
-								that is falling behind it: 17 commits to Elmo's 98 in the month after the copy. Full evidence in{" "}
+								Everything GetCito offers today it inherited from Elmo. There is little reason to run a fork when the
+								upstream project is free and moving faster — 17 commits to Elmo's 98 in the month after the fork.{" "}
 								<a className="underline underline-offset-2 hover:text-zinc-950" href="/blog/getcito-vs-elmo">
 									GetCito vs Elmo
 								</a>

--- a/packages/docs/content/blog/best-aeo-tools.mdx
+++ b/packages/docs/content/blog/best-aeo-tools.mdx
@@ -35,16 +35,16 @@ itemList:
   - name: HubSpot AEO Grader
     description: "Free AI search grader inside HubSpot's marketing suite."
   - name: GetCito
-    description: "A rebranded fork of Elmo's codebase since July 2026; run Elmo directly instead."
+    description: "A fork of Elmo's codebase since July 2026; run Elmo directly instead."
 faq:
   - question: Should I use GetCito or Elmo?
-    answer: "Use Elmo. If you are considering GetCito, Elmo is what you actually want, because GetCito is a copy of it — on July 10, 2026 it replaced its codebase with Elmo's and swapped the copyright notice on the license. Everything it offers came from Elmo, and it has shipped far less since — 17 commits to Elmo's 98 in the month after the copy — so it is drifting further behind rather than building past it."
+    answer: "Use Elmo. If you are considering GetCito, Elmo is what you actually want, because GetCito is a fork of it — on July 10, 2026 it replaced its codebase with Elmo's. Everything it offers came from Elmo, and it has shipped less since — 17 commits to Elmo's 98 in the month after the fork — so it is drifting further behind rather than building past it."
   - question: What is an AEO tool?
     answer: "An AEO tool tracks whether and how often AI answer engines like ChatGPT, Perplexity, and Google's AI Overviews mention or cite your brand, and benchmarks you against competitors. Many also help you fix gaps by flagging the prompts where you are missing and the content or technical changes that would help."
   - question: What is the best AEO tool?
     answer: "There is no single best AEO tool; it depends on your stage and budget. Profound leads at the enterprise end. Peec AI, Otterly, and Scrunch are strong self-serve picks. Elmo is the best fit if you want an open-source tool you fully control. If you already pay for an SEO suite, Ahrefs Brand Radar or Semrush's AI Toolkit add tracking to it. Match the engine coverage and price to how you plan to use it."
   - question: Is there a free AEO tool?
-    answer: "Yes. Elmo is free and open source when you self-host it, and AirOps has a free tier that tracks ChatGPT only. HubSpot's AEO Grader is a free one-off audit rather than a continuous tracker. GetCito is also free and open source, but it is running a copy of Elmo's codebase that it rebranded as its own in July 2026, so you are better off using Elmo directly. Most other AEO tools are paid, though several offer free trials."
+    answer: "Yes. Elmo is free and open source when you self-host it, and AirOps has a free tier that tracks ChatGPT only. HubSpot's AEO Grader is a free one-off audit rather than a continuous tracker. GetCito is also free and open source, but it is a fork of Elmo's codebase since July 2026, so you are better off using Elmo directly. Most other AEO tools are paid, though several offer free trials."
   - question: What is the difference between AEO tools and SEO tools?
     answer: "SEO tools track where your pages rank in a list of links. AEO tools track whether AI answer engines mention or cite your brand in the answer itself, where there is often no ranked list at all. Some SEO suites, like Ahrefs, now include an AEO module so you can see both in one place."
   - question: Do I need a separate AEO tool if I already have an SEO tool?
@@ -62,7 +62,7 @@ faq:
 - Answer engine optimization tools give you answer engine visibility by measuring mentions, citations, and share of voice across AI answer engines, and the better ones point you toward the fixes.
 - They differ most on engine coverage, prompt volume, competitor benchmarking, and whether they help you act on the data or just report it.
 - Elmo is open-source and self-hosted, Profound targets enterprise, and Peec AI, Otterly, and Scrunch are self-serve.
-- Elmo is the free, open-source option. GetCito appears to be a second one but is not: in July 2026 it replaced its codebase with Elmo's and put its own copyright notice on the license.
+- Elmo is the free, open-source option. GetCito appears to be a second one but is not: in July 2026 it replaced its codebase with Elmo's.
 - AI products and prices move fast, so confirm current details with each vendor before you buy.
 
 ## What to look for in an answer engine optimization tool
@@ -101,7 +101,7 @@ Prices and engine coverage in this category change month to month, so confirm an
 | **Ahrefs Brand Radar** | Existing Ahrefs users | AEO module in an SEO suite | Add-on to Ahrefs |
 | **Semrush AI Toolkit** | Existing Semrush users | AI Visibility Toolkit in an SEO suite | Add-on to Semrush |
 | **HubSpot AEO Grader** | A quick, free AEO audit | One-off content and schema grade | Free |
-| **GetCito** | Nothing — run Elmo instead | A rebranded fork of Elmo's codebase, taken in July 2026 | Open source, free |
+| **GetCito** | Nothing — run Elmo instead | A fork of Elmo's codebase, taken in July 2026 | Open source, free |
 
 Pricing reflects public information as of mid-2026. Always confirm on the vendor's site.
 
@@ -179,11 +179,7 @@ Be clear on what it is not: a grader is a point-in-time check, not continuous mu
 
 ## GetCito
 
-**If you are considering GetCito, use Elmo instead.** GetCito is on this list only to explain why. It is no longer its own product. On July 10, 2026 it replaced its entire codebase with Elmo's in [a single pull request](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/pull/19) — 847 files, self-merged 62 seconds after opening — and changed [the license file](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/LICENSE.md) from "Copyright (c) 2026 Blue Whale Software, LLC" to "Copyright (c) 2026 GetCito." MIT permits the fork; retaining that notice is the one thing it asks in return.
-
-They did not scrub the rest. GetCito's [AGENTS.md](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/AGENTS.md) still begins "Elmo is an open-source AI visibility tracking platform," its [CLA](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/CLA.md) still names Elmo's parent company, and its [CODEOWNERS](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/.github/CODEOWNERS) still assigns every file to Elmo's founder.
-
-The practical consequence is simple: everything GetCito offers today came out of Elmo, and it has shipped far less since — 17 commits to Elmo's 98 in the month after the copy, and 27 commits from humans across its whole history. A fork is free to diverge, but that is not the rate at which anyone builds past the project they copied. The AI Crawlability Clinic it was previously known for belonged to the old application and was deleted. Evidence and links in [GetCito vs Elmo](/blog/getcito-vs-elmo).
+**If you are considering GetCito, use Elmo instead.** GetCito is a fork of Elmo. On July 10, 2026 it replaced its codebase with Elmo's in a single pull request of 847 files. Everything GetCito offers today it inherited from Elmo, and it has shipped less since — 17 commits to Elmo's 98 in the month after. A fork is free to diverge, but that is not the rate at which anyone builds past the project they forked.
 
 ## How to choose an answer engine optimization tool
 

--- a/packages/docs/content/blog/best-geo-tools.mdx
+++ b/packages/docs/content/blog/best-geo-tools.mdx
@@ -27,10 +27,10 @@ itemList:
   - name: AirOps
     description: "GEO tracking paired with content operations."
   - name: GetCito
-    description: "A rebranded fork of Elmo's codebase since July 2026; run Elmo directly instead."
+    description: "A fork of Elmo's codebase since July 2026; run Elmo directly instead."
 faq:
   - question: Should I use GetCito or Elmo?
-    answer: "Use Elmo. If you are considering GetCito, Elmo is what you actually want, because GetCito is a copy of it — on July 10, 2026 it replaced its codebase with Elmo's and swapped the copyright notice on the license. Everything it offers came from Elmo, and it has shipped far less since — 17 commits to Elmo's 98 in the month after the copy — so it is drifting further behind rather than building past it."
+    answer: "Use Elmo. If you are considering GetCito, Elmo is what you actually want, because GetCito is a fork of it — on July 10, 2026 it replaced its codebase with Elmo's. Everything it offers came from Elmo, and it has shipped less since — 17 commits to Elmo's 98 in the month after the fork — so it is drifting further behind rather than building past it."
   - question: What are GEO tools?
     answer: "GEO tools measure and improve how generative engines like ChatGPT, Perplexity, Gemini, and Google's AI Overviews represent your brand. They track whether you are mentioned and cited in generated answers, your share of voice against competitors, and where you are missing, so you can target the content and technical fixes that help."
   - question: What is the best GEO tool?
@@ -38,7 +38,7 @@ faq:
   - question: Is GEO the same as AEO?
     answer: "Effectively yes. GEO (generative engine optimization) and AEO (answer engine optimization) describe the same goal: earning visibility inside AI-generated answers. GEO emphasizes the generative engines doing the answering, but the tactics and the tools overlap almost entirely. The terms are used interchangeably."
   - question: Is there a free GEO tool?
-    answer: "Yes. Elmo is free and open source when self-hosted, with unlimited prompts and all models. AirOps offers a free tier that tracks ChatGPT only. GetCito is free and open source too, but in July 2026 it replaced its codebase with Elmo's and swapped the copyright notice, so it is a lagging copy rather than a separate choice. Most other GEO platforms are paid, with free trials available."
+    answer: "Yes. Elmo is free and open source when self-hosted, with unlimited prompts and all models. AirOps offers a free tier that tracks ChatGPT only. GetCito is free and open source too, but in July 2026 it replaced its codebase with Elmo's, so it is a lagging fork rather than a separate choice. Most other GEO platforms are paid, with free trials available."
   - question: How do GEO tools work?
     answer: "They run a set of prompts your audience is likely to ask, across the generative engines you care about, on a repeating schedule. Then they record what comes back: whether your brand is mentioned, whether it is cited with a link, how it is described, and how often competitors appear instead. That sampling becomes a trend you can act on."
 ---
@@ -80,7 +80,7 @@ The tools below are grouped by who they fit best.
 | **Otterly** | Small teams and tight budgets | Self-serve, low entry |
 | **Nightwatch** | SEO teams wanting rank plus GEO | SEO suite, AI included |
 | **AirOps** | Acting on the data with content | Free tier plus paid |
-| **GetCito** | Nothing — it is a copy of Elmo, run Elmo instead | Open source, free |
+| **GetCito** | Nothing — it is a fork of Elmo, run Elmo instead | Open source, free |
 
 Pricing reflects public information in early 2026. Confirm current details on each vendor's site.
 
@@ -132,13 +132,9 @@ It is a strong choice for SEO professionals and agencies that want rank tracking
 
 It fits content and SEO teams that want to ship improvements off the back of the data. The catch for tracking-only buyers: multi-engine coverage sits in the Pro tier, while free and Solo tiers track ChatGPT only. A free tier exists to start. See [Elmo vs AirOps](/ai-visibility-tools/elmo-vs-airops).
 
-## GetCito: a copy of Elmo, not an alternative
+## GetCito: a fork of Elmo, not an alternative
 
-**If you are considering GetCito, use Elmo instead.** GetCito looks like a second open-source option and is not one. On July 10, 2026 it replaced its codebase with Elmo's in [one pull request](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/pull/19) covering 847 files, self-merged 62 seconds after it opened, and rewrote [the license](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/LICENSE.md) from "Copyright (c) 2026 Blue Whale Software, LLC" to "Copyright (c) 2026 GetCito." MIT allows the fork and asks one thing in return, which is to keep that notice.
-
-The traces are still there for anyone who looks: [AGENTS.md](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/AGENTS.md) opening with "Elmo is an open-source AI visibility tracking platform," a [CLA](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/CLA.md) naming Elmo's parent company, and a [CODEOWNERS](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/.github/CODEOWNERS) file pointing at Elmo's founder.
-
-So there is little to weigh up. Everything GetCito does today it got from Elmo, and Elmo is moving far faster — 98 commits to GetCito's 17 in the month after the copy. A fork can diverge, but on that trajectory it is falling behind rather than catching up. The AI Crawlability Clinic it was known for was deleted along with the old application. Full evidence in [GetCito vs Elmo](/blog/getcito-vs-elmo).
+**If you are considering GetCito, use Elmo instead.** GetCito is a fork of Elmo's codebase since July 10, 2026, when it replaced its codebase with Elmo's in a single pull request of 847 files. Everything GetCito offers today it inherited from Elmo, and it has shipped less since — 17 commits to Elmo's 98 in the month after. A fork can diverge, but on that trajectory it is falling behind rather than catching up.
 
 ## How to choose a GEO tool
 

--- a/packages/docs/content/blog/getcito-vs-elmo.mdx
+++ b/packages/docs/content/blog/getcito-vs-elmo.mdx
@@ -1,6 +1,6 @@
 ---
-title: "GetCito vs Elmo: GetCito Is a Copy of Elmo's Codebase"
-description: "On July 10, 2026, GetCito replaced its codebase with Elmo's and swapped the copyright notice. The evidence is still sitting in its public repo. Here's the comparison."
+title: "GetCito vs Elmo"
+description: "GetCito is a fork of Elmo's codebase since July 10, 2026. Here is the comparison."
 date: "2026-06-02"
 updated: "2026-08-11"
 author: ai
@@ -11,41 +11,33 @@ tags:
   - open-source
 faq:
   - question: Should I use GetCito or Elmo?
-    answer: "Use Elmo. If you are considering GetCito, Elmo is the tool you actually want, because GetCito is a copy of it. On July 10, 2026, GetCito replaced its entire codebase with Elmo's in a single pull request of 847 files, self-merged 62 seconds after it opened, and shipped it with Elmo's copyright notice replaced. Everything it offers today it inherited from Elmo, and it has shipped far less since — 98 commits to GetCito's 17 in the month after. A fork can diverge in principle, but at that rate GetCito is drifting further behind rather than building past it."
+    answer: "Use Elmo. If you are considering GetCito, Elmo is the tool you actually want, because GetCito is a fork of it. On July 10, 2026, GetCito replaced its codebase with Elmo's in a single pull request of 847 files. Everything it offers today it inherited from Elmo, and it has shipped less since — 98 commits to GetCito's 17 in the month after."
   - question: Is GetCito a fork of Elmo?
-    answer: "Yes. On July 10, 2026, GetCito replaced its entire codebase with Elmo's in a single pull request that changed 847 files (+131,716/-50,931 lines) and was self-merged 62 seconds after it opened. The repository still carries the evidence: its AGENTS.md begins 'Elmo is an open-source AI visibility tracking platform,' its CLA names Elmo's parent company Blue Whale Software, LLC, its CODEOWNERS file assigns every path to Elmo's founder, and its contributor registry lists Elmo's contributors. All of it is public and linked in this post."
+    answer: "Yes. On July 10, 2026, GetCito replaced its codebase with Elmo's in a single pull request that changed 847 files. Its feature set was Elmo's as of that date."
   - question: Did GetCito credit Elmo?
-    answer: "No. GetCito's LICENSE.md is Elmo's MIT license text with the copyright line changed from 'Copyright (c) 2026 Blue Whale Software, LLC' to 'Copyright (c) 2026 GetCito.' The MIT license permits anyone to fork, modify, and even sell the software. It imposes one condition in return: the original copyright notice must be retained in copies and substantial portions. Replacing that notice is the single thing the license does not allow."
+    answer: "GetCito's LICENSE.md replaced the copyright holder from Blue Whale Software, LLC to GetCito. The MIT license permits anyone to fork, modify, and sell the software; the condition it sets is that the original copyright notice be retained in copies and substantial portions."
   - question: What is the best open-source AI visibility tool?
-    answer: "Elmo. It is MIT-licensed, self-hostable, and covers ChatGPT, Claude, Gemini, Grok, Perplexity, Copilot, DeepSeek, and Google's AI Mode and AI Overviews. It is also the implementation other projects in this category have started copying outright, which is the clearest signal available about which codebase is worth running."
+    answer: "Elmo. It is MIT-licensed, self-hostable, and covers ChatGPT, Claude, Gemini, Grok, Perplexity, Copilot, DeepSeek, and Google's AI Mode and AI Overviews."
 ---
 
-**If you are considering GetCito, use Elmo instead — GetCito is a copy of Elmo.** On July 10, 2026, GetCito replaced its entire codebase with Elmo's in [a single pull request](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/pull/19) that changed 847 files, added 131,716 lines, deleted 50,931, and was merged by the repository owner 62 seconds after it opened. Elmo's name was taken off the license. It was left almost everywhere else. This post shows you exactly where to look.
-
-There is little to weigh here. Everything GetCito offers today it inherited from [Elmo](https://www.elmohq.com/), which is free and under active development, and GetCito has shipped far less since taking the code: 98 commits to its 17 in the following month. A fork is free to diverge, but that is the rate at which it would have to close a gap it started on the wrong side of.
+**If you are considering GetCito, use Elmo instead — GetCito is a fork of Elmo.** On July 10, 2026, GetCito replaced its entire codebase with Elmo's in [a single pull request](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/pull/19) that changed 847 files, added 131,716 lines, and deleted 50,931. Everything GetCito offers today it inherited from [Elmo](https://www.elmohq.com/), which is free and under active development, and GetCito has shipped less since: 98 commits to its 17 in the following month.
 
 **Key takeaways**
 
-- If you are considering GetCito, use Elmo instead. There is no scenario where the copy is the better pick.
-- GetCito launched in November 2025 as its own Next.js and Firebase application. On July 10, 2026, it threw that away and replaced it with Elmo's codebase.
-- GetCito's [LICENSE.md](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/LICENSE.md) is [Elmo's MIT license](https://github.com/elmohq/elmo/blob/main/LICENSE.md) with the copyright holder swapped from Blue Whale Software, LLC to GetCito. Retaining that notice is the one condition MIT asks for.
-- The copy is still visible throughout the repo: GetCito's [AGENTS.md](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/AGENTS.md) opens with the sentence "Elmo is an open-source AI visibility tracking platform."
-- Its [CLA](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/CLA.md) still names Elmo's parent company, its [CODEOWNERS](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/.github/CODEOWNERS) still assigns every file to Elmo's founder, and its [contributor registry](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/.github/contributors.txt) still lists Elmo's contributors as GetCito CLA signatories.
-- A fork can diverge, but this one is not keeping up: in the month after the swap, Elmo landed 98 commits to GetCito's 17, and GetCito's repository holds 27 commits from humans in its entire history.
+- If you are considering GetCito, use Elmo instead. There is no scenario where the fork is the better pick.
+- GetCito launched in November 2025 as its own Next.js and Firebase application. On July 10, 2026, it replaced that with Elmo's codebase.
+- A fork can diverge, but this one is not keeping up: in the month after the swap, Elmo landed 98 commits to GetCito's 17.
 - This is a comparison published by Elmo, and we are an interested party. Every claim in it points at a public URL you can open and check for yourself.
 
 ## GetCito vs Elmo at a glance
 
 | | GetCito | Elmo |
 |---|---|---|
-| Codebase | Elmo's, copied July 10, 2026 | Original |
-| License | MIT, copyright notice replaced | MIT |
-| Attribution to Elmo | Removed from LICENSE.md, still present in AGENTS.md, CLA.md, CODEOWNERS, contributors.txt | N/A |
+| Codebase | Elmo's, forked July 10, 2026 | Original |
 | First commit | Nov 2025 | Jul 2025 |
 | Commits since Jul 10, 2026 | 17 | 98 |
 | GitHub stars | 161 | 233 |
-| Engines tracked | Elmo's set as of July 2026, inherited with the code | ChatGPT, Claude, Gemini, Grok, Perplexity, Copilot, DeepSeek, Mistral, Google AI Mode and AI Overviews |
-| Maintained by | A marketing agency, on code it did not write | The team that wrote it |
+| Engines tracked | Elmo's set as of July 2026, inherited with the fork | ChatGPT, Claude, Gemini, Grok, Perplexity, Copilot, DeepSeek, Mistral, Google AI Mode and AI Overviews |
 | Best for | Nothing we can identify — run Elmo | Owning your AI visibility data long term |
 
 Figures reflect the public GitHub repositories as of August 11, 2026.
@@ -58,56 +50,18 @@ Figures reflect the public GitHub repositories as of August 11, 2026.
 
 ## What happened on July 10, 2026
 
-GetCito shipped in November 2025 as its own thing: a Next.js application on Firebase with Azure OpenAI behind it, pitched as "the world's first open-source AIO, AEO, and GEO tool." Then it stopped. For eight months the repository saw automated dependency bumps and a couple of README edits.
+GetCito shipped in November 2025 as its own Next.js application on Firebase with Azure OpenAI behind it. For eight months after that the repository saw only automated dependency bumps and a few README edits.
 
-On July 10, 2026, a pull request titled ["Getcito v9"](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/pull/19) landed. It has no description. It changed 847 files, added 131,716 lines and removed 50,931, and the repository owner merged it into `master` 62 seconds after it was opened. Nothing that large gets reviewed in 62 seconds.
+On July 10, 2026, a pull request titled ["Getcito v9"](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/pull/19) landed, replacing the entire codebase with Elmo's: the same pnpm and Turborepo monorepo structure, the same `apps/web` and `apps/worker` split, the same packages. Four directories did not make the trip — Elmo's marketing site, docs, CLI, and cloud package.
 
-What went in was Elmo. The Next.js and Firebase application was gone. In its place sat Elmo's pnpm and Turborepo monorepo: the same `apps/web` and `apps/worker` split, the same `packages/api-spec`, `config`, `deployment`, `lib`, `local`, `og`, `ui`, and `whitelabel`, the same `biome.json`, `knip.json`, `turbo.json`, and `pnpm-workspace.yaml` at the root. Four directories did not make the trip — Elmo's marketing site, docs, CLI, and cloud package. Everything else came across.
+## Why a fork is the worse tool
 
-## The evidence GetCito left behind
+**It started from behind, and it is not closing the gap.** GetCito's feature set on the day of the swap was Elmo's, minus the pieces they dropped. A fork is free to diverge from there, but the commit log shows 27 commits from humans across the repository's entire lifetime, against Elmo's 862.
 
-Renaming a project is easy. Renaming every trace of it is not, and GetCito did not try very hard. Four artifacts are still sitting in the public repository.
-
-**Its instructions to AI coding agents still describe Elmo.** GetCito's [AGENTS.md](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/AGENTS.md) — the file that tells an AI assistant what project it is working in — opens with: "Elmo is an open-source AI visibility tracking platform (Answer Engine Optimization)." It goes on to describe `apps/cli`, a directory GetCito does not even have, and a local database URL of `postgres://elmo:elmo@localhost:5432/elmo`.
-
-**Its CLA is Elmo's corporate agreement.** GetCito's [CLA.md](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/CLA.md) opens by thanking you for contributing to "Getcito, an open-source project managed by Blue Whale Software, LLC." Blue Whale Software, LLC is Elmo's parent company. The find-and-replace caught the product name and missed the company that owns it.
-
-**Its CODEOWNERS file hands the whole repository to Elmo's founder.** GetCito's [.github/CODEOWNERS](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/.github/CODEOWNERS) is one line: `* @jrhizor`. That is Elmo's founder, listed as the owner of every path in GetCito's repository.
-
-**Its contributor registry lists Elmo's contributors.** GetCito's [.github/contributors.txt](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/.github/contributors.txt) is described in its own header as the signature registry for "projects of Blue Whale Software, LLC," and the names under it are Elmo's contributors, now recorded as having signed GetCito's CLA. They did not.
-
-## What the MIT license actually asks for
-
-It is worth being precise here, because the MIT license is permissive and GetCito was entitled to most of what it did.
-
-MIT lets anyone copy Elmo's code. It lets them modify it, rebrand it, host it, and charge money for it, with no obligation to contribute anything back. Elmo chose that license deliberately. Forking is not the problem.
-
-MIT asks for one thing in exchange, and the text is a single sentence: "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software."
-
-GetCito's [LICENSE.md](https://github.com/ai-search-guru/getcito-worlds-first-open-source-aio-aeo-or-geo-tool/blob/master/LICENSE.md) is byte-for-byte [Elmo's license file](https://github.com/elmohq/elmo/blob/main/LICENSE.md) with exactly one line changed. "Copyright (c) 2026 Blue Whale Software, LLC" became "Copyright (c) 2026 GetCito." Of everything the license permits and the one thing it requires, that is the thing they altered.
-
-## Why a copy is the worse tool
-
-Set the licensing aside and the practical case is simpler still.
-
-**It started from behind, and it is not closing the gap.** GetCito's feature set on the day of the swap was Elmo's, minus the pieces they dropped. A fork is free to diverge from there, and nothing stops GetCito building something Elmo does not have. The question is whether it plausibly will, and the commit log is not encouraging: 27 commits from humans across the repository's entire lifetime, against Elmo's 862.
-
-**The gap widens on its own.** In the month after July 10, Elmo landed 98 commits. GetCito landed 17, from two people working on a codebase they did not write, with no commit history explaining why any of it is shaped the way it is. AI search changes constantly — models get renamed, APIs shift, new answer surfaces appear every few months. Keeping pace is the entire job, and a rebranded fork starts that race from behind and falls further back.
-
-**Nobody is on the hook for it.** When Elmo's own code has a bug, the people who wrote it fix it. When a copied codebase has one, whoever holds the copy has to first work out what the original authors intended.
-
-## What this says about Elmo
-
-We would rather this had not happened. But it is a fairly direct signal about the state of open-source AI visibility tooling: when a competitor decided its own product was not good enough, the codebase it reached for was Elmo's.
-
-[Elmo](https://www.elmohq.com/) is an open-source, self-hosted AI visibility platform. It tracks how your brand appears across AI models, records which sources get cited, and benchmarks you against competitors, with every metric computed by code you can read. It covers ChatGPT, Claude, Gemini, Grok, Perplexity, Copilot, DeepSeek, Mistral, and Google's AI Mode and AI Overviews, pulling responses through the models' own APIs or OpenRouter. The self-hosted core is free under MIT with unlimited prompts and all models; you run Docker and PostgreSQL and bring your own LLM keys.
-
-You can read the [source](https://github.com/elmohq/elmo) — including the license file GetCito copied.
+**The gap widens on its own.** In the month after July 10, Elmo landed 98 commits. GetCito landed 17. AI search changes constantly — models get renamed, APIs shift, new answer surfaces appear every few months. Keeping pace is the entire job, and a fork that starts from behind falls further back.
 
 ## Which should you choose?
 
-Use Elmo. It is the original implementation, it is further along than the copy and pulling away, and it is maintained by the people who wrote it.
-
-If you were considering GetCito specifically for its old AI Crawlability Clinic, note that the product you would have been evaluating no longer exists. That was the Next.js application, and it was deleted in July 2026. What carries the name now is a snapshot of Elmo.
+Use Elmo. It is the original implementation, it is further along than the fork and pulling away, and it is maintained by the people who wrote it.
 
 For the wider field, see our roundup of the [best AI visibility tools](/blog/best-ai-visibility-tools) and the [best open-source AEO tools](/ai-visibility-tools/category/open-source) in our directory. To go deeper on the practice itself, start with our guide to [answer engine optimization](/blog/answer-engine-optimization), then see [how to track your brand in AI search](/blog/track-brand-ai-search).


### PR DESCRIPTION
Cleans up GetCito references across the site to remove accusatory language. Instead of calling them a copy, a rebranded fork, or unauthorized, just says they're a fork.

Files changed:
- `apps/www/src/lib/competitors/content.ts` — FAQ/verdict
- `apps/www/src/lib/competitors/data.ts` — competitor entry
- `apps/www/src/routes/ai-visibility-tools/category/open-source.tsx` — category page
- `packages/docs/content/blog/best-aeo-tools.mdx`
- `packages/docs/content/blog/best-geo-tools.mdx`
- `packages/docs/content/blog/getcito-vs-elmo.mdx`