### PR TITLE
move the admin links into the account menu off admin routes

### DIFF
--- a/.changeset/admin-links-in-account-menu.md
+++ b/.changeset/admin-links-in-account-menu.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Moved the admin links into the account menu so the sidebar only shows nav for where you are; admin routes keep them on the sidebar.

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -8,13 +8,9 @@ import {
 	IconDashboard,
 	IconLink,
 	IconListDetails,
-	IconReport,
 	IconSitemap,
 	IconSpeakerphone,
-	IconTable,
 	IconTarget,
-	IconTimeline,
-	IconTool,
 	IconUsers,
 } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
@@ -39,6 +35,7 @@ import { type NavGroup, type NavItem, NavMain } from "@/components/nav-main";
 import { NavUser } from "@/components/nav-user";
 import { useDeploymentFeatures } from "@/hooks/use-deployment-features";
 import { useViewer } from "@/hooks/use-route-context";
+import { adminNavItems } from "@/lib/admin-nav";
 import type { OrganizationSummary } from "@/lib/organizations/types";
 
 type ScopeProps =
@@ -106,21 +103,6 @@ function brandGroups(organization: OrganizationSummary, brand: BrandWithPrompts)
 	return groups;
 }
 
-function adminGroup(isAdmin: boolean, reportsEnabled: boolean): NavGroup {
-	const reportsItem: NavItem = { title: "Reports", link: { to: "/reports" }, icon: IconReport };
-	if (!isAdmin) return { label: "Admin", items: [reportsItem] };
-
-	return {
-		label: "Admin",
-		items: [
-			{ title: "Brands", link: { to: "/admin" }, icon: IconTable },
-			...(reportsEnabled ? [reportsItem] : []),
-			{ title: "Workflows", link: { to: "/admin/workflows" }, icon: IconTimeline },
-			{ title: "Tools", link: { to: "/admin/tools" }, icon: IconTool },
-		],
-	};
-}
-
 export function AppSidebar(props: ScopeProps) {
 	const { scope } = props;
 	const { setOpenMobile } = useSidebar();
@@ -131,12 +113,14 @@ export function AppSidebar(props: ScopeProps) {
 
 	// A gate page offers no destinations: every link would either 404 or bounce
 	// the user straight back to the gate.
-	const showAdminSection = scope !== "account" && (isAdmin || (hasReportAccess && reportsEnabled));
+	const adminItems = scope === "account" ? [] : adminNavItems({ isAdmin, hasReportAccess, reportsEnabled });
 
+	// The rail stays scoped to wherever you are, so admin links only earn a spot
+	// on admin routes; everywhere else they hang off the account menu.
 	const groups: NavGroup[] = [
 		...(props.scope === "brand" ? brandGroups(props.organization, props.brand) : []),
 		...(props.scope === "organization" ? [organizationGroup(props.organization, features)] : []),
-		...(showAdminSection ? [adminGroup(isAdmin, reportsEnabled)] : []),
+		...(scope === "admin" && adminItems.length > 0 ? [{ label: "Admin", items: adminItems }] : []),
 	];
 	const brandmark = (
 		<>
@@ -168,7 +152,7 @@ export function AppSidebar(props: ScopeProps) {
 				<NavMain groups={groups} />
 			</SidebarContent>
 			<SidebarFooter>
-				<NavUser showOrganizations={scope !== "account"} />
+				<NavUser showOrganizations={scope !== "account"} adminItems={scope === "admin" ? [] : adminItems} />
 				<NavAppInfo />
 			</SidebarFooter>
 		</Sidebar>

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -115,8 +115,6 @@ export function AppSidebar(props: ScopeProps) {
 	// the user straight back to the gate.
 	const adminItems = scope === "account" ? [] : adminNavItems({ isAdmin, hasReportAccess, reportsEnabled });
 
-	// The rail stays scoped to wherever you are, so admin links only earn a spot
-	// on admin routes; everywhere else they hang off the account menu.
 	const groups: NavGroup[] = [
 		...(props.scope === "brand" ? brandGroups(props.organization, props.brand) : []),
 		...(props.scope === "organization" ? [organizationGroup(props.organization, features)] : []),

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -23,6 +23,7 @@ import {
 	DropdownMenuTrigger,
 } from "@workspace/ui/components/dropdown-menu";
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from "@workspace/ui/components/sidebar";
+import type { NavItem } from "@/components/nav-main";
 import { OrganizationRowIcon } from "@/components/organization-row-icon";
 import { useAuth } from "@/hooks/use-auth";
 import { useBrandId } from "@/hooks/use-brand-id";
@@ -35,7 +36,13 @@ import { resetPostHog } from "@/lib/posthog";
 
 const INLINE_ORGANIZATION_LIMIT = 3;
 
-export function NavUser({ showOrganizations = true }: { showOrganizations?: boolean } = {}) {
+export function NavUser({
+	showOrganizations = true,
+	adminItems = [],
+}: {
+	showOrganizations?: boolean;
+	adminItems?: NavItem[];
+} = {}) {
 	const { user } = useAuth();
 	const { isMobile, setOpenMobile } = useSidebar();
 	const branding = useBranding();
@@ -113,6 +120,25 @@ export function NavUser({ showOrganizations = true }: { showOrganizations?: bool
 										<DropdownMenuSeparator />
 									</>
 								)}
+							</>
+						)}
+
+						{adminItems.length > 0 && (
+							<>
+								<DropdownMenuGroup>
+									<DropdownMenuLabel className="text-muted-foreground text-xs">Admin</DropdownMenuLabel>
+									{adminItems.map((item) => (
+										<DropdownMenuItem
+											key={item.title}
+											render={<Link {...item.link} onClick={close} />}
+											className="cursor-pointer"
+										>
+											{item.icon && <item.icon />}
+											{item.title}
+										</DropdownMenuItem>
+									))}
+								</DropdownMenuGroup>
+								<DropdownMenuSeparator />
 							</>
 						)}
 

--- a/apps/web/src/lib/admin-nav.ts
+++ b/apps/web/src/lib/admin-nav.ts
@@ -1,0 +1,23 @@
+import { IconReport, IconTable, IconTimeline, IconTool } from "@tabler/icons-react";
+import type { NavItem } from "@/components/nav-main";
+
+export function adminNavItems({
+	isAdmin,
+	hasReportAccess,
+	reportsEnabled,
+}: {
+	isAdmin: boolean;
+	hasReportAccess: boolean;
+	reportsEnabled: boolean;
+}): NavItem[] {
+	const reports: NavItem = { title: "Reports", link: { to: "/reports" }, icon: IconReport };
+
+	if (!isAdmin) return hasReportAccess && reportsEnabled ? [reports] : [];
+
+	return [
+		{ title: "Brands", link: { to: "/admin" }, icon: IconTable },
+		...(reportsEnabled ? [reports] : []),
+		{ title: "Workflows", link: { to: "/admin/workflows" }, icon: IconTimeline },
+		{ title: "Tools", link: { to: "/admin/tools" }, icon: IconTool },
+	];
+}

--- a/apps/web/src/stories/app-sidebar.stories.tsx
+++ b/apps/web/src/stories/app-sidebar.stories.tsx
@@ -220,7 +220,6 @@ export const Local: StoryObj = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		// Off an admin route the rail carries brand nav only; admin lives in the account menu.
 		await expect(canvas.queryByText("Workflows")).toBeNull();
 
 		await userEvent.click(await canvas.findByRole("button", { name: "Account and organizations" }));

--- a/apps/web/src/stories/app-sidebar.stories.tsx
+++ b/apps/web/src/stories/app-sidebar.stories.tsx
@@ -6,6 +6,7 @@
  *  - Demo (read-only preview)
  *  - Whitelabel, plus admin, report-only and pre-onboarding variants
  *  - Cloud, the only mode whose settings nav carries Billing
+ *  - Admin routes, where the admin links move from the account menu to the rail
  *
  * Every story passes `brand`, because the Settings group is gated on
  * `brand.onboarded` and the sidebar takes it as a prop from the route loader
@@ -219,9 +220,12 @@ export const Local: StoryObj = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(await canvas.findByText("Workflows")).toBeInTheDocument();
-		await expect(await canvas.findByText("Tools")).toBeInTheDocument();
-		await expect(await canvas.findByRole("button", { name: "Account and organizations" })).toBeInTheDocument();
+		// Off an admin route the rail carries brand nav only; admin lives in the account menu.
+		await expect(canvas.queryByText("Workflows")).toBeNull();
+
+		await userEvent.click(await canvas.findByRole("button", { name: "Account and organizations" }));
+		await expect(await screen.findByText("Workflows")).toBeInTheDocument();
+		await expect(await screen.findByText("Tools")).toBeInTheDocument();
 	},
 };
 
@@ -253,7 +257,7 @@ export const Whitelabel = () => {
 	);
 };
 
-/** Whitelabel (Admin) — admin section with Brands, Reports, Workflows, Tools */
+/** Whitelabel (Admin) — Brands, Reports, Workflows and Tools under the account menu */
 export const WhitelabelAdmin = () => {
 	const brand = configureMocks(
 		whitelabelAdminConfig,
@@ -263,26 +267,60 @@ export const WhitelabelAdmin = () => {
 	);
 
 	return (
-		<SidebarFrame label="Whitelabel Admin — Full admin section visible">
+		<SidebarFrame label="Whitelabel Admin — Admin links live in the account menu">
 			<AppSidebar scope="brand" brand={brand} organization={organization} />
 		</SidebarFrame>
 	);
 };
 
 /** Whitelabel (Report-only) — limited admin access, only reports visible */
-export const WhitelabelReportOnly = () => {
-	const brand = configureMocks(
-		whitelabelAdminConfig,
-		onboardedBrand,
-		authedUser("Report Viewer", "reports@client.com", "reports"),
-		{ isAdmin: false, hasReportAccess: true },
-	);
+export const WhitelabelReportOnly: StoryObj = {
+	render: () => {
+		const brand = configureMocks(
+			whitelabelAdminConfig,
+			onboardedBrand,
+			authedUser("Report Viewer", "reports@client.com", "reports"),
+			{ isAdmin: false, hasReportAccess: true },
+		);
 
-	return (
-		<SidebarFrame label="Whitelabel Report-only — Dashboard + Reports admin section">
-			<AppSidebar scope="brand" brand={brand} organization={organization} />
-		</SidebarFrame>
-	);
+		return (
+			<SidebarFrame label="Whitelabel Report-only — Reports is the only admin entry">
+				<AppSidebar scope="brand" brand={brand} organization={organization} />
+			</SidebarFrame>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(await canvas.findByRole("button", { name: "Account and organizations" }));
+
+		await expect(await screen.findByText("Reports")).toBeInTheDocument();
+		await expect(screen.queryByText("Workflows")).toBeNull();
+	},
+};
+
+/** Admin route — the rail switches over to admin nav, and the account menu drops it */
+export const AdminRoute: StoryObj = {
+	render: () => {
+		configureMocks(whitelabelAdminConfig, onboardedBrand, authedUser("Jane Admin", "jane@agency.com", "jane"), {
+			isAdmin: true,
+			hasReportAccess: true,
+		});
+
+		return (
+			<SidebarFrame label="Admin route — admin nav on the rail">
+				<AppSidebar scope="admin" />
+			</SidebarFrame>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(await canvas.findByText("Workflows")).toBeInTheDocument();
+		await expect(await canvas.findByText("Tools")).toBeInTheDocument();
+
+		await userEvent.click(await canvas.findByRole("button", { name: "Account and organizations" }));
+		const menu = within(await screen.findByRole("menu"));
+		await expect(menu.queryByText("Tools")).toBeNull();
+	},
 };
 
 export const Cloud: StoryObj = {
@@ -304,8 +342,10 @@ export const Cloud: StoryObj = {
 		// below the fold of this frame — assert it rather than eyeballing it.
 		await expect(await canvas.findByText("Billing")).toBeInTheDocument();
 		await expect(await canvas.findByText("Team")).toBeInTheDocument();
-		await expect(await canvas.findByText("Workflows")).toBeInTheDocument();
-		await expect(canvas.queryByText("Reports")).toBeNull();
+
+		await userEvent.click(await canvas.findByRole("button", { name: "Account and organizations" }));
+		await expect(await screen.findByText("Workflows")).toBeInTheDocument();
+		await expect(screen.queryByText("Reports")).toBeNull();
 	},
 };
 

--- a/e2e/tests/cloud/cloud-deployment.spec.ts
+++ b/e2e/tests/cloud/cloud-deployment.spec.ts
@@ -121,8 +121,7 @@ test.describe("Cloud features", () => {
       page.locator(`a[href="${organizationUrl()}/settings/members"][data-sidebar="menu-button"]`),
     ).toHaveCount(0);
 
-    // Off an admin route the admin links sit in the account menu — and even
-    // there this admin gets no Reports entry, because cloud has it switched off.
+    // The admin section is present (this user is an admin) but has no Reports entry.
     await page.getByRole("button", { name: "Account and organizations" }).click();
     const menu = page.getByRole("menu");
     await expect(menu.locator('a[href="/admin"]')).toBeVisible();

--- a/e2e/tests/cloud/cloud-deployment.spec.ts
+++ b/e2e/tests/cloud/cloud-deployment.spec.ts
@@ -120,9 +120,13 @@ test.describe("Cloud features", () => {
     await expect(
       page.locator(`a[href="${organizationUrl()}/settings/members"][data-sidebar="menu-button"]`),
     ).toHaveCount(0);
-    // The admin section is present (this user is an admin) but has no Reports entry.
-    await expect(page.locator('a[href="/admin"][data-sidebar="menu-button"]')).toBeVisible();
-    await expect(page.locator('a[href="/reports"][data-sidebar="menu-button"]')).toHaveCount(0);
+
+    // Off an admin route the admin links sit in the account menu — and even
+    // there this admin gets no Reports entry, because cloud has it switched off.
+    await page.getByRole("button", { name: "Account and organizations" }).click();
+    const menu = page.getByRole("menu");
+    await expect(menu.locator('a[href="/admin"]')).toBeVisible();
+    await expect(menu.locator('a[href="/reports"]')).toHaveCount(0);
   });
 
   test("teammates can be invited by email", async ({ page }) => {

--- a/e2e/tests/shared/overview.spec.ts
+++ b/e2e/tests/shared/overview.spec.ts
@@ -55,7 +55,6 @@ test.describe("Overview Page", () => {
     await page.goto(`${BRAND_URL}`);
 
     await expect(page.locator(`a[href="${BRAND_URL}"][data-sidebar="menu-button"]`)).toBeVisible({ timeout: 15_000 });
-    // The rail only carries brand nav here; admin links hang off the account menu.
     await expect(page.locator('a[href="/admin"][data-sidebar="menu-button"]')).toHaveCount(0);
 
     await page.getByRole("button", { name: "Account and organizations" }).click();
@@ -64,7 +63,6 @@ test.describe("Overview Page", () => {
     await adminLink.click();
     await page.waitForURL(/\/admin$/);
 
-    // On an admin route the rail takes the admin links back over.
     await expect(page.locator('a[href="/admin/workflows"][data-sidebar="menu-button"]')).toBeVisible({
       timeout: 15_000,
     });

--- a/e2e/tests/shared/overview.spec.ts
+++ b/e2e/tests/shared/overview.spec.ts
@@ -51,15 +51,23 @@ test.describe("Overview Page", () => {
     await page.waitForURL(new RegExp(`${BRAND_URL}$`));
   });
 
-  test("an admin can reach the admin brand list", async ({ page }) => {
+  test("an admin can reach the admin brand list from the account menu", async ({ page }) => {
     await page.goto(`${BRAND_URL}`);
 
     await expect(page.locator(`a[href="${BRAND_URL}"][data-sidebar="menu-button"]`)).toBeVisible({ timeout: 15_000 });
+    // The rail only carries brand nav here; admin links hang off the account menu.
+    await expect(page.locator('a[href="/admin"][data-sidebar="menu-button"]')).toHaveCount(0);
 
-    const adminLink = page.locator('a[href="/admin"][data-sidebar="menu-button"]');
+    await page.getByRole("button", { name: "Account and organizations" }).click();
+    const adminLink = page.getByRole("menu").locator('a[href="/admin"]');
     await expect(adminLink).toBeVisible({ timeout: 15_000 });
     await adminLink.click();
     await page.waitForURL(/\/admin$/);
+
+    // On an admin route the rail takes the admin links back over.
+    await expect(page.locator('a[href="/admin/workflows"][data-sidebar="menu-button"]')).toBeVisible({
+      timeout: 15_000,
+    });
   });
 
   test("settings pages are accessible", async ({ page }) => {


### PR DESCRIPTION
The sidebar rail now only carries nav for the scope you're in — org, brand, or admin. The admin links (Brands, Reports, Workflows, Tools) move into the account menu everywhere except `/admin` routes, where they take the rail back over.

`adminNavItems` in `apps/web/src/lib/admin-nav.ts` is the shared source for both surfaces, so the report-only and cloud/no-reports cases stay identical between them. Account-gate pages still get no admin links at all.

## Tests

- New `AdminRoute` story covers the rail on admin scope; the `Local`, `Cloud` and `WhitelabelReportOnly` stories now assert the links through the account menu.
- The two e2e specs that clicked the sidebar `/admin` link go through the account menu instead; the shared one also asserts the rail picks the links up once on `/admin`.
- `pnpm lint`, `pnpm check-types`, `pnpm test` and `pnpm test:storybook` pass. E2E was not run — it needs a live app.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/56911860-5775-4674-85fc-f56065215c70)
