### PR TITLE
Fail e2e tests on unexpected browser console errors

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -8,7 +8,8 @@
  * the specs for what makes that mode different.
  */
 import { defineConfig, devices } from "@playwright/test";
-import { authStatePath, DEPLOYMENT_MODES } from "./fixtures";
+import { authStatePath, DEPLOYMENT_MODES, WHITELABEL } from "./fixtures";
+import type { ConsoleErrorOptions } from "./test";
 
 // Base URL can be overridden via environment variable.
 // Default: http://localhost:1515 (Docker Compose maps web:3000 → host:1515)
@@ -32,11 +33,15 @@ const modeProjects = DEPLOYMENT_MODES.flatMap((mode) => [
     // keeps its own — a shared one would delete the previous pass's traces
     // before CI uploads them.
     outputDir: `test-results-${mode}`,
-    use: { ...devices["Desktop Chrome"], storageState: authStatePath(mode) },
+    use: {
+      ...devices["Desktop Chrome"],
+      storageState: authStatePath(mode),
+      allowedConsoleErrors: mode === "whitelabel" ? [WHITELABEL.appIcon] : [],
+    },
   },
 ]);
 
-export default defineConfig({
+export default defineConfig<ConsoleErrorOptions>({
   testDir: "./tests",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -55,6 +55,8 @@ export const test = base.extend<
 		});
 	},
 
+	// Listening here rather than in the auto fixture above keeps a spec that only
+	// takes `request` from building a browser context it never uses.
 	context: async ({ context, _consoleErrorLog }, use) => {
 		const watch = (page: Page) => {
 			page.on("console", (message) => {

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -1,0 +1,83 @@
+import { type ConsoleMessage, type Page, expect, test as base } from "@playwright/test";
+
+export type ConsoleErrorPattern = string | RegExp;
+
+const ALWAYS_ALLOWED: ConsoleErrorPattern[] = [/t[0-9]\.gstatic\.com/];
+
+export const failedResource = (status: number, from: string): RegExp =>
+	new RegExp(`Failed to load resource: the server responded with a status of ${status}\\D.*${escapeRegExp(from)}`);
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export const ABORTED_SSR_STREAM = /Minified React error #419/;
+
+export interface ConsoleErrorCollector {
+	allow(...patterns: ConsoleErrorPattern[]): void;
+	recorded(): string[];
+}
+
+export interface ConsoleErrorOptions {
+	allowedConsoleErrors: ConsoleErrorPattern[];
+}
+
+interface ConsoleErrorLog {
+	recorded: string[];
+	allowed: ConsoleErrorPattern[];
+}
+
+export const test = base.extend<
+	ConsoleErrorOptions & { consoleErrors: ConsoleErrorCollector; _consoleErrorLog: ConsoleErrorLog }
+>({
+	allowedConsoleErrors: [[], { option: true }],
+
+	_consoleErrorLog: [
+		async ({ allowedConsoleErrors }, use, testInfo) => {
+			const log: ConsoleErrorLog = { recorded: [], allowed: [...ALWAYS_ALLOWED, ...allowedConsoleErrors] };
+
+			await use(log);
+
+			if (testInfo.status !== testInfo.expectedStatus) return;
+
+			const unexpected = [...new Set(log.recorded)].filter(
+				(entry) => !log.allowed.some((pattern) => matches(entry, pattern)),
+			);
+			expect(unexpected, "the browser console reported errors this test did not allow").toEqual([]);
+		},
+		{ auto: true },
+	],
+
+	consoleErrors: async ({ _consoleErrorLog }, use) => {
+		await use({
+			allow: (...patterns) => _consoleErrorLog.allowed.push(...patterns),
+			recorded: () => [..._consoleErrorLog.recorded],
+		});
+	},
+
+	context: async ({ context, _consoleErrorLog }, use) => {
+		const watch = (page: Page) => {
+			page.on("console", (message) => {
+				if (message.type() === "error") _consoleErrorLog.recorded.push(describeConsoleError(message));
+			});
+			page.on("pageerror", (error) => {
+				_consoleErrorLog.recorded.push(`[pageerror] ${error.message}`);
+			});
+		};
+		for (const page of context.pages()) watch(page);
+		context.on("page", watch);
+
+		await use(context);
+	},
+});
+
+function matches(entry: string, pattern: ConsoleErrorPattern): boolean {
+	return typeof pattern === "string" ? entry.includes(pattern) : pattern.test(entry);
+}
+
+function describeConsoleError(message: ConsoleMessage): string {
+	const { url, lineNumber } = message.location();
+	return `[console.error] ${message.text()}${url ? ` (${url}:${lineNumber})` : ""}`;
+}
+
+export { expect };

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -14,7 +14,6 @@
  * Whichever path runs, the user ends up an admin of TEST_BRAND_ID with report
  * generator access, so shared specs see the same surface in every mode.
  */
-import { test as setup } from "@playwright/test";
 import type { APIRequestContext, Page } from "@playwright/test";
 import { authStatePath, isDeploymentMode, TEST_USER, type DeploymentMode } from "../fixtures";
 import {
@@ -27,6 +26,7 @@ import {
   userExists,
   withDb,
 } from "../session";
+import { test as setup } from "../test";
 
 setup("authenticate", async ({ page, baseURL }, testInfo) => {
   const mode = testInfo.project.name.replace(/:setup$/, "");

--- a/e2e/tests/cloud/cloud-deployment.spec.ts
+++ b/e2e/tests/cloud/cloud-deployment.spec.ts
@@ -9,7 +9,7 @@
  * transactional-email provider — so the specs verify addresses in the database
  * and assert on everything around it.
  */
-import { expect, test } from "@playwright/test";
+import { expect, failedResource, test } from "../../test";
 import { CLOUD_SIGNUP, TEST_BRAND_ID, TEST_USER, brandUrl, organizationUrl } from "../../fixtures";
 import { deleteUsers, userExists, verifyEmail } from "../../session";
 
@@ -105,7 +105,8 @@ test.describe("Cloud self-serve signup", () => {
 });
 
 test.describe("Cloud features", () => {
-  test("report generation is switched off", async ({ page }) => {
+  test("report generation is switched off", async ({ page, consoleErrors }) => {
+    consoleErrors.allow(failedResource(404, "/reports"));
     await page.goto("/reports");
     await expect(page.getByText("404 Not Found")).toBeVisible({ timeout: 30_000 });
   });

--- a/e2e/tests/demo/demo-deployment.spec.ts
+++ b/e2e/tests/demo/demo-deployment.spec.ts
@@ -11,7 +11,7 @@
  * write leaves the database untouched — a 403 that still wrote would pass the
  * unit tests.
  */
-import { expect, test } from "@playwright/test";
+import { ABORTED_SSR_STREAM, expect, failedResource, test } from "../../test";
 import {
   COMPETITOR_IDS,
   DEMO_CREDENTIALS,
@@ -81,7 +81,8 @@ test.describe("Demo refuses writes", () => {
     expect(prompt.status()).toBe(200);
   });
 
-  test("saving brand settings from the UI fails and writes nothing", async ({ page }) => {
+  test("saving brand settings from the UI fails and writes nothing", async ({ page, consoleErrors }) => {
+    consoleErrors.allow(failedResource(403, "/_serverFn/"));
     await page.goto(`${brandUrl()}/settings/brand`);
 
     const nameInput = page.getByLabel("Brand Name");
@@ -148,7 +149,8 @@ test.describe("Demo auth is sign-in only", () => {
     await expect(page.getByLabel("Password")).toHaveCount(0);
   });
 
-  test("the register page sends you to sign in", async ({ page }) => {
+  test("the register page sends you to sign in", async ({ page, consoleErrors }) => {
+    consoleErrors.allow(ABORTED_SSR_STREAM);
     await page.goto("/auth/register");
     await page.waitForURL(/\/auth\/login/, { timeout: 30_000 });
   });
@@ -169,7 +171,8 @@ test.describe("Demo features", () => {
     await page.waitForURL(new RegExp(`${organizationUrl()}/settings$`), { timeout: 30_000 });
   });
 
-  test("saving organization settings fails and says why", async ({ page }) => {
+  test("saving organization settings fails and says why", async ({ page, consoleErrors }) => {
+    consoleErrors.allow(failedResource(403, "/_serverFn/"));
     await page.goto(`${organizationUrl()}/settings`);
 
     const nameField = page.getByLabel("Organization Name", { exact: true });
@@ -180,7 +183,8 @@ test.describe("Demo features", () => {
     await expect(page.getByText("Edits are not allowed in demo mode.")).toBeVisible({ timeout: 30_000 });
   });
 
-  test("the team page is not offered and not reachable", async ({ page }) => {
+  test("the team page is not offered and not reachable", async ({ page, consoleErrors }) => {
+    consoleErrors.allow(failedResource(404, `${organizationUrl()}/settings/members`));
     await page.goto(`${organizationUrl()}/settings`);
     await expect(
       page.locator(`a[href="${organizationUrl()}/settings/members"][data-sidebar="menu-button"]`),

--- a/e2e/tests/local/local-deployment.spec.ts
+++ b/e2e/tests/local/local-deployment.spec.ts
@@ -6,7 +6,7 @@
  * ships the full report generator and the stock Elmo branding, and it lets the
  * operator create as many brands as they like.
  */
-import { expect, test } from "@playwright/test";
+import { ABORTED_SSR_STREAM, expect, failedResource, test } from "../../test";
 import { TEST_BRAND_ID, TEST_USER, brandUrl, organizationUrl } from "../../fixtures";
 import { userExists } from "../../session";
 
@@ -31,7 +31,8 @@ test.describe("Local signup is closed after bootstrap", () => {
     expect(await userExists(SECOND_USER.email)).toBe(false);
   });
 
-  test("the register page sends you to sign in", async ({ page }) => {
+  test("the register page sends you to sign in", async ({ page, consoleErrors }) => {
+    consoleErrors.allow(ABORTED_SSR_STREAM);
     await page.goto("/auth/register");
     await page.waitForURL(/\/auth\/login/, { timeout: 30_000 });
   });
@@ -78,7 +79,11 @@ test.describe("Local features", () => {
     );
   });
 
-  test("the team page is not offered and not reachable — a local install is one user", async ({ page }) => {
+  test("the team page is not offered and not reachable — a local install is one user", async ({
+    page,
+    consoleErrors,
+  }) => {
+    consoleErrors.allow(failedResource(404, `${organizationUrl()}/settings/members`));
     await page.goto(`${organizationUrl()}/settings`);
     await expect(
       page.locator(`a[href="${organizationUrl()}/settings/members"][data-sidebar="menu-button"]`),

--- a/e2e/tests/local/organization-rename.spec.ts
+++ b/e2e/tests/local/organization-rename.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../../test";
 import { RENAMEABLE_BRAND_ID, RENAMEABLE_BRAND_SLUG, TEST_BRAND_NAME, TEST_ORG_SLUG, brandUrl, organizationUrl } from "../../fixtures";
 
 test.describe("Organization rename", () => {

--- a/e2e/tests/shared/access-control.spec.ts
+++ b/e2e/tests/shared/access-control.spec.ts
@@ -8,7 +8,7 @@
  * point — a mode-specific auth or middleware change that quietly opens one of
  * these up fails here.
  */
-import { expect, test } from "@playwright/test";
+import { expect, failedResource, test } from "../../test";
 import { NIKE_BRAND_ID, TEST_API_KEY, TEST_BRAND_ID, brandUrl, organizationUrl } from "../../fixtures";
 
 test.describe("Unauthenticated access", () => {
@@ -42,7 +42,8 @@ test.describe("Unauthenticated access", () => {
 });
 
 test.describe("Authenticated access", () => {
-  test("a brand in another org is not found", async ({ page }) => {
+  test("a brand in another org is not found", async ({ page, consoleErrors }) => {
+    consoleErrors.allow(failedResource(404, `${organizationUrl()}/brand/${NIKE_BRAND_ID}`));
     await page.goto(`${organizationUrl()}/brand/${NIKE_BRAND_ID}`);
     await expect(page.getByText("404 Not Found")).toBeVisible({ timeout: 30_000 });
   });

--- a/e2e/tests/shared/account-menu.spec.ts
+++ b/e2e/tests/shared/account-menu.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../../test";
 import { TEST_BRAND_NAME, TEST_ORGANIZATION_NAME, brandUrl, organizationUrl } from "../../fixtures";
 
 test.describe("Account menu", () => {

--- a/e2e/tests/shared/app-routing.spec.ts
+++ b/e2e/tests/shared/app-routing.spec.ts
@@ -1,4 +1,3 @@
-import { expect, test } from "@playwright/test";
 import {
 	NIKE_BRAND_ID,
 	SLUGGED_BRAND_ID,
@@ -10,6 +9,7 @@ import {
 	brandUrl,
 	organizationUrl,
 } from "../../fixtures";
+import { expect, failedResource, test } from "../../test";
 
 const BRAND_URL = brandUrl();
 const SLUGGED_BRAND_URL = brandUrl(SLUGGED_BRAND_SLUG);
@@ -39,14 +39,16 @@ test.describe("App routing", () => {
 		});
 	});
 
-	test("an unknown page offers everything the user can reach", async ({ page }) => {
+	test("an unknown page offers everything the user can reach", async ({ page, consoleErrors }) => {
+		consoleErrors.allow(failedResource(404, "/app/org/not-a-organization"));
 		await page.goto("/app/org/not-a-organization");
 
 		await expect(page.getByText("That page doesn't exist or moved.")).toBeVisible({ timeout: 30_000 });
 		await expect(page.getByRole("link", { name: TEST_BRAND_NAME, exact: true }).first()).toBeVisible();
 	});
 
-	test("the mark on a full-page view leads to the directory", async ({ page }) => {
+	test("the mark on a full-page view leads to the directory", async ({ page, consoleErrors }) => {
+		consoleErrors.allow(failedResource(404, "/app/org/not-a-organization"), failedResource(404, "/appadsf"));
 		await page.goto("/app/org/not-a-organization");
 
 		const mark = page.getByRole("link", { name: "Go to your organizations" });
@@ -59,14 +61,16 @@ test.describe("App routing", () => {
 		});
 	});
 
-	test("a pre-organization link lands on the same directory", async ({ page }) => {
+	test("a pre-organization link lands on the same directory", async ({ page, consoleErrors }) => {
+		consoleErrors.allow(failedResource(404, `/app/${TEST_BRAND_ID}/citations`));
 		await page.goto(`/app/${TEST_BRAND_ID}/citations`);
 
 		await expect(page.getByText("That page doesn't exist or moved.")).toBeVisible({ timeout: 30_000 });
 		await expect(page.locator(`a[href="${BRAND_URL}"]`).first()).toBeVisible();
 	});
 
-	test("a brand from another organization does not resolve under this one", async ({ page }) => {
+	test("a brand from another organization does not resolve under this one", async ({ page, consoleErrors }) => {
+		consoleErrors.allow(failedResource(404, brandUrl(NIKE_BRAND_ID)));
 		await page.goto(brandUrl(NIKE_BRAND_ID));
 		await expect(page.getByText("404 Not Found")).toBeVisible({ timeout: 30_000 });
 	});

--- a/e2e/tests/shared/citations.spec.ts
+++ b/e2e/tests/shared/citations.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "../../test";
 import { brandUrl } from "../../fixtures";
 
 const BRAND_URL = brandUrl();

--- a/e2e/tests/shared/og-image.spec.ts
+++ b/e2e/tests/shared/og-image.spec.ts
@@ -11,7 +11,7 @@
  * WASM bundling regression in the standalone Docker image fails CI here instead
  * of silently shipping blank social cards.
  */
-import { test, expect } from "@playwright/test";
+import { expect, test } from "../../test";
 
 // PNG files start with this 8-byte signature.
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);

--- a/e2e/tests/shared/organization-settings.spec.ts
+++ b/e2e/tests/shared/organization-settings.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "../../test";
 import { TEST_BRAND_ID, TEST_BRAND_NAME, TEST_ORG_SLUG } from "../../fixtures";
 
 test.describe("Organization settings", () => {

--- a/e2e/tests/shared/overview.spec.ts
+++ b/e2e/tests/shared/overview.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "../../test";
 import { brandUrl } from "../../fixtures";
 
 const BRAND_URL = brandUrl();

--- a/e2e/tests/shared/prompt-details.spec.ts
+++ b/e2e/tests/shared/prompt-details.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "../../test";
 import { brandUrl } from "../../fixtures";
 
 const BRAND_URL = brandUrl();

--- a/e2e/tests/shared/support-chat.spec.ts
+++ b/e2e/tests/shared/support-chat.spec.ts
@@ -5,13 +5,15 @@
  *
  * Requests to Crisp are aborted in the browser, so CI never reaches them.
  */
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../../test";
 import { TEST_BRAND_ID, brandUrl, isDeploymentMode } from "../../fixtures";
 
 const CRISP_HOSTS = "**://*.crisp.chat/**";
 
 test.describe("Support chat", () => {
-  test("loads on the deployments we operate, and only those", async ({ page }, testInfo) => {
+  test("loads on the deployments we operate, and only those", async ({ page, consoleErrors }, testInfo) => {
+    consoleErrors.allow(/Failed to load resource: net::ERR_FAILED.*crisp\.chat/);
+
     const mode = testInfo.project.name;
     if (!isDeploymentMode(mode)) {
       throw new Error(`Project "${testInfo.project.name}" does not name a deployment mode`);

--- a/e2e/tests/shared/visibility.spec.ts
+++ b/e2e/tests/shared/visibility.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "../../test";
 import { brandUrl } from "../../fixtures";
 
 const BRAND_URL = brandUrl();

--- a/e2e/tests/whitelabel/whitelabel-deployment.spec.ts
+++ b/e2e/tests/whitelabel/whitelabel-deployment.spec.ts
@@ -12,7 +12,7 @@
  * SSO round trip (the authenticated session is minted directly — see
  * e2e/session.ts).
  */
-import { expect, test } from "@playwright/test";
+import { expect, failedResource, test } from "../../test";
 import { TEST_BRAND_ID, WHITELABEL, brandUrl, organizationUrl } from "../../fixtures";
 
 const isIdpRequest = (url: URL) => url.host === WHITELABEL.auth0Domain;
@@ -147,7 +147,8 @@ test.describe("Whitelabel features", () => {
     await expect(page.getByRole("heading", { name: /reports/i }).first()).toBeVisible({ timeout: 30_000 });
   });
 
-  test("the team page is not offered and not reachable", async ({ page }) => {
+  test("the team page is not offered and not reachable", async ({ page, consoleErrors }) => {
+    consoleErrors.allow(failedResource(404, `${organizationUrl()}/settings/members`));
     await page.goto(`${organizationUrl()}/settings`);
     await expect(
       page.locator(`a[href="${organizationUrl()}/settings/members"][data-sidebar="menu-button"]`),

--- a/e2e/tests/worker.spec.ts
+++ b/e2e/tests/worker.spec.ts
@@ -13,7 +13,7 @@
  * self-healing scheduler can't re-enqueue the seeded prompts and mutate data
  * they assert on (see .github/workflows/e2e.yaml).
  */
-import { test, expect } from "@playwright/test";
+import { expect, test } from "../test";
 import pg from "pg";
 import { DATABASE_URL, TEST_API_KEY, TEST_BRAND_ID } from "../fixtures";
 


### PR DESCRIPTION
## Summary

A broken page announces itself in the console long before an assertion notices — an error boundary rendering for a frame, a request failing in the background. Every spec now imports a `test` that fails when the browser logs an error the spec didn't allow.

Errors a spec provokes on purpose are declared rather than ignored globally:

```ts
test.use({ allowedConsoleErrors: [/quota exceeded/] });   // file or describe

test("...", async ({ page, consoleErrors }) => {
  consoleErrors.allow(failedResource(404, "/reports"));   // this test only
});
```

`failedResource(status, url)` ties an allowance to the request it comes from, so allowing one refusal doesn't excuse every other refusal of that status on the page.

The listeners hang off a `context` override rather than the auto fixture, so specs that only take `request` (`worker.spec.ts`, `og-image.spec.ts`) don't build a browser context they never use.

Split out of #671.

## Verification

- `pnpm --filter e2e check-types`
- `pnpm exec playwright test --list` (225 tests, 17 files)
- Fixture behaviour checked against a scratch project: an unallowed `console.error` fails the test, an allowed one passes, and an API-only test builds no context.

Not run against a live stack — this workspace has no seeded database. CI will run it in all four deployment modes.