### PR TITLE
link to the organization switcher past three organizations

### DIFF
--- a/.changeset/collapse-many-organizations.md
+++ b/.changeset/collapse-many-organizations.md
@@ -2,4 +2,4 @@
 "@workspace/web": patch
 ---
 
-The account menu links to the organization switcher instead of listing every organization once you belong to more than three.
+The account menu offers a single Switch Brand link instead of listing every organization once you belong to more than three.

--- a/.changeset/collapse-many-organizations.md
+++ b/.changeset/collapse-many-organizations.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+The account menu links to the organization switcher instead of listing every organization once you belong to more than three.

--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -2,12 +2,19 @@ import type { Decorator } from "@storybook/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "../src/styles.css";
 
-const queryClient = new QueryClient({
-	defaultOptions: { queries: { retry: false, staleTime: Infinity } },
-});
+const queryClients = new Map<string, QueryClient>();
 
-const withQueryClient: Decorator = (Story) => (
-	<QueryClientProvider client={queryClient}>
+function queryClientFor(storyId: string): QueryClient {
+	const existing = queryClients.get(storyId);
+	if (existing) return existing;
+
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } });
+	queryClients.set(storyId, client);
+	return client;
+}
+
+const withQueryClient: Decorator = (Story, context) => (
+	<QueryClientProvider client={queryClientFor(context.id)}>
 		<Story />
 	</QueryClientProvider>
 );

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -32,6 +32,8 @@ import { organizationTree } from "@/lib/organizations/tree";
 import type { OrganizationSummary } from "@/lib/organizations/types";
 import { resetPostHog } from "@/lib/posthog";
 
+const INLINE_ORGANIZATION_LIMIT = 3;
+
 export function NavUser({ showOrganizations = true }: { showOrganizations?: boolean } = {}) {
 	const { user } = useAuth();
 	const { isMobile, setOpenMobile } = useSidebar();
@@ -154,6 +156,19 @@ export function NavUser({ showOrganizations = true }: { showOrganizations?: bool
 function OrganizationSwitcher({ onNavigate }: { onNavigate: () => void }) {
 	const { organizations, isLoading, isError, isFetching, refetch } = useOrganizations();
 	const currentBrandId = useBrandId();
+
+	if (organizations.length > INLINE_ORGANIZATION_LIMIT) {
+		return (
+			<>
+				<DropdownMenuItem render={<Link to="/app" onClick={onNavigate} />} className="cursor-pointer font-medium">
+					<IconBriefcase className="size-4 shrink-0 text-muted-foreground" />
+					<span className="truncate">All organizations</span>
+					<span className="ml-auto shrink-0 text-muted-foreground text-xs">{organizations.length}</span>
+				</DropdownMenuItem>
+				<DropdownMenuSeparator />
+			</>
+		);
+	}
 
 	return (
 		<>

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -7,6 +7,7 @@ import {
 	IconRefresh,
 	IconSelector,
 	IconSettings,
+	IconStatusChange,
 	IconUser,
 } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
@@ -160,10 +161,9 @@ function OrganizationSwitcher({ onNavigate }: { onNavigate: () => void }) {
 	if (organizations.length > INLINE_ORGANIZATION_LIMIT) {
 		return (
 			<>
-				<DropdownMenuItem render={<Link to="/app" onClick={onNavigate} />} className="cursor-pointer font-medium">
-					<IconBriefcase className="size-4 shrink-0 text-muted-foreground" />
-					<span className="truncate">All organizations</span>
-					<span className="ml-auto shrink-0 text-muted-foreground text-xs">{organizations.length}</span>
+				<DropdownMenuItem render={<Link to="/app" onClick={onNavigate} />} className="cursor-pointer">
+					<IconStatusChange />
+					Switch Brand
 				</DropdownMenuItem>
 				<DropdownMenuSeparator />
 			</>

--- a/apps/web/src/stories/app-sidebar.stories.tsx
+++ b/apps/web/src/stories/app-sidebar.stories.tsx
@@ -17,6 +17,7 @@ import { SidebarInset, SidebarProvider } from "@workspace/ui/components/sidebar"
 import { expect, screen, userEvent, within } from "storybook/test";
 import { AppSidebar } from "@/components/app-sidebar";
 import { type ClientConfig, setMockClientConfig } from "./_mocks/config-client";
+import { setMockOrganizations } from "./_mocks/server-organizations";
 import { setMockRouteContext } from "./_mocks/tanstack-router";
 import { setMockAuth } from "./_mocks/use-auth";
 import { setMockBrand } from "./_mocks/use-brands";
@@ -129,9 +130,11 @@ function configureMocks(
 	brand: any,
 	auth?: Parameters<typeof setMockAuth>[0],
 	viewer: { isAdmin: boolean; hasReportAccess: boolean } = { isAdmin: false, hasReportAccess: false },
+	organizations: Parameters<typeof setMockOrganizations>[0] = [organization],
 ) {
 	setMockClientConfig(config);
 	setMockBrand(brand);
+	setMockOrganizations(organizations);
 	setMockRouteContext({ clientConfig: config, ...viewer });
 	if (auth) setMockAuth(auth);
 	return brand;
@@ -342,6 +345,38 @@ export const ChoosePlanGate: StoryObj = {
 
 		await userEvent.click(await canvas.findByRole("button", { name: "Account" }));
 		await expect(await screen.findByText("Log out")).toBeInTheDocument();
+	},
+};
+
+/** Many organizations — the account menu collapses to a single switcher link */
+export const ManyOrganizations: StoryObj = {
+	render: () => {
+		const brand = configureMocks(
+			cloudConfig,
+			onboardedBrand,
+			authedUser("Multi Org", "multi@acme.com", "multi"),
+			undefined,
+			Array.from({ length: 5 }, (_, index) => ({
+				id: `org-${index + 1}`,
+				slug: `org-${index + 1}`,
+				name: `Organization ${index + 1}`,
+				brandCreation: { kind: "allowed" as const },
+				brands: [],
+			})),
+		);
+
+		return (
+			<SidebarFrame label="Many organizations — account menu links to the switcher">
+				<AppSidebar scope="brand" brand={brand} organization={organization} />
+			</SidebarFrame>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(await canvas.findByRole("button", { name: "Account and organizations" }));
+
+		await expect(await screen.findByText("All organizations")).toBeInTheDocument();
+		await expect(screen.queryByText("Organization 1")).toBeNull();
 	},
 };
 

--- a/apps/web/src/stories/app-sidebar.stories.tsx
+++ b/apps/web/src/stories/app-sidebar.stories.tsx
@@ -375,7 +375,7 @@ export const ManyOrganizations: StoryObj = {
 		const canvas = within(canvasElement);
 		await userEvent.click(await canvas.findByRole("button", { name: "Account and organizations" }));
 
-		await expect(await screen.findByText("All organizations")).toBeInTheDocument();
+		await expect(await screen.findByText("Switch Brand")).toBeInTheDocument();
 		await expect(screen.queryByText("Organization 1")).toBeNull();
 	},
 };


### PR DESCRIPTION
The account menu listed every organization you belong to and every brand under each one. Past a handful of organizations the popup runs the height of the screen.

Now, above three organizations, the menu collapses to a single **Switch Brand** row pointing at `/app`, the existing organization switcher — the same label and `IconStatusChange` the menu used before #576. Three or fewer keeps the current inline tree.

Stories in `app-sidebar.stories.tsx` shared one QueryClient and one mutable organizations mock, so the new many-organizations story leaked its data into every story viewed after it. The decorator now hands each story its own QueryClient, and `configureMocks` always sets the organizations rather than letting the last story's value stick.

## Verification
- `pnpm lint`, `tsc --noEmit`, `pnpm test` (345), `pnpm test:storybook` (105) all pass.
- Checked in a live Storybook: the many-organizations menu shows the single Switch Brand link, other stories still show their own organization tree, and switching back and forth stays correct.