### PR TITLE
fix: add missing browser tab titles

### DIFF
--- a/.changeset/route-titles.md
+++ b/.changeset/route-titles.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Authentication and workspace entry pages now show descriptive, deployment-aware browser tab titles.

--- a/.github/contributors.txt
+++ b/.github/contributors.txt
@@ -21,6 +21,7 @@
 # ─────────────────────────────────────────────────────────────────────
 
 jrhizor
+uchiha-suraj
 prashantindurkar
 jrwrest
 tuliren

--- a/apps/web/src/routes/_authed/accept-invitation/$invitationId.tsx
+++ b/apps/web/src/routes/_authed/accept-invitation/$invitationId.tsx
@@ -11,6 +11,7 @@ import { Alert, AlertDescription } from "@workspace/ui/components/alert";
 import { Button, buttonVariants } from "@workspace/ui/components/button";
 import { useState } from "react";
 import FullPageCard from "@/components/full-page-card";
+import { buildTitle, getAppName } from "@/lib/route-head";
 import { acceptInvitationFn, getInvitationFn } from "@/server/team";
 
 export const Route = createFileRoute("/_authed/accept-invitation/$invitationId")({
@@ -24,6 +25,15 @@ export const Route = createFileRoute("/_authed/accept-invitation/$invitationId")
 				error: err instanceof Error ? err.message : "This invitation could not be loaded",
 			};
 		}
+	},
+	head: ({ match }) => {
+		const appName = getAppName(match);
+		return {
+			meta: [
+				{ title: buildTitle("Accept invitation", { appName }) },
+				{ name: "description", content: "Join your team." },
+			],
+		};
 	},
 	component: AcceptInvitationPage,
 });

--- a/apps/web/src/routes/_authed/app/$brand/prompts/edit.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/prompts/edit.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
+import { buildTitle, getAppName, getBrandName } from "@/lib/route-head";
 
 export const Route = createFileRoute("/_authed/app/$brand/prompts/edit")({
 	beforeLoad: ({ params }) => {
@@ -6,5 +7,15 @@ export const Route = createFileRoute("/_authed/app/$brand/prompts/edit")({
 			to: "/app/$brand/settings/prompts",
 			params: { brand: params.brand },
 		});
+	},
+	head: ({ matches, match }) => {
+		const appName = getAppName(match);
+		const brandName = getBrandName(matches);
+		return {
+			meta: [
+				{ title: buildTitle("Prompts", { appName, brandName }) },
+				{ name: "description", content: "Add, edit, or remove tracked prompts." },
+			],
+		};
 	},
 });

--- a/apps/web/src/routes/_authed/app/$brand/prompts/index.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/prompts/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
+import { buildTitle, getAppName, getBrandName } from "@/lib/route-head";
 
 export const Route = createFileRoute("/_authed/app/$brand/prompts/")({
 	beforeLoad: ({ params }) => {
@@ -6,5 +7,15 @@ export const Route = createFileRoute("/_authed/app/$brand/prompts/")({
 			to: "/app/$brand/visibility",
 			params: { brand: params.brand },
 		});
+	},
+	head: ({ matches, match }) => {
+		const appName = getAppName(match);
+		const brandName = getBrandName(matches);
+		return {
+			meta: [
+				{ title: buildTitle("Visibility", { appName, brandName }) },
+				{ name: "description", content: "Track how LLMs respond to prompts about your brand." },
+			],
+		};
 	},
 });

--- a/apps/web/src/routes/_authed/app/$brand/settings/index.tsx
+++ b/apps/web/src/routes/_authed/app/$brand/settings/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
+import { buildTitle, getAppName, getBrandName } from "@/lib/route-head";
 
 export const Route = createFileRoute("/_authed/app/$brand/settings/")({
 	beforeLoad: ({ params }) => {
@@ -6,5 +7,15 @@ export const Route = createFileRoute("/_authed/app/$brand/settings/")({
 			to: "/app/$brand/settings/brand",
 			params: { brand: params.brand },
 		});
+	},
+	head: ({ matches, match }) => {
+		const appName = getAppName(match);
+		const brandName = getBrandName(matches);
+		return {
+			meta: [
+				{ title: buildTitle("Brand Settings", { appName, brandName }) },
+				{ name: "description", content: "Manage your brand name and website." },
+			],
+		};
 	},
 });

--- a/apps/web/src/routes/_authed/app/index.tsx
+++ b/apps/web/src/routes/_authed/app/index.tsx
@@ -19,6 +19,7 @@ import FullPageCard from "@/components/full-page-card";
 import { SiteIcon } from "@/components/site-icon";
 import { listUserOrganizations, requireAuthSession } from "@/lib/auth/helpers";
 import { getDeployment } from "@/lib/config/server";
+import { buildTitle, getAppName } from "@/lib/route-head";
 
 const getBrandSwitcherData = createServerFn({ method: "GET" }).handler(
 	async (): Promise<{
@@ -96,6 +97,15 @@ export const Route = createFileRoute("/_authed/app/")({
 		canCreateBrands: boolean;
 	}> => {
 		return getBrandSwitcherData();
+	},
+	head: ({ match }) => {
+		const appName = getAppName(match);
+		return {
+			meta: [
+				{ title: buildTitle("Brand Switcher", { appName }) },
+				{ name: "description", content: "Select a brand to get started." },
+			],
+		};
 	},
 	component: BrandSwitcherPage,
 });

--- a/apps/web/src/routes/_authed/app/new.tsx
+++ b/apps/web/src/routes/_authed/app/new.tsx
@@ -32,6 +32,7 @@ import { listUserOrganizations, requireAuthSession } from "@/lib/auth/helpers";
 import { validateWebsiteUrl } from "@/lib/brand-website";
 import { getDeployment } from "@/lib/config/server";
 import { trackEvent } from "@/lib/posthog";
+import { buildTitle, getAppName } from "@/lib/route-head";
 import { createBrandInOrgFn } from "@/server/brands";
 import { getOnboardingPlatformStateFn, type OnboardingPlatformState } from "@/server/platform-picks";
 
@@ -90,6 +91,15 @@ export const Route = createFileRoute("/_authed/app/new")({
 			throw redirect({ to: "/app" });
 		}
 		return { organizations };
+	},
+	head: ({ match }) => {
+		const appName = getAppName(match);
+		return {
+			meta: [
+				{ title: buildTitle("Create a new brand", { appName }) },
+				{ name: "description", content: "Set up a brand to start tracking." },
+			],
+		};
 	},
 	component: NewBrandPage,
 });

--- a/apps/web/src/routes/auth/forgot-password.tsx
+++ b/apps/web/src/routes/auth/forgot-password.tsx
@@ -18,8 +18,18 @@ import { Label } from "@workspace/ui/components/label";
 import { useState } from "react";
 import { AuthSplitLayout } from "@/components/auth/auth-split-layout";
 import { SalesFooterLinks, SalesPanel } from "@/components/auth/sales-panel";
+import { buildTitle, getAppName } from "@/lib/route-head";
 
 export const Route = createFileRoute("/auth/forgot-password")({
+	head: ({ match }) => {
+		const appName = getAppName(match);
+		return {
+			meta: [
+				{ title: buildTitle("Reset password", { appName }) },
+				{ name: "description", content: "Request a password reset link." },
+			],
+		};
+	},
 	component: ForgotPasswordPage,
 });
 

--- a/apps/web/src/routes/auth/login.tsx
+++ b/apps/web/src/routes/auth/login.tsx
@@ -22,6 +22,7 @@ import { AuthSplitLayout } from "@/components/auth/auth-split-layout";
 import { SalesFooterLinks, SalesPanel } from "@/components/auth/sales-panel";
 import FullPageCard from "@/components/full-page-card";
 import { safeReturnTo } from "@/lib/return-to";
+import { buildTitle, getAppName } from "@/lib/route-head";
 
 export const Route = createFileRoute("/auth/login")({
 	validateSearch: z.object({
@@ -33,6 +34,15 @@ export const Route = createFileRoute("/auth/login")({
 		 */
 		ref: z.string().optional(),
 	}),
+	head: ({ match }) => {
+		const appName = getAppName(match);
+		return {
+			meta: [
+				{ title: buildTitle("Sign in", { appName }) },
+				{ name: "description", content: "Sign in to your account." },
+			],
+		};
+	},
 	component: LoginPage,
 });
 

--- a/apps/web/src/routes/auth/register.tsx
+++ b/apps/web/src/routes/auth/register.tsx
@@ -22,6 +22,7 @@ import { AuthSplitLayout } from "@/components/auth/auth-split-layout";
 import { SalesFooterLinks, SalesPanel } from "@/components/auth/sales-panel";
 import FullPageCard from "@/components/full-page-card";
 import { safeReturnTo } from "@/lib/return-to";
+import { buildTitle, getAppName } from "@/lib/route-head";
 
 export const Route = createFileRoute("/auth/register")({
 	validateSearch: z.object({
@@ -33,6 +34,12 @@ export const Route = createFileRoute("/auth/register")({
 		 */
 		ref: z.string().optional(),
 	}),
+	head: ({ match }) => {
+		const appName = getAppName(match);
+		return {
+			meta: [{ title: buildTitle("Sign up", { appName }) }, { name: "description", content: "Create an account." }],
+		};
+	},
 	component: RegisterPage,
 });
 

--- a/apps/web/src/routes/auth/reset-password.tsx
+++ b/apps/web/src/routes/auth/reset-password.tsx
@@ -16,12 +16,22 @@ import { useState } from "react";
 import { z } from "zod";
 import { AuthSplitLayout } from "@/components/auth/auth-split-layout";
 import { SalesFooterLinks, SalesPanel } from "@/components/auth/sales-panel";
+import { buildTitle, getAppName } from "@/lib/route-head";
 
 export const Route = createFileRoute("/auth/reset-password")({
 	validateSearch: z.object({
 		token: z.string().optional(),
 		error: z.string().optional(),
 	}),
+	head: ({ match }) => {
+		const appName = getAppName(match);
+		return {
+			meta: [
+				{ title: buildTitle("Choose a new password", { appName }) },
+				{ name: "description", content: "Set a new password for your account." },
+			],
+		};
+	},
 	component: ResetPasswordPage,
 });
 


### PR DESCRIPTION
## Summary

- add deployment-aware browser tab titles to authentication routes
- add titles to the brand switcher, new brand, and invitation pages
- add a patch changeset for the user-facing update
- add my GitHub username to the contributors list for the CLA

## Testing

- `pnpm lint`

Closes #627