### PR TITLE
look for reports in the account menu in the local e2e spec

### DIFF
--- a/e2e/tests/local/local-deployment.spec.ts
+++ b/e2e/tests/local/local-deployment.spec.ts
@@ -59,12 +59,15 @@ test.describe("Local features", () => {
     await expect(page.getByRole("heading", { name: /reports/i }).first()).toBeVisible({ timeout: 30_000 });
   });
 
-  test("the sidebar offers reports on a brand, and the organization's pages on its own", async ({ page }) => {
+  test("reports are in the account menu on a brand, and the organization's pages are its own", async ({ page }) => {
     await page.goto(`${brandUrl()}`);
-    await expect(page.locator('a[href="/reports"][data-sidebar="menu-button"]')).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(`a[href="${brandUrl()}"][data-sidebar="menu-button"]`)).toBeVisible({ timeout: 30_000 });
     await expect(page.locator(`a[href="${organizationUrl()}/settings/brands"][data-sidebar="menu-button"]`)).toHaveCount(
       0,
     );
+
+    await page.getByRole("button", { name: "Account and organizations" }).click();
+    await expect(page.getByRole("menu").locator('a[href="/reports"]')).toBeVisible({ timeout: 30_000 });
 
     await page.goto(`${organizationUrl()}/settings`);
     await expect(


### PR DESCRIPTION
Fixes the E2E Tests failure on `main`.

#667 moved the admin nav — including `/reports` — out of the sidebar and into the account dropdown, so the sidebar now only renders the Admin group on admin routes. That PR updated `cloud-deployment.spec.ts` and `shared/overview.spec.ts` for the new placement but missed the local spec, which still asserted `a[href="/reports"][data-sidebar="menu-button"]` on a brand page.

The test now gates on the brand overview sidebar link for page load, then opens the account menu and asserts `/reports` there — the same pattern #667 established in the cloud and overview specs.

`Build` was never red; only the E2E job. It has been failing since cf0caf0.

## Verification

- `pnpm lint`, `e2e` `tsc --noEmit`, and `pnpm build` (16/16) all pass.
- The locators are already proven under the `local` Playwright project: `overview.spec.ts` opens the same "Account and organizations" menu and finds `a[href="/admin"]` — it passed in the same run this test failed in. `/reports` is in the same `adminNavItems` list for a local admin (`reportGeneration: true` in `packages/local/src/auth-provider.ts`).
- All 11 `app-sidebar` Storybook tests pass.

No changeset: test-only, nothing user-facing.

## Note

The E2E job runs modes sequentially (local → worker → cloud → whitelabel → demo) and died at local, so cloud, whitelabel, and demo have not run since #664. Their specs look consistent on inspection, but this fix may uncover further failures CI hasn't reached yet.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1aa4c36a-494b-4af9-bc25-48d661c6676a)
