### PR TITLE
Move API keys under organization settings

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -59,6 +59,8 @@ function organizationGroup(organization: OrganizationSummary, features?: Feature
 		items.push({ title: "Billing", link: { to: "/app/org/$org/settings/billing", params }, icon: IconCreditCard });
 	}
 
+	items.push({ title: "API keys", link: { to: "/app/org/$org/settings/api-keys", params }, icon: IconKey });
+
 	return { label: "Organization Settings", items };
 }
 
@@ -100,11 +102,6 @@ function brandGroups(organization: OrganizationSummary, brand: BrandWithPrompts)
 					icon: IconListDetails,
 				},
 				{ title: "LLMs", link: { to: "/app/org/$org/brand/$brand/settings/llms", params }, icon: IconCpu },
-				{
-					title: "API keys",
-					link: { to: "/app/org/$org/brand/$brand/settings/api-keys", params },
-					icon: IconKey,
-				},
 			],
 		});
 	}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -67,6 +67,7 @@ import { Route as ApiV1OrganizationsOrganizationIdBillingRouteImport } from './r
 import { Route as ApiV1PromptsPromptIdSnapshotRouteImport } from './routes/api/v1/prompts/$promptId/snapshot'
 import { Route as AuthedAppOrgOrgBrandBrandRouteImport } from './routes/_authed/app/org/$org/brand/$brand'
 import { Route as AuthedAppOrgOrgSettingsIndexRouteImport } from './routes/_authed/app/org/$org/settings/index'
+import { Route as AuthedAppOrgOrgSettingsApiKeysRouteImport } from './routes/_authed/app/org/$org/settings/api-keys'
 import { Route as AuthedAppOrgOrgSettingsBillingRouteImport } from './routes/_authed/app/org/$org/settings/billing'
 import { Route as AuthedAppOrgOrgSettingsBrandsRouteImport } from './routes/_authed/app/org/$org/settings/brands'
 import { Route as AuthedAppOrgOrgSettingsMembersRouteImport } from './routes/_authed/app/org/$org/settings/members'
@@ -86,7 +87,6 @@ import { Route as AuthedAppOrgOrgBrandBrandPromptsIndexRouteImport } from './rou
 import { Route as AuthedAppOrgOrgBrandBrandPromptsPromptIdRouteImport } from './routes/_authed/app/org/$org/brand/$brand/prompts/$promptId'
 import { Route as AuthedAppOrgOrgBrandBrandPromptsEditRouteImport } from './routes/_authed/app/org/$org/brand/$brand/prompts/edit'
 import { Route as AuthedAppOrgOrgBrandBrandSettingsIndexRouteImport } from './routes/_authed/app/org/$org/brand/$brand/settings/index'
-import { Route as AuthedAppOrgOrgBrandBrandSettingsApiKeysRouteImport } from './routes/_authed/app/org/$org/brand/$brand/settings/api-keys'
 import { Route as AuthedAppOrgOrgBrandBrandSettingsBrandRouteImport } from './routes/_authed/app/org/$org/brand/$brand/settings/brand'
 import { Route as AuthedAppOrgOrgBrandBrandSettingsCompetitorsRouteImport } from './routes/_authed/app/org/$org/brand/$brand/settings/competitors'
 import { Route as AuthedAppOrgOrgBrandBrandSettingsLlmsRouteImport } from './routes/_authed/app/org/$org/brand/$brand/settings/llms'
@@ -398,6 +398,12 @@ const AuthedAppOrgOrgSettingsIndexRoute =
     path: '/',
     getParentRoute: () => AuthedAppOrgOrgSettingsRoute,
   } as any)
+const AuthedAppOrgOrgSettingsApiKeysRoute =
+  AuthedAppOrgOrgSettingsApiKeysRouteImport.update({
+    id: '/api-keys',
+    path: '/api-keys',
+    getParentRoute: () => AuthedAppOrgOrgSettingsRoute,
+  } as any)
 const AuthedAppOrgOrgSettingsBillingRoute =
   AuthedAppOrgOrgSettingsBillingRouteImport.update({
     id: '/billing',
@@ -512,12 +518,6 @@ const AuthedAppOrgOrgBrandBrandSettingsIndexRoute =
     path: '/settings/',
     getParentRoute: () => AuthedAppOrgOrgBrandBrandRoute,
   } as any)
-const AuthedAppOrgOrgBrandBrandSettingsApiKeysRoute =
-  AuthedAppOrgOrgBrandBrandSettingsApiKeysRouteImport.update({
-    id: '/settings/api-keys',
-    path: '/settings/api-keys',
-    getParentRoute: () => AuthedAppOrgOrgBrandBrandRoute,
-  } as any)
 const AuthedAppOrgOrgBrandBrandSettingsBrandRoute =
   AuthedAppOrgOrgBrandBrandSettingsBrandRouteImport.update({
     id: '/settings/brand',
@@ -600,6 +600,7 @@ export interface FileRoutesByFullPath {
   '/app/org/$org/': typeof AuthedAppOrgOrgIndexRoute
   '/api/plausible/js/script/': typeof ApiPlausibleJsScriptIndexRoute
   '/app/org/$org/brand/$brand': typeof AuthedAppOrgOrgBrandBrandRouteWithChildren
+  '/app/org/$org/settings/api-keys': typeof AuthedAppOrgOrgSettingsApiKeysRoute
   '/app/org/$org/settings/billing': typeof AuthedAppOrgOrgSettingsBillingRoute
   '/app/org/$org/settings/brands': typeof AuthedAppOrgOrgSettingsBrandsRoute
   '/app/org/$org/settings/members': typeof AuthedAppOrgOrgSettingsMembersRoute
@@ -618,7 +619,6 @@ export interface FileRoutesByFullPath {
   '/app/org/$org/brand/$brand/': typeof AuthedAppOrgOrgBrandBrandIndexRoute
   '/app/org/$org/brand/$brand/prompts/$promptId': typeof AuthedAppOrgOrgBrandBrandPromptsPromptIdRoute
   '/app/org/$org/brand/$brand/prompts/edit': typeof AuthedAppOrgOrgBrandBrandPromptsEditRoute
-  '/app/org/$org/brand/$brand/settings/api-keys': typeof AuthedAppOrgOrgBrandBrandSettingsApiKeysRoute
   '/app/org/$org/brand/$brand/settings/brand': typeof AuthedAppOrgOrgBrandBrandSettingsBrandRoute
   '/app/org/$org/brand/$brand/settings/competitors': typeof AuthedAppOrgOrgBrandBrandSettingsCompetitorsRoute
   '/app/org/$org/brand/$brand/settings/llms': typeof AuthedAppOrgOrgBrandBrandSettingsLlmsRoute
@@ -677,6 +677,7 @@ export interface FileRoutesByTo {
   '/api/v1/prompts/$promptId/snapshot': typeof ApiV1PromptsPromptIdSnapshotRoute
   '/app/org/$org': typeof AuthedAppOrgOrgIndexRoute
   '/api/plausible/js/script': typeof ApiPlausibleJsScriptIndexRoute
+  '/app/org/$org/settings/api-keys': typeof AuthedAppOrgOrgSettingsApiKeysRoute
   '/app/org/$org/settings/billing': typeof AuthedAppOrgOrgSettingsBillingRoute
   '/app/org/$org/settings/brands': typeof AuthedAppOrgOrgSettingsBrandsRoute
   '/app/org/$org/settings/members': typeof AuthedAppOrgOrgSettingsMembersRoute
@@ -695,7 +696,6 @@ export interface FileRoutesByTo {
   '/app/org/$org/brand/$brand': typeof AuthedAppOrgOrgBrandBrandIndexRoute
   '/app/org/$org/brand/$brand/prompts/$promptId': typeof AuthedAppOrgOrgBrandBrandPromptsPromptIdRoute
   '/app/org/$org/brand/$brand/prompts/edit': typeof AuthedAppOrgOrgBrandBrandPromptsEditRoute
-  '/app/org/$org/brand/$brand/settings/api-keys': typeof AuthedAppOrgOrgBrandBrandSettingsApiKeysRoute
   '/app/org/$org/brand/$brand/settings/brand': typeof AuthedAppOrgOrgBrandBrandSettingsBrandRoute
   '/app/org/$org/brand/$brand/settings/competitors': typeof AuthedAppOrgOrgBrandBrandSettingsCompetitorsRoute
   '/app/org/$org/brand/$brand/settings/llms': typeof AuthedAppOrgOrgBrandBrandSettingsLlmsRoute
@@ -762,6 +762,7 @@ export interface FileRoutesById {
   '/_authed/app/org/$org/': typeof AuthedAppOrgOrgIndexRoute
   '/api/plausible/js/script/': typeof ApiPlausibleJsScriptIndexRoute
   '/_authed/app/org/$org/brand/$brand': typeof AuthedAppOrgOrgBrandBrandRouteWithChildren
+  '/_authed/app/org/$org/settings/api-keys': typeof AuthedAppOrgOrgSettingsApiKeysRoute
   '/_authed/app/org/$org/settings/billing': typeof AuthedAppOrgOrgSettingsBillingRoute
   '/_authed/app/org/$org/settings/brands': typeof AuthedAppOrgOrgSettingsBrandsRoute
   '/_authed/app/org/$org/settings/members': typeof AuthedAppOrgOrgSettingsMembersRoute
@@ -780,7 +781,6 @@ export interface FileRoutesById {
   '/_authed/app/org/$org/brand/$brand/': typeof AuthedAppOrgOrgBrandBrandIndexRoute
   '/_authed/app/org/$org/brand/$brand/prompts/$promptId': typeof AuthedAppOrgOrgBrandBrandPromptsPromptIdRoute
   '/_authed/app/org/$org/brand/$brand/prompts/edit': typeof AuthedAppOrgOrgBrandBrandPromptsEditRoute
-  '/_authed/app/org/$org/brand/$brand/settings/api-keys': typeof AuthedAppOrgOrgBrandBrandSettingsApiKeysRoute
   '/_authed/app/org/$org/brand/$brand/settings/brand': typeof AuthedAppOrgOrgBrandBrandSettingsBrandRoute
   '/_authed/app/org/$org/brand/$brand/settings/competitors': typeof AuthedAppOrgOrgBrandBrandSettingsCompetitorsRoute
   '/_authed/app/org/$org/brand/$brand/settings/llms': typeof AuthedAppOrgOrgBrandBrandSettingsLlmsRoute
@@ -847,6 +847,7 @@ export interface FileRouteTypes {
     | '/app/org/$org/'
     | '/api/plausible/js/script/'
     | '/app/org/$org/brand/$brand'
+    | '/app/org/$org/settings/api-keys'
     | '/app/org/$org/settings/billing'
     | '/app/org/$org/settings/brands'
     | '/app/org/$org/settings/members'
@@ -865,7 +866,6 @@ export interface FileRouteTypes {
     | '/app/org/$org/brand/$brand/'
     | '/app/org/$org/brand/$brand/prompts/$promptId'
     | '/app/org/$org/brand/$brand/prompts/edit'
-    | '/app/org/$org/brand/$brand/settings/api-keys'
     | '/app/org/$org/brand/$brand/settings/brand'
     | '/app/org/$org/brand/$brand/settings/competitors'
     | '/app/org/$org/brand/$brand/settings/llms'
@@ -924,6 +924,7 @@ export interface FileRouteTypes {
     | '/api/v1/prompts/$promptId/snapshot'
     | '/app/org/$org'
     | '/api/plausible/js/script'
+    | '/app/org/$org/settings/api-keys'
     | '/app/org/$org/settings/billing'
     | '/app/org/$org/settings/brands'
     | '/app/org/$org/settings/members'
@@ -942,7 +943,6 @@ export interface FileRouteTypes {
     | '/app/org/$org/brand/$brand'
     | '/app/org/$org/brand/$brand/prompts/$promptId'
     | '/app/org/$org/brand/$brand/prompts/edit'
-    | '/app/org/$org/brand/$brand/settings/api-keys'
     | '/app/org/$org/brand/$brand/settings/brand'
     | '/app/org/$org/brand/$brand/settings/competitors'
     | '/app/org/$org/brand/$brand/settings/llms'
@@ -1008,6 +1008,7 @@ export interface FileRouteTypes {
     | '/_authed/app/org/$org/'
     | '/api/plausible/js/script/'
     | '/_authed/app/org/$org/brand/$brand'
+    | '/_authed/app/org/$org/settings/api-keys'
     | '/_authed/app/org/$org/settings/billing'
     | '/_authed/app/org/$org/settings/brands'
     | '/_authed/app/org/$org/settings/members'
@@ -1026,7 +1027,6 @@ export interface FileRouteTypes {
     | '/_authed/app/org/$org/brand/$brand/'
     | '/_authed/app/org/$org/brand/$brand/prompts/$promptId'
     | '/_authed/app/org/$org/brand/$brand/prompts/edit'
-    | '/_authed/app/org/$org/brand/$brand/settings/api-keys'
     | '/_authed/app/org/$org/brand/$brand/settings/brand'
     | '/_authed/app/org/$org/brand/$brand/settings/competitors'
     | '/_authed/app/org/$org/brand/$brand/settings/llms'
@@ -1480,6 +1480,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedAppOrgOrgSettingsIndexRouteImport
       parentRoute: typeof AuthedAppOrgOrgSettingsRoute
     }
+    '/_authed/app/org/$org/settings/api-keys': {
+      id: '/_authed/app/org/$org/settings/api-keys'
+      path: '/api-keys'
+      fullPath: '/app/org/$org/settings/api-keys'
+      preLoaderRoute: typeof AuthedAppOrgOrgSettingsApiKeysRouteImport
+      parentRoute: typeof AuthedAppOrgOrgSettingsRoute
+    }
     '/_authed/app/org/$org/settings/billing': {
       id: '/_authed/app/org/$org/settings/billing'
       path: '/billing'
@@ -1613,13 +1620,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedAppOrgOrgBrandBrandSettingsIndexRouteImport
       parentRoute: typeof AuthedAppOrgOrgBrandBrandRoute
     }
-    '/_authed/app/org/$org/brand/$brand/settings/api-keys': {
-      id: '/_authed/app/org/$org/brand/$brand/settings/api-keys'
-      path: '/settings/api-keys'
-      fullPath: '/app/org/$org/brand/$brand/settings/api-keys'
-      preLoaderRoute: typeof AuthedAppOrgOrgBrandBrandSettingsApiKeysRouteImport
-      parentRoute: typeof AuthedAppOrgOrgBrandBrandRoute
-    }
     '/_authed/app/org/$org/brand/$brand/settings/brand': {
       id: '/_authed/app/org/$org/brand/$brand/settings/brand'
       path: '/settings/brand'
@@ -1668,6 +1668,7 @@ const AuthedAdminRouteWithChildren = AuthedAdminRoute._addFileChildren(
 )
 
 interface AuthedAppOrgOrgSettingsRouteChildren {
+  AuthedAppOrgOrgSettingsApiKeysRoute: typeof AuthedAppOrgOrgSettingsApiKeysRoute
   AuthedAppOrgOrgSettingsBillingRoute: typeof AuthedAppOrgOrgSettingsBillingRoute
   AuthedAppOrgOrgSettingsBrandsRoute: typeof AuthedAppOrgOrgSettingsBrandsRoute
   AuthedAppOrgOrgSettingsMembersRoute: typeof AuthedAppOrgOrgSettingsMembersRoute
@@ -1676,6 +1677,7 @@ interface AuthedAppOrgOrgSettingsRouteChildren {
 
 const AuthedAppOrgOrgSettingsRouteChildren: AuthedAppOrgOrgSettingsRouteChildren =
   {
+    AuthedAppOrgOrgSettingsApiKeysRoute: AuthedAppOrgOrgSettingsApiKeysRoute,
     AuthedAppOrgOrgSettingsBillingRoute: AuthedAppOrgOrgSettingsBillingRoute,
     AuthedAppOrgOrgSettingsBrandsRoute: AuthedAppOrgOrgSettingsBrandsRoute,
     AuthedAppOrgOrgSettingsMembersRoute: AuthedAppOrgOrgSettingsMembersRoute,
@@ -1697,7 +1699,6 @@ interface AuthedAppOrgOrgBrandBrandRouteChildren {
   AuthedAppOrgOrgBrandBrandIndexRoute: typeof AuthedAppOrgOrgBrandBrandIndexRoute
   AuthedAppOrgOrgBrandBrandPromptsPromptIdRoute: typeof AuthedAppOrgOrgBrandBrandPromptsPromptIdRoute
   AuthedAppOrgOrgBrandBrandPromptsEditRoute: typeof AuthedAppOrgOrgBrandBrandPromptsEditRoute
-  AuthedAppOrgOrgBrandBrandSettingsApiKeysRoute: typeof AuthedAppOrgOrgBrandBrandSettingsApiKeysRoute
   AuthedAppOrgOrgBrandBrandSettingsBrandRoute: typeof AuthedAppOrgOrgBrandBrandSettingsBrandRoute
   AuthedAppOrgOrgBrandBrandSettingsCompetitorsRoute: typeof AuthedAppOrgOrgBrandBrandSettingsCompetitorsRoute
   AuthedAppOrgOrgBrandBrandSettingsLlmsRoute: typeof AuthedAppOrgOrgBrandBrandSettingsLlmsRoute
@@ -1724,8 +1725,6 @@ const AuthedAppOrgOrgBrandBrandRouteChildren: AuthedAppOrgOrgBrandBrandRouteChil
       AuthedAppOrgOrgBrandBrandPromptsPromptIdRoute,
     AuthedAppOrgOrgBrandBrandPromptsEditRoute:
       AuthedAppOrgOrgBrandBrandPromptsEditRoute,
-    AuthedAppOrgOrgBrandBrandSettingsApiKeysRoute:
-      AuthedAppOrgOrgBrandBrandSettingsApiKeysRoute,
     AuthedAppOrgOrgBrandBrandSettingsBrandRoute:
       AuthedAppOrgOrgBrandBrandSettingsBrandRoute,
     AuthedAppOrgOrgBrandBrandSettingsCompetitorsRoute:

--- a/apps/web/src/routes/_authed/app/org/$org/settings/api-keys.tsx
+++ b/apps/web/src/routes/_authed/app/org/$org/settings/api-keys.tsx
@@ -17,10 +17,11 @@ import { trackEvent } from "@/lib/posthog";
 import { pageHead } from "@/lib/route-head";
 import { type ApiKeysPageData, createApiKeyFn, listApiKeysFn, revokeApiKeyFn } from "@/server/api-keys";
 
-export const Route = createFileRoute("/_authed/app/org/$org/brand/$brand/settings/api-keys")({
-	loader: async ({ params }): Promise<ApiKeysPageData> => listApiKeysFn({ data: { brandId: params.brand } }),
+export const Route = createFileRoute("/_authed/app/org/$org/settings/api-keys")({
+	loader: ({ context }): Promise<ApiKeysPageData> =>
+		listApiKeysFn({ data: { organizationId: context.organization.id } }),
 	staticData: { crumb: "API keys" },
-	head: pageHead({ description: "Issue and revoke API keys for this workspace." }),
+	head: pageHead({ description: "Issue and revoke API keys for this organization." }),
 	component: ApiKeysSettingsPage,
 });
 
@@ -42,8 +43,8 @@ function scopeGroups(scopes: readonly ApiScope[]): Map<string, ApiScope[]> {
 }
 
 function ApiKeysSettingsPage() {
-	const { brand: brandId } = Route.useParams();
 	const { keys, brands, allScopes, expiryOptions, canManage, organization } = Route.useLoaderData();
+	const organizationId = organization.id;
 	const router = useRouter();
 
 	const [name, setName] = useState("");
@@ -69,7 +70,7 @@ function ApiKeysSettingsPage() {
 		try {
 			const { key } = await createApiKeyFn({
 				data: {
-					brandId,
+					organizationId,
 					name,
 					scopes,
 					// Null, not `[]`: unrestricted is the absence of a restriction. The
@@ -97,7 +98,7 @@ function ApiKeysSettingsPage() {
 		setError(null);
 		setRevoking(keyId);
 		try {
-			await revokeApiKeyFn({ data: { brandId, keyId } });
+			await revokeApiKeyFn({ data: { organizationId, keyId } });
 			await router.invalidate();
 		} catch (err) {
 			setError(err instanceof Error ? err.message : "Failed to revoke the API key");
@@ -113,8 +114,8 @@ function ApiKeysSettingsPage() {
 			<div>
 				<h1 className="text-3xl font-bold">API keys</h1>
 				<p className="text-muted-foreground">
-					Keys act as {organization.name}, not as you, so they keep working after you change teams. Any workspace admin
-					can revoke one.
+					Keys act as {organization.name}, not as you, so they keep working after you change teams. Any organization
+					admin can revoke one.
 				</p>
 			</div>
 
@@ -268,7 +269,7 @@ function ApiKeysSettingsPage() {
 									<p className="text-sm text-muted-foreground">
 										{key.brandIds
 											? `Limited to ${key.brandIds.map((id) => brandNames.get(id) ?? id).join(", ")}`
-											: "All brands in this workspace"}{" "}
+											: "All brands in this organization"}{" "}
 										· created {formatDate(key.createdAt)} · last used {formatDate(key.lastUsedAt)}
 										{key.expiresAt ? ` · expires ${formatDate(key.expiresAt)}` : ""}
 									</p>

--- a/apps/web/src/server/api-keys.ts
+++ b/apps/web/src/server/api-keys.ts
@@ -1,7 +1,7 @@
 /**
  * The only way to mint a key; the plugin's HTTP endpoints are blocked. This is
  * where the brand narrowing, which lives in client-writable `metadata`, is
- * checked against the workspace's own brands.
+ * checked against the organization's own brands.
  */
 import { createServerFn } from "@tanstack/react-start";
 import { getRequestHeaders } from "@tanstack/react-start/server";
@@ -12,7 +12,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { API_SCOPES, type ApiScope, permissionsToScopes, scopesToPermissions } from "@/lib/api/scopes";
 import { readBrandRestriction } from "@/lib/auth/api-auth";
-import { requireAuthSession, requireBrandOrganization } from "@/lib/auth/helpers";
+import { requireAuthSession, requireOrganization } from "@/lib/auth/helpers";
 import { auth } from "@/lib/auth/server";
 
 const EXPIRY_DAYS = [30, 90, 180, 365] as const;
@@ -63,22 +63,22 @@ function summarize(key: StoredApiKey): ApiKeySummary {
 	};
 }
 
-async function requireWorkspace(brandId: string) {
+async function requireKeyAccess(organizationId: string) {
 	const session = await requireAuthSession();
-	const org = await requireBrandOrganization(session.user.id, brandId);
+	const org = await requireOrganization(session.user.id, organizationId);
 	return { session, org, canManage: isOrgAdminRole(org.role) };
 }
 
 function requireManager(canManage: boolean): void {
-	if (!canManage) throw new Error("Only workspace admins can manage API keys");
+	if (!canManage) throw new Error("Only organization admins can manage API keys");
 }
 
 export const listApiKeysFn = createServerFn({ method: "GET" })
-	.validator(z.object({ brandId: z.string() }))
+	.validator(z.object({ organizationId: z.string() }))
 	.handler(async ({ data }): Promise<ApiKeysPageData> => {
-		const { org, canManage } = await requireWorkspace(data.brandId);
+		const { org, canManage } = await requireKeyAccess(data.organizationId);
 
-		const [keys, workspaceBrands] = await Promise.all([
+		const [keys, organizationBrands] = await Promise.all([
 			auth.api.listApiKeys({ query: { organizationId: org.id }, headers: getRequestHeaders() }),
 			db
 				.select({ id: brands.id, name: brands.name })
@@ -91,14 +91,14 @@ export const listApiKeysFn = createServerFn({ method: "GET" })
 			organization: org,
 			canManage,
 			keys: keys.apiKeys.map(summarize),
-			brands: workspaceBrands,
+			brands: organizationBrands,
 			allScopes: API_SCOPES,
 			expiryOptions: EXPIRY_DAYS,
 		};
 	});
 
 const createInput = z.object({
-	brandId: z.string(),
+	organizationId: z.string(),
 	name: z.string().trim().min(1, "Give the key a name"),
 	scopes: z.array(z.enum(API_SCOPES)).min(1, "Choose at least one scope"),
 	/** Null is every brand; `[]` is rejected rather than read as "all", which is
@@ -119,7 +119,7 @@ const createInput = z.object({
 export const createApiKeyFn = createServerFn({ method: "POST" })
 	.validator(createInput)
 	.handler(async ({ data }): Promise<{ key: string; summary: ApiKeySummary }> => {
-		const { session, org, canManage } = await requireWorkspace(data.brandId);
+		const { session, org, canManage } = await requireKeyAccess(data.organizationId);
 		requireManager(canManage);
 
 		if (data.brandIds) {
@@ -127,7 +127,7 @@ export const createApiKeyFn = createServerFn({ method: "POST" })
 				(await db.select({ id: brands.id }).from(brands).where(eq(brands.organizationId, org.id))).map((row) => row.id),
 			);
 			const stray = data.brandIds.find((id) => !owned.has(id));
-			if (stray) throw new Error(`"${stray}" is not a brand in this workspace`);
+			if (stray) throw new Error(`"${stray}" is not a brand in this organization`);
 		}
 
 		// No `headers`: the plugin refuses to set `permissions` for a request
@@ -149,9 +149,9 @@ export const createApiKeyFn = createServerFn({ method: "POST" })
 	});
 
 export const revokeApiKeyFn = createServerFn({ method: "POST" })
-	.validator(z.object({ brandId: z.string(), keyId: z.string() }))
+	.validator(z.object({ organizationId: z.string(), keyId: z.string() }))
 	.handler(async ({ data }): Promise<{ revoked: true }> => {
-		const { org, canManage } = await requireWorkspace(data.brandId);
+		const { org, canManage } = await requireKeyAccess(data.organizationId);
 		requireManager(canManage);
 
 		// The id arrives from the browser and the plugin's delete trusts it.
@@ -160,7 +160,7 @@ export const revokeApiKeyFn = createServerFn({ method: "POST" })
 			headers: getRequestHeaders(),
 		});
 		if (!keys.apiKeys.some((key) => key.id === data.keyId)) {
-			throw new Error("API key not found in this workspace");
+			throw new Error("API key not found in this organization");
 		}
 
 		await auth.api.deleteApiKey({ body: { keyId: data.keyId }, headers: getRequestHeaders() });

--- a/e2e/tests/shared/api-keys.spec.ts
+++ b/e2e/tests/shared/api-keys.spec.ts
@@ -3,9 +3,9 @@
  * table, which says nothing about whether the product can mint one.
  */
 import { expect, test } from "../../test";
-import { NIKE_BRAND_ID, TEST_BRAND_ID, brandUrl } from "../../fixtures";
+import { NIKE_BRAND_ID, TEST_BRAND_ID, organizationUrl } from "../../fixtures";
 
-const KEYS_PAGE = `${brandUrl()}/settings/api-keys`;
+const KEYS_PAGE = `${organizationUrl()}/settings/api-keys`;
 
 type Page = import("@playwright/test").Page;
 


### PR DESCRIPTION
API keys are minted for an organization and can span every brand in it, but the page that issues them lived under brand settings — both in the URL and in the sidebar. It now sits where its scope actually is.

- `/app/org/$org/brand/$brand/settings/api-keys` → `/app/org/$org/settings/api-keys`
- Sidebar entry moved from the brand **Settings** group to **Organization Settings**, after Billing
- The server functions take an `organizationId` instead of a `brandId`, so the org is resolved directly rather than through a brand that was only ever a proxy for it

No changeset.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/57c5aa2e-7651-47b6-b3b1-9194fc623560)
