### PR TITLE
bound citation titles to a sane length

### DIFF
--- a/.changeset/bound-citation-title-length.md
+++ b/.changeset/bound-citation-title-length.md
@@ -1,0 +1,5 @@
+---
+"@workspace/lib": patch
+---
+
+Stop dropping citations when an answer engine returns a page's body text in place of its title

--- a/packages/docs/content/docs/developer-guide/architecture.mdx
+++ b/packages/docs/content/docs/developer-guide/architecture.mdx
@@ -83,6 +83,12 @@ The database schema is defined with Drizzle ORM in `packages/lib/src/db/`. Key t
 
 Migrations are generated with `drizzle-kit generate` and applied with `drizzle-kit migrate`.
 
+Never use `drizzle-kit push` against a deployment. It diffs the live database
+against the schema files rather than replaying migrations, so it drops any index
+a migration created that the schema cannot express — `INCLUDE` indexes, and
+anything on the generated better-auth tables. It also records nothing in
+`drizzle.__drizzle_migrations`, leaving `migrate` unable to tell what has run.
+
 ## Provider Abstraction
 
 All AI scraping flows through a single `Provider` interface in `packages/lib/src/providers/`. The runtime wiring:

--- a/packages/docs/content/docs/developer-guide/commands.mdx
+++ b/packages/docs/content/docs/developer-guide/commands.mdx
@@ -67,6 +67,10 @@ pnpm drizzle-kit generate
 pnpm drizzle-kit migrate
 ```
 
+Apply schema changes with `drizzle-kit migrate` only. See
+[Architecture](/docs/developer-guide/architecture#database) for why `drizzle-kit
+push` is unsafe against a deployment.
+
 ## Component Stories
 
 ```bash

--- a/packages/lib/src/providers/registry/olostep.ts
+++ b/packages/lib/src/providers/registry/olostep.ts
@@ -1,7 +1,7 @@
 import Olostep from "olostep";
 import { WEB_QUERIES_UNAVAILABLE } from "../../constants";
 import { getCredential } from "../../secrets";
-import type { Citation } from "../../text-extraction";
+import { type Citation, normalizeCitationTitle } from "../../text-extraction";
 import type { ModelConfig, Provider, ProviderOptions, ScrapeResult } from "../types";
 
 const OLOSTEP_PARSERS: Record<string, { parserId: string; urlTemplate: (q: string) => string; credits: number }> = {
@@ -69,7 +69,7 @@ function extractCitationsFromOlostep(data: any): Citation[] {
 			const parsed = new URL(url);
 			citations.push({
 				url,
-				title: source?.title ?? source?.label ?? undefined,
+				title: normalizeCitationTitle(source?.title ?? source?.label),
 				domain: parsed.hostname.replace(/^www\./, ""),
 				citationIndex: idx++,
 			});

--- a/packages/lib/src/providers/registry/openrouter.ts
+++ b/packages/lib/src/providers/registry/openrouter.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { WEB_QUERIES_UNAVAILABLE } from "../../constants";
 import { getCredential } from "../../secrets";
-import type { Citation } from "../../text-extraction";
+import { type Citation, normalizeCitationTitle } from "../../text-extraction";
 import { API_PROVIDER_MAX_OUTPUT_TOKENS, warnIfOutputCapped } from "../config";
 import type {
 	Provider,
@@ -60,7 +60,7 @@ function extractCitationsFromOpenRouterResponse(data: any): Citation[] {
 			const parsed = new URL(url);
 			citations.push({
 				url,
-				title: cite.title ?? undefined,
+				title: normalizeCitationTitle(cite.title),
 				domain: parsed.hostname.replace(/^www\./, ""),
 				citationIndex: idx++,
 			});

--- a/packages/lib/src/text-extraction.test.ts
+++ b/packages/lib/src/text-extraction.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	CITATION_TITLE_MAX_LENGTH,
 	extractCitations,
 	extractCitationsFromBrightdata,
 	extractCitationsFromDataforseoLlm,
@@ -14,6 +15,7 @@ import {
 	extractTextFromGoogle,
 	extractTextFromOpenAI,
 	extractTextFromOxylabs,
+	normalizeCitationTitle,
 } from "./text-extraction";
 
 /** A minimal DataForSEO AI Optimization "LLM Responses" payload. */
@@ -742,6 +744,47 @@ describe("text-extraction", () => {
 
 		it("should return empty array for unknown model group", () => {
 			expect(extractCitations({}, "unknown")).toEqual([]);
+		});
+	});
+
+	describe("citation titles", () => {
+		it("keeps titles that are already a sensible length", () => {
+			expect(normalizeCitationTitle("A perfectly normal page title")).toBe("A perfectly normal page title");
+		});
+
+		it("treats a missing or empty title as absent", () => {
+			expect(normalizeCitationTitle(undefined)).toBeUndefined();
+			expect(normalizeCitationTitle("")).toBeUndefined();
+			expect(normalizeCitationTitle(12345)).toBeUndefined();
+		});
+
+		it("bounds titles so an oversized one cannot fail the citation insert", () => {
+			const bodyText = "x".repeat(11_325);
+			expect(normalizeCitationTitle(bodyText)).toHaveLength(CITATION_TITLE_MAX_LENGTH);
+		});
+
+		it("truncates on whole characters so multi-byte titles stay valid", () => {
+			const truncated = normalizeCitationTitle("\u{1D518}".repeat(CITATION_TITLE_MAX_LENGTH + 50));
+			expect(truncated).toBe("\u{1D518}".repeat(CITATION_TITLE_MAX_LENGTH));
+		});
+
+		it("bounds titles arriving from a provider payload", () => {
+			const citations = extractCitationsFromOpenAI({
+				output: [
+					{
+						type: "message",
+						content: [
+							{
+								type: "output_text",
+								text: "answer",
+								annotations: [{ type: "url_citation", url: "https://example.com/manual.pdf", title: "y".repeat(8000) }],
+							},
+						],
+					},
+				],
+			});
+			expect(citations).toHaveLength(1);
+			expect(citations[0].title).toHaveLength(CITATION_TITLE_MAX_LENGTH);
 		});
 	});
 });

--- a/packages/lib/src/text-extraction.ts
+++ b/packages/lib/src/text-extraction.ts
@@ -400,20 +400,8 @@ export type Citation = {
 	citationIndex: number;
 };
 
-/**
- * Providers report whatever their upstream model calls the citation's title. When
- * a URL has no usable title — PDFs and other non-HTML documents especially — some
- * return kilobytes of the document's body text in that field instead.
- *
- * `title` is a key column of idx_citations_brand_analytics, and Postgres rejects
- * any btree tuple over ~2704 bytes. Citations are written as one multi-row insert
- * per run, so a single oversized title fails the whole batch rather than its own
- * row. This bound is well above any real title and leaves room for the url and
- * domain sharing the tuple.
- */
 export const CITATION_TITLE_MAX_LENGTH = 256;
 
-/** Slices by code point so a truncation can't split a surrogate pair. */
 export function normalizeCitationTitle(title: unknown): string | undefined {
 	if (typeof title !== "string" || !title) return undefined;
 	const chars = Array.from(title);

--- a/packages/lib/src/text-extraction.ts
+++ b/packages/lib/src/text-extraction.ts
@@ -400,12 +400,32 @@ export type Citation = {
 	citationIndex: number;
 };
 
+/**
+ * Providers report whatever their upstream model calls the citation's title. When
+ * a URL has no usable title — PDFs and other non-HTML documents especially — some
+ * return kilobytes of the document's body text in that field instead.
+ *
+ * `title` is a key column of idx_citations_brand_analytics, and Postgres rejects
+ * any btree tuple over ~2704 bytes. Citations are written as one multi-row insert
+ * per run, so a single oversized title fails the whole batch rather than its own
+ * row. This bound is well above any real title and leaves room for the url and
+ * domain sharing the tuple.
+ */
+export const CITATION_TITLE_MAX_LENGTH = 256;
+
+/** Slices by code point so a truncation can't split a surrogate pair. */
+export function normalizeCitationTitle(title: unknown): string | undefined {
+	if (typeof title !== "string" || !title) return undefined;
+	const chars = Array.from(title);
+	return chars.length > CITATION_TITLE_MAX_LENGTH ? chars.slice(0, CITATION_TITLE_MAX_LENGTH).join("") : title;
+}
+
 function parseCitationUrl(url: string, title: string | undefined, idx: number): Citation | null {
 	try {
 		const parsed = new URL(url);
 		return {
 			url,
-			title: title || undefined,
+			title: normalizeCitationTitle(title),
 			domain: parsed.hostname.replace(/^www\./, ""),
 			citationIndex: idx,
 		};


### PR DESCRIPTION
## What

Bounds `citations.title` at 256 characters when citations are extracted, and documents why `drizzle-kit push` must not be run against a deployment.

## Why

Providers report whatever their upstream model calls a citation's title. When a URL has no usable title — PDFs especially — some return kilobytes of the document's body text in that field instead. Nothing in the codebase bounded it.

`title` is a key column of `idx_citations_brand_analytics`, and Postgres rejects any btree tuple over ~2704 bytes. Because `saveCitations` writes one multi-row insert per run with no per-row handling, a single oversized title fails **the entire batch** — every citation for that prompt run is discarded, not just the offending one.

This is live on deployments that have the index. One production database holds 464 rows that cannot be indexed, the worst at 11,509 bytes, with 22 more within 300 bytes of the limit. The URLs are ordinary product pages and PDFs; only the title field is pathological.

## How

`normalizeCitationTitle` + `CITATION_TITLE_MAX_LENGTH` in `text-extraction.ts`, applied in `parseCitationUrl` — which covers 16 of the 18 provider extraction sites — and in the two providers that build `Citation` objects inline (`openrouter.ts`, `olostep.ts`). Bounding at every construction site makes the limit an invariant of the `Citation` type rather than a check that can be routed around.

Truncation is by code point, so it cannot split a surrogate pair.

The bound was picked by measurement, not guesswork: with a deliberately pessimistic tuple (300-byte url, 253-byte max-length domain, 24-byte brand_id) the index rejects titles between 2048 and 2080 bytes. At 256 characters the worst case is 1024 bytes of UTF-8, leaving roughly 1KB of headroom.

## Testing

Five tests in `text-extraction.test.ts`, including an 8KB title driven through the real OpenAI extractor and a multi-byte truncation case. Full suite passes; lint clean.

## Note

Existing oversized rows still need repairing separately — this stops the bleeding, it does not backfill. Citations already rejected are not recoverable.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/dca073a1-902a-4749-9020-1a0a79371355)
