### PR TITLE
keep the brand slug prefix on one line

### DIFF
--- a/.changeset/brand-slug-one-line.md
+++ b/.changeset/brand-slug-one-line.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+The brand slug field on brand settings keeps its URL prefix on a single line.

--- a/apps/web/src/components/slug-field.tsx
+++ b/apps/web/src/components/slug-field.tsx
@@ -23,8 +23,8 @@ export function SlugField({
 	return (
 		<div className="space-y-2">
 			<Label htmlFor={id}>{label}</Label>
-			<div className={cn("flex items-center rounded-md border font-mono text-sm", className)}>
-				<span className="pl-3 text-muted-foreground">{prefix}</span>
+			<div className={cn("flex w-full items-center overflow-hidden rounded-md border font-mono text-sm", className)}>
+				<span className="shrink-0 whitespace-nowrap pl-3 text-muted-foreground">{prefix}</span>
 				<Input
 					id={id}
 					value={value}

--- a/apps/web/src/routes/_authed/app/org/$org/brand/$brand/settings/brand.tsx
+++ b/apps/web/src/routes/_authed/app/org/$org/brand/$brand/settings/brand.tsx
@@ -127,7 +127,7 @@ function BrandSettingsPage() {
 	};
 
 	return (
-		<div className="space-y-6 max-w-3xl">
+		<div className="space-y-6 max-w-2xl">
 			<div>
 				<h1 className="text-3xl font-bold">Brand</h1>
 				<p className="text-muted-foreground">Manage your brand name and website</p>

--- a/apps/web/src/routes/_authed/app/org/$org/brand/$brand/settings/brand.tsx
+++ b/apps/web/src/routes/_authed/app/org/$org/brand/$brand/settings/brand.tsx
@@ -127,7 +127,7 @@ function BrandSettingsPage() {
 	};
 
 	return (
-		<div className="space-y-6 max-w-2xl">
+		<div className="space-y-6 max-w-3xl">
 			<div>
 				<h1 className="text-3xl font-bold">Brand</h1>
 				<p className="text-muted-foreground">Manage your brand name and website</p>


### PR DESCRIPTION
The brand slug field rendered its `/app/org/<org>/brand/` prefix as a shrinkable flex item next to a `w-full` input, so the prefix broke across two lines at the hyphen.

Prefix is now `shrink-0 whitespace-nowrap`; the input absorbs the remaining space (it already has `min-w-0`), and the container is `overflow-hidden` so nothing bleeds past the rounded border on narrow screens.

Verified by rendering the same flex/CSS in headless Chrome: two-line wrap before, one line after — including a long org slug and a 340px viewport, where the input scrolls internally instead of wrapping the prefix.