### PR TITLE
Redirect /.well-known/change-password to the change-password page

### DIFF
--- a/.changeset/well-known-change-password.md
+++ b/.changeset/well-known-change-password.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Added a `/.well-known/change-password` redirect to the in-app change-password page.

--- a/.github/contributors.txt
+++ b/.github/contributors.txt
@@ -34,3 +34,4 @@ snowyukitty
 morovinger
 mandapavankalyan
 raheebgill29
+theghulam

--- a/apps/web/src/lib/__tests__/change-existing-password.test.ts
+++ b/apps/web/src/lib/__tests__/change-existing-password.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function requestUrl(input: RequestInfo | URL): string {
+	if (typeof input === "string") return input;
+	if (input instanceof URL) return input.href;
+	return input.url;
+}
+
+async function requestBody(input: RequestInfo | URL, init: RequestInit | undefined): Promise<string> {
+	if (typeof init?.body === "string") return init.body;
+	if (input instanceof Request) return input.clone().text();
+	return String(init?.body ?? "");
+}
+
+describe("changeExistingPassword", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+		vi.resetModules();
+	});
+
+	it("posts current and new password to better-auth change-password", async () => {
+		const fetchMock = vi.fn(async () => {
+			return new Response(JSON.stringify({}), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		vi.resetModules();
+		const { changeExistingPassword } = await import("../change-existing-password");
+
+		await changeExistingPassword({
+			currentPassword: "old-secret",
+			newPassword: "new-secret-123",
+		});
+
+		expect(fetchMock).toHaveBeenCalled();
+		const [input, init] = fetchMock.mock.calls[0] as [RequestInfo | URL, RequestInit | undefined];
+		const url = requestUrl(input);
+		expect(url).toContain("/api/auth/change-password");
+		expect(url).not.toContain("forgot-password");
+		expect(url).not.toContain("reset-password");
+		expect(url).not.toContain("/.well-known/change-password");
+		expect((init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase()).toBe("POST");
+
+		const body = JSON.parse(await requestBody(input, init)) as Record<string, unknown>;
+		expect(body.currentPassword).toBe("old-secret");
+		expect(body.newPassword).toBe("new-secret-123");
+	});
+});

--- a/apps/web/src/lib/__tests__/change-existing-password.test.ts
+++ b/apps/web/src/lib/__tests__/change-existing-password.test.ts
@@ -20,7 +20,7 @@ describe("changeExistingPassword", () => {
 	});
 
 	it("posts current and new password to better-auth change-password", async () => {
-		const fetchMock = vi.fn(async () => {
+		const fetchMock = vi.fn<typeof fetch>(async () => {
 			return new Response(JSON.stringify({}), {
 				status: 200,
 				headers: { "Content-Type": "application/json" },
@@ -36,7 +36,7 @@ describe("changeExistingPassword", () => {
 		});
 
 		expect(fetchMock).toHaveBeenCalled();
-		const [input, init] = fetchMock.mock.calls[0] as [RequestInfo | URL, RequestInit | undefined];
+		const [input, init] = fetchMock.mock.calls[0];
 		const url = requestUrl(input);
 		expect(url).toContain("/api/auth/change-password");
 		expect(url).not.toContain("forgot-password");

--- a/apps/web/src/lib/__tests__/well-known-change-password.test.ts
+++ b/apps/web/src/lib/__tests__/well-known-change-password.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { CHANGE_PASSWORD_PATH, handleWellKnownChangePasswordGet } from "../well-known-change-password";
+
+describe("GET /.well-known/change-password", () => {
+	it("redirects to the in-app change-existing-password page", () => {
+		const response = handleWellKnownChangePasswordGet({
+			request: new Request("http://localhost/.well-known/change-password"),
+		});
+
+		expect([302, 303, 307]).toContain(response.status);
+
+		const location = response.headers.get("Location");
+		expect(location).toBeTruthy();
+		const path = new URL(location ?? "", "http://localhost").pathname;
+		expect(path).toBe(CHANGE_PASSWORD_PATH);
+		expect(path).toBe("/change-password");
+		expect(path).not.toBe("/auth/forgot-password");
+		expect(path).not.toBe("/auth/reset-password");
+		expect(path).not.toBe("/.well-known/change-password");
+		expect(response.body).toBeNull();
+	});
+});

--- a/apps/web/src/lib/change-existing-password.ts
+++ b/apps/web/src/lib/change-existing-password.ts
@@ -1,0 +1,9 @@
+import { authClient } from "@workspace/lib/auth/client";
+
+/** Rotate an existing password via better-auth. Requires the current password. */
+export async function changeExistingPassword(input: { currentPassword: string; newPassword: string }) {
+	return authClient.changePassword({
+		currentPassword: input.currentPassword,
+		newPassword: input.newPassword,
+	});
+}

--- a/apps/web/src/lib/well-known-change-password.ts
+++ b/apps/web/src/lib/well-known-change-password.ts
@@ -1,0 +1,15 @@
+/**
+ * W3C change-password-url + RFC 8615: GET /.well-known/change-password must
+ * redirect (302/303/307) to the in-app page that changes an existing password.
+ * Password-manager probes hit this exact path; 404 would mean "unsupported".
+ */
+export const CHANGE_PASSWORD_PATH = "/change-password";
+
+/** Shipped GET handler for `/.well-known/change-password`. */
+export function handleWellKnownChangePasswordGet({ request }: { request: Request }): Response {
+	const location = new URL(CHANGE_PASSWORD_PATH, request.url).pathname;
+	return new Response(null, {
+		status: 302,
+		headers: { Location: location },
+	});
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as AuthedAdminRouteImport } from './routes/_authed/admin'
 import { Route as AuthedAppRouteImport } from './routes/_authed/app'
+import { Route as AuthedChangePasswordRouteImport } from './routes/_authed/change-password'
 import { Route as AuthedChoosePlanRouteImport } from './routes/_authed/choose-plan'
 import { Route as AuthedReportsRouteImport } from './routes/_authed/reports'
 import { Route as AuthForgotPasswordRouteImport } from './routes/auth/forgot-password'
@@ -81,6 +82,11 @@ const AuthedAdminRoute = AuthedAdminRouteImport.update({
 const AuthedAppRoute = AuthedAppRouteImport.update({
   id: '/app',
   path: '/app',
+  getParentRoute: () => AuthedRoute,
+} as any)
+const AuthedChangePasswordRoute = AuthedChangePasswordRouteImport.update({
+  id: '/change-password',
+  path: '/change-password',
   getParentRoute: () => AuthedRoute,
 } as any)
 const AuthedChoosePlanRoute = AuthedChoosePlanRouteImport.update({
@@ -357,6 +363,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/admin': typeof AuthedAdminRouteWithChildren
   '/app': typeof AuthedAppRouteWithChildren
+  '/change-password': typeof AuthedChangePasswordRoute
   '/choose-plan': typeof AuthedChoosePlanRoute
   '/reports': typeof AuthedReportsRouteWithChildren
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
@@ -410,6 +417,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/change-password': typeof AuthedChangePasswordRoute
   '/choose-plan': typeof AuthedChoosePlanRoute
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
   '/auth/login': typeof AuthLoginRoute
@@ -465,6 +473,7 @@ export interface FileRoutesById {
   '/_authed': typeof AuthedRouteWithChildren
   '/_authed/admin': typeof AuthedAdminRouteWithChildren
   '/_authed/app': typeof AuthedAppRouteWithChildren
+  '/_authed/change-password': typeof AuthedChangePasswordRoute
   '/_authed/choose-plan': typeof AuthedChoosePlanRoute
   '/_authed/reports': typeof AuthedReportsRouteWithChildren
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
@@ -522,6 +531,7 @@ export interface FileRouteTypes {
     | '/'
     | '/admin'
     | '/app'
+    | '/change-password'
     | '/choose-plan'
     | '/reports'
     | '/auth/forgot-password'
@@ -575,6 +585,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/change-password'
     | '/choose-plan'
     | '/auth/forgot-password'
     | '/auth/login'
@@ -629,6 +640,7 @@ export interface FileRouteTypes {
     | '/_authed'
     | '/_authed/admin'
     | '/_authed/app'
+    | '/_authed/change-password'
     | '/_authed/choose-plan'
     | '/_authed/reports'
     | '/auth/forgot-password'
@@ -735,6 +747,13 @@ declare module '@tanstack/react-router' {
       path: '/app'
       fullPath: '/app'
       preLoaderRoute: typeof AuthedAppRouteImport
+      parentRoute: typeof AuthedRoute
+    }
+    '/_authed/change-password': {
+      id: '/_authed/change-password'
+      path: '/change-password'
+      fullPath: '/change-password'
+      preLoaderRoute: typeof AuthedChangePasswordRouteImport
       parentRoute: typeof AuthedRoute
     }
     '/_authed/choose-plan': {
@@ -1184,6 +1203,7 @@ const AuthedReportsRouteWithChildren = AuthedReportsRoute._addFileChildren(
 interface AuthedRouteChildren {
   AuthedAdminRoute: typeof AuthedAdminRouteWithChildren
   AuthedAppRoute: typeof AuthedAppRouteWithChildren
+  AuthedChangePasswordRoute: typeof AuthedChangePasswordRoute
   AuthedChoosePlanRoute: typeof AuthedChoosePlanRoute
   AuthedReportsRoute: typeof AuthedReportsRouteWithChildren
   AuthedAcceptInvitationInvitationIdRoute: typeof AuthedAcceptInvitationInvitationIdRoute
@@ -1192,6 +1212,7 @@ interface AuthedRouteChildren {
 const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedAdminRoute: AuthedAdminRouteWithChildren,
   AuthedAppRoute: AuthedAppRouteWithChildren,
+  AuthedChangePasswordRoute: AuthedChangePasswordRoute,
   AuthedChoosePlanRoute: AuthedChoosePlanRoute,
   AuthedReportsRoute: AuthedReportsRouteWithChildren,
   AuthedAcceptInvitationInvitationIdRoute:

--- a/apps/web/src/routes/_authed/change-password.tsx
+++ b/apps/web/src/routes/_authed/change-password.tsx
@@ -1,0 +1,130 @@
+/**
+ * /change-password — change an existing password while signed in.
+ *
+ * Unauthenticated visits go through /auth/login with returnTo via `_authed`.
+ * Forgot/reset remain a different flow; this page always asks for the current
+ * password.
+ */
+
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Alert, AlertDescription } from "@workspace/ui/components/alert";
+import { Button, buttonVariants } from "@workspace/ui/components/button";
+import { Input } from "@workspace/ui/components/input";
+import { Label } from "@workspace/ui/components/label";
+import { useState } from "react";
+import FullPageCard from "@/components/full-page-card";
+import { changeExistingPassword } from "@/lib/change-existing-password";
+import { buildTitle, getAppName } from "@/lib/route-head";
+
+export const Route = createFileRoute("/_authed/change-password")({
+	head: ({ match }) => {
+		const appName = getAppName(match);
+		return {
+			meta: [
+				{ title: buildTitle("Change password", { appName }) },
+				{ name: "description", content: "Change the password for your account." },
+			],
+		};
+	},
+	component: ChangePasswordPage,
+});
+
+function ChangePasswordPage() {
+	return <ChangePasswordForm />;
+}
+
+export function ChangePasswordForm() {
+	const [currentPassword, setCurrentPassword] = useState("");
+	const [newPassword, setNewPassword] = useState("");
+	const [confirmPassword, setConfirmPassword] = useState("");
+	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState(false);
+	const [updated, setUpdated] = useState(false);
+
+	async function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		setError(null);
+		if (newPassword !== confirmPassword) {
+			setError("Passwords do not match");
+			return;
+		}
+		setLoading(true);
+
+		try {
+			const result = await changeExistingPassword({ currentPassword, newPassword });
+			if (result.error) {
+				setError(result.error.message ?? "Failed to change password");
+				setLoading(false);
+				return;
+			}
+			setUpdated(true);
+		} catch {
+			setError("Something went wrong. Please try again.");
+			setLoading(false);
+		}
+	}
+
+	if (updated) {
+		return (
+			<FullPageCard title="Password updated" subtitle="Your password has been changed.">
+				<Link to="/app" className={buttonVariants({ className: "w-full" })}>
+					Continue
+				</Link>
+			</FullPageCard>
+		);
+	}
+
+	return (
+		<FullPageCard title="Change password" subtitle="Enter your current password and choose a new one.">
+			<form onSubmit={handleSubmit} className="space-y-4 w-full">
+				{error && (
+					<Alert variant="destructive">
+						<AlertDescription>{error}</AlertDescription>
+					</Alert>
+				)}
+				<div className="space-y-2">
+					<Label htmlFor="current-password">Current password</Label>
+					<Input
+						id="current-password"
+						type="password"
+						placeholder="Current password"
+						value={currentPassword}
+						onChange={(e) => setCurrentPassword(e.target.value)}
+						required
+						autoComplete="current-password"
+						autoFocus
+					/>
+				</div>
+				<div className="space-y-2">
+					<Label htmlFor="new-password">New password</Label>
+					<Input
+						id="new-password"
+						type="password"
+						placeholder="New password"
+						value={newPassword}
+						onChange={(e) => setNewPassword(e.target.value)}
+						required
+						autoComplete="new-password"
+						minLength={8}
+					/>
+				</div>
+				<div className="space-y-2">
+					<Label htmlFor="confirm-password">Confirm new password</Label>
+					<Input
+						id="confirm-password"
+						type="password"
+						placeholder="Confirm new password"
+						value={confirmPassword}
+						onChange={(e) => setConfirmPassword(e.target.value)}
+						required
+						autoComplete="new-password"
+						minLength={8}
+					/>
+				</div>
+				<Button type="submit" className="w-full" disabled={loading}>
+					{loading ? "Changing..." : "Change password"}
+				</Button>
+			</form>
+		</FullPageCard>
+	);
+}

--- a/apps/web/src/routes/_authed/change-password.tsx
+++ b/apps/web/src/routes/_authed/change-password.tsx
@@ -1,12 +1,5 @@
-/**
- * /change-password — change an existing password while signed in.
- *
- * Unauthenticated visits go through /auth/login with returnTo via `_authed`.
- * Forgot/reset remain a different flow; this page always asks for the current
- * password.
- */
-
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useRouteContext } from "@tanstack/react-router";
+import type { ClientConfig } from "@workspace/config/types";
 import { Alert, AlertDescription } from "@workspace/ui/components/alert";
 import { Button, buttonVariants } from "@workspace/ui/components/button";
 import { Input } from "@workspace/ui/components/input";
@@ -30,6 +23,22 @@ export const Route = createFileRoute("/_authed/change-password")({
 });
 
 function ChangePasswordPage() {
+	const { clientConfig } = useRouteContext({ strict: false }) as { clientConfig?: ClientConfig };
+
+	if (clientConfig?.mode === "demo" || clientConfig?.mode === "whitelabel") {
+		return (
+			<FullPageCard
+				title="Change password"
+				subtitle={
+					clientConfig.mode === "demo"
+						? "Password changes are disabled for the shared demo account."
+						: "Your password is managed by your sign-in provider. Change it with your provider."
+				}
+				showBackButton
+			/>
+		);
+	}
+
 	return <ChangePasswordForm />;
 }
 

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -2,6 +2,7 @@ import "../instrument.server.mjs";
 import { wrapFetchWithSentry } from "@sentry/tanstackstart-react";
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
 import { startCredentialRefresh } from "@workspace/lib/secrets";
+import { handleWellKnownChangePasswordGet } from "./lib/well-known-change-password";
 
 // Not awaited: the app has to serve sign-in and settings whether or not the
 // credential store is reachable.
@@ -52,6 +53,12 @@ function addSecurityHeaders(response: Response): Response {
 export default createServerEntry(
 	wrapFetchWithSentry({
 		async fetch(request: Request) {
+			const pathname = new URL(request.url).pathname;
+			// Password-manager probes hit this exact path. Intercept here so a
+			// leading-dot well-known segment cannot 404 in file-based routing.
+			if ((request.method === "GET" || request.method === "HEAD") && pathname === "/.well-known/change-password") {
+				return addSecurityHeaders(handleWellKnownChangePasswordGet({ request }));
+			}
 			const response = await handler.fetch(request);
 			return addSecurityHeaders(response);
 		},

--- a/apps/web/src/stories/_mocks/auth-client.ts
+++ b/apps/web/src/stories/_mocks/auth-client.ts
@@ -62,6 +62,7 @@ export const authClient = {
 	signUp: { email: async () => ({ error: null }) },
 	requestPasswordReset: async () => ({ error: null }),
 	resetPassword: async () => ({ error: null }),
+	changePassword: (args: unknown) => respond("changePassword", args),
 	sendVerificationEmail: async () => ({ error: null }),
 	signOut: async () => ({ error: null }),
 	useSession: () => ({ data: null, isPending: false }),

--- a/apps/web/src/stories/change-password.stories.tsx
+++ b/apps/web/src/stories/change-password.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, within } from "storybook/test";
+import { ChangePasswordForm, Route } from "@/routes/_authed/change-password";
+import { getMockSubscriptionCalls, resetMockAuthClient, setMockSubscriptionError } from "./_mocks/auth-client";
+import { setMockRouteContext } from "./_mocks/tanstack-router";
+
+const meta = {
+	title: "Auth / Change password",
+	component: ChangePasswordForm,
+	parameters: { layout: "fullscreen" },
+	beforeEach: () => {
+		resetMockAuthClient();
+		setMockRouteContext({ clientConfig: { mode: "local" } });
+	},
+} satisfies Meta<typeof ChangePasswordForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+async function fillPasswords(canvasElement: HTMLElement, confirmation = "new-password-123") {
+	const canvas = within(canvasElement);
+	await userEvent.type(canvas.getByLabelText("Current password"), "old-password-123");
+	await userEvent.type(canvas.getByLabelText("New password"), "new-password-123");
+	await userEvent.type(canvas.getByLabelText("Confirm new password"), confirmation);
+	await userEvent.click(canvas.getByRole("button", { name: "Change password" }));
+	return canvas;
+}
+
+export const Form: Story = {};
+
+export const Mismatch: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = await fillPasswords(canvasElement, "different-password");
+		await expect(await canvas.findByRole("alert")).toHaveTextContent("Passwords do not match");
+		await expect(getMockSubscriptionCalls()).toHaveLength(0);
+	},
+};
+
+export const Updated: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = await fillPasswords(canvasElement);
+		await expect(await canvas.findByText("Password updated")).toBeVisible();
+		await expect(canvas.getByText("Continue")).toBeVisible();
+		await expect(canvas.queryByLabelText("Current password")).not.toBeInTheDocument();
+		await expect(getMockSubscriptionCalls()).toEqual([
+			{ method: "changePassword", args: { currentPassword: "old-password-123", newPassword: "new-password-123" } },
+		]);
+	},
+};
+
+export const InvalidCurrentPassword: Story = {
+	play: async ({ canvasElement }) => {
+		setMockSubscriptionError("Invalid password");
+		const canvas = await fillPasswords(canvasElement);
+		await expect(await canvas.findByRole("alert")).toHaveTextContent("Invalid password");
+		await expect(canvas.getByRole("button", { name: "Change password" })).toBeEnabled();
+		await expect(canvas.queryByText("Password updated")).not.toBeInTheDocument();
+		setMockSubscriptionError(null);
+		await userEvent.click(canvas.getByRole("button", { name: "Change password" }));
+		await expect(await canvas.findByText("Password updated")).toBeVisible();
+	},
+};
+
+export const Demo: Story = {
+	render: () => {
+		setMockRouteContext({ clientConfig: { mode: "demo" } });
+		const Page = Route.options.component as typeof ChangePasswordForm;
+		return <Page />;
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("Password changes are disabled for the shared demo account.")).toBeVisible();
+		await expect(canvas.queryByLabelText("Current password")).not.toBeInTheDocument();
+	},
+};
+
+export const SingleSignOn: Story = {
+	render: () => {
+		setMockRouteContext({ clientConfig: { mode: "whitelabel" } });
+		const Page = Route.options.component as typeof ChangePasswordForm;
+		return <Page />;
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText(/Your password is managed by your sign-in provider/)).toBeVisible();
+		await expect(canvas.queryByLabelText("Current password")).not.toBeInTheDocument();
+	},
+};


### PR DESCRIPTION
Fixes #660.

Chrome, Safari, and password managers look up `/.well-known/change-password` to send people to the in-app password change screen. That URL now 302s to `/change-password`, a signed-in page that asks for the current password and a new one. Unauthenticated visits go through sign-in with `returnTo`.

Local and cloud accounts can change an existing password. Demo displays an explanation for the shared account, and whitelabel directs users to their sign-in provider. Demo still blocks `POST /api/auth/change-password`. Forgot/reset remain separate flows.

I've added my username to `.github/contributors.txt` to sign the CLA.

## Screenshots

Password form at `/change-password` for signed-in local/cloud accounts:

<img src="https://raw.githubusercontent.com/TheGhulam/elmo/pr-662-screenshots/01-form.png" alt="Change password form" width="640" />

<img src="https://raw.githubusercontent.com/TheGhulam/elmo/pr-662-screenshots/05-form-mobile.png" alt="Change password form at 390px" width="280" />

Mismatch:

<img src="https://raw.githubusercontent.com/TheGhulam/elmo/pr-662-screenshots/02-mismatch.png" alt="Passwords do not match" width="640" />

After a successful change:

<img src="https://raw.githubusercontent.com/TheGhulam/elmo/pr-662-screenshots/03-updated.png" alt="Password updated" width="640" />


## Validation

- Node 24: `pnpm lint`, web TypeScript check, and 91 targeted unit tests pass.
- Chromium component tests cover mismatch without a request, successful submission, API rejection and retry, and demo/SSO explanations. Auth responses are mocked.
- Screenshots illustrate the form and its UI states. A database-backed sign-in and password-change round trip was not run as part of this review.
