### PR TITLE
Open the app root on sign-up or sign-in

### DIFF
--- a/.changeset/app-root-opens-on-auth.md
+++ b/.changeset/app-root-opens-on-auth.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Opening the app URL now goes straight to sign-up or sign-in instead of a page with a single Sign In button on it.

--- a/.changeset/app-root-opens-on-auth.md
+++ b/.changeset/app-root-opens-on-auth.md
@@ -1,5 +1,0 @@
----
-"@workspace/web": patch
----
-
-Opening the app URL now goes straight to sign-up or sign-in instead of a page with a single Sign In button on it.

--- a/apps/web/src/lib/__tests__/entry-route.test.ts
+++ b/apps/web/src/lib/__tests__/entry-route.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { entryRouteForVisitor } from "@/lib/entry-route";
+
+describe("entryRouteForVisitor", () => {
+	it("opens cloud on sign-up, whether or not the instance has accounts", () => {
+		expect(entryRouteForVisitor({ mode: "cloud", canRegister: true, hasUsers: false })).toBe("/auth/register");
+		expect(entryRouteForVisitor({ mode: "cloud", canRegister: true, hasUsers: true })).toBe("/auth/register");
+	});
+
+	it("opens an unbootstrapped local instance on sign-up and a bootstrapped one on sign-in", () => {
+		expect(entryRouteForVisitor({ mode: "local", canRegister: true, hasUsers: false })).toBe("/auth/register");
+		expect(entryRouteForVisitor({ mode: "local", canRegister: false, hasUsers: true })).toBe("/auth/login");
+	});
+
+	it("opens demo on sign-in", () => {
+		expect(entryRouteForVisitor({ mode: "demo", canRegister: false, hasUsers: true })).toBe("/auth/login");
+	});
+
+	it("leaves whitelabel on the home page rather than starting an SSO round trip", () => {
+		expect(entryRouteForVisitor({ mode: "whitelabel", canRegister: false, hasUsers: true })).toBeNull();
+	});
+
+	it("leaves the home page up when the deployment config has not loaded", () => {
+		expect(entryRouteForVisitor(undefined)).toBeNull();
+	});
+});

--- a/apps/web/src/lib/entry-route.ts
+++ b/apps/web/src/lib/entry-route.ts
@@ -1,0 +1,34 @@
+import type { DeploymentMode } from "@workspace/config/types";
+
+/** The auth pages a visitor can be sent to from the bare app URL. */
+export type EntryRoute = "/auth/login" | "/auth/register";
+
+interface EntryConfig {
+	mode: DeploymentMode;
+	canRegister: boolean;
+	hasUsers: boolean;
+}
+
+/**
+ * Where a signed-out visitor to `/` belongs, or null to leave them on the home
+ * page.
+ *
+ * The bare app URL is typed and linked to, so it should open the thing the
+ * visitor came for rather than a card with one button on it. Which page that
+ * is depends on what the deployment is for:
+ *
+ * - cloud sells accounts, so sign-up — it carries the pitch, and it is where
+ *   the marketing site points anyone who wants to buy
+ * - local is one operator's instance: sign-in, or sign-up while the single
+ *   account it will ever hold has yet to be created
+ * - demo puts the shared credentials on sign-in, ready to submit
+ *
+ * Whitelabel is the exception. Its sign-in page hands off to the partner's
+ * identity provider the moment it renders, so redirecting there would start an
+ * SSO round trip nobody asked for — the visitor clicks first.
+ */
+export function entryRouteForVisitor(config: EntryConfig | undefined): EntryRoute | null {
+	if (!config || config.mode === "whitelabel") return null;
+	if (config.canRegister && (config.mode === "cloud" || !config.hasUsers)) return "/auth/register";
+	return "/auth/login";
+}

--- a/apps/web/src/lib/entry-route.ts
+++ b/apps/web/src/lib/entry-route.ts
@@ -1,6 +1,5 @@
 import type { DeploymentMode } from "@workspace/config/types";
 
-/** The auth pages a visitor can be sent to from the bare app URL. */
 export type EntryRoute = "/auth/login" | "/auth/register";
 
 interface EntryConfig {
@@ -9,24 +8,6 @@ interface EntryConfig {
 	hasUsers: boolean;
 }
 
-/**
- * Where a signed-out visitor to `/` belongs, or null to leave them on the home
- * page.
- *
- * The bare app URL is typed and linked to, so it should open the thing the
- * visitor came for rather than a card with one button on it. Which page that
- * is depends on what the deployment is for:
- *
- * - cloud sells accounts, so sign-up — it carries the pitch, and it is where
- *   the marketing site points anyone who wants to buy
- * - local is one operator's instance: sign-in, or sign-up while the single
- *   account it will ever hold has yet to be created
- * - demo puts the shared credentials on sign-in, ready to submit
- *
- * Whitelabel is the exception. Its sign-in page hands off to the partner's
- * identity provider the moment it renders, so redirecting there would start an
- * SSO round trip nobody asked for — the visitor clicks first.
- */
 export function entryRouteForVisitor(config: EntryConfig | undefined): EntryRoute | null {
 	if (!config || config.mode === "whitelabel") return null;
 	if (config.canRegister && (config.mode === "cloud" || !config.hasUsers)) return "/auth/register";

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,23 +1,26 @@
 /**
  * Home page - / route
  *
- * Redirects authenticated users to /app.
- * In demo mode, auto-redirects unauthenticated users to /auth/login
- * (the login page pre-fills the demo credentials, so the bare home page
- * is just a redundant extra click).
- * On a fresh deployment that needs bootstrapping (registration is open
- * AND no users exist yet), redirects to /auth/register so the first
- * visitor sees the signup screen instead of an empty-database login form.
- * Shows sign-in for unauthenticated users in other modes.
+ * Sends authenticated visitors to /app and everyone else straight to the auth
+ * page their deployment opens on (see entryRouteForVisitor), so the bare app
+ * URL is never a card with a single button on it. Whitelabel, the one mode
+ * with no such page, still gets the card.
  */
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { buttonVariants } from "@workspace/ui/components/button";
 import FullPageCard from "@/components/full-page-card";
 import { getSession } from "@/lib/auth/session";
+import { entryRouteForVisitor } from "@/lib/entry-route";
 
 export const Route = createFileRoute("/")({
 	validateSearch: (search: Record<string, unknown>) => ({
 		redirect: typeof search.redirect === "string" ? search.redirect : undefined,
+		/**
+		 * Attribution tag carried by links back to us (see
+		 * @workspace/config/referrals). Passed along so a click that lands on the
+		 * bare app URL is still credited once we bounce it to sign-up.
+		 */
+		ref: typeof search.ref === "string" ? search.ref : undefined,
 	}),
 	beforeLoad: async ({ context, search }) => {
 		const session = await getSession();
@@ -26,17 +29,14 @@ export const Route = createFileRoute("/")({
 			throw redirect({ to: "/app" });
 		}
 
-		if (context.clientConfig?.mode === "demo") {
+		const entryRoute = entryRouteForVisitor(context.clientConfig);
+		if (entryRoute) {
 			throw redirect({
-				to: "/auth/login",
-				search: search.redirect ? { returnTo: search.redirect } : {},
-			});
-		}
-
-		if (context.clientConfig?.canRegister && !context.clientConfig?.hasUsers) {
-			throw redirect({
-				to: "/auth/register",
-				search: search.redirect ? { returnTo: search.redirect } : {},
+				to: entryRoute,
+				search: {
+					...(search.redirect ? { returnTo: search.redirect } : {}),
+					...(search.ref ? { ref: search.ref } : {}),
+				},
 			});
 		}
 

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,11 +1,3 @@
-/**
- * Home page - / route
- *
- * Sends authenticated visitors to /app and everyone else straight to the auth
- * page their deployment opens on (see entryRouteForVisitor), so the bare app
- * URL is never a card with a single button on it. Whitelabel, the one mode
- * with no such page, still gets the card.
- */
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { buttonVariants } from "@workspace/ui/components/button";
 import FullPageCard from "@/components/full-page-card";
@@ -15,11 +7,6 @@ import { entryRouteForVisitor } from "@/lib/entry-route";
 export const Route = createFileRoute("/")({
 	validateSearch: (search: Record<string, unknown>) => ({
 		redirect: typeof search.redirect === "string" ? search.redirect : undefined,
-		/**
-		 * Attribution tag carried by links back to us (see
-		 * @workspace/config/referrals). Passed along so a click that lands on the
-		 * bare app URL is still credited once we bounce it to sign-up.
-		 */
 		ref: typeof search.ref === "string" ? search.ref : undefined,
 	}),
 	beforeLoad: async ({ context, search }) => {

--- a/e2e/tests/cloud/cloud-deployment.spec.ts
+++ b/e2e/tests/cloud/cloud-deployment.spec.ts
@@ -42,6 +42,12 @@ test.describe("Cloud self-serve signup", () => {
     await expect(page.getByRole("link", { name: /create one/i })).toBeVisible();
   });
 
+  test("the bare app URL opens on sign-up, keeping the referral tag", async ({ page }) => {
+    await page.goto("/?ref=marketing-cta");
+    await page.waitForURL(/\/auth\/register\?.*ref=marketing-cta/, { timeout: 30_000 });
+    await expect(page.getByRole("button", { name: "Create account" })).toBeVisible({ timeout: 30_000 });
+  });
+
   test("registering asks the new account to verify its email", async ({ page }) => {
     await page.goto("/auth/register");
     await expect(page.getByRole("button", { name: /continue with google/i })).toBeVisible({ timeout: 30_000 });

--- a/e2e/tests/demo/demo-deployment.spec.ts
+++ b/e2e/tests/demo/demo-deployment.spec.ts
@@ -154,6 +154,12 @@ test.describe("Demo auth is sign-in only", () => {
     await page.goto("/auth/register");
     await page.waitForURL(/\/auth\/login/, { timeout: 30_000 });
   });
+
+  test("the bare app URL opens on sign-in", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForURL(/\/auth\/login/, { timeout: 30_000 });
+    await expect(page.getByText("Demo Account")).toBeVisible({ timeout: 30_000 });
+  });
 });
 
 test.describe("Demo features", () => {

--- a/e2e/tests/local/local-deployment.spec.ts
+++ b/e2e/tests/local/local-deployment.spec.ts
@@ -37,6 +37,12 @@ test.describe("Local signup is closed after bootstrap", () => {
     await page.waitForURL(/\/auth\/login/, { timeout: 30_000 });
   });
 
+  test("the bare app URL opens on sign-in once an account exists", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForURL(/\/auth\/login/, { timeout: 30_000 });
+    await expect(page.getByLabel("Email")).toBeVisible({ timeout: 30_000 });
+  });
+
   test("sign in is email and password, with no cloud provider options", async ({ page }) => {
     await page.goto("/auth/login");
     await expect(page.getByLabel("Email")).toBeVisible({ timeout: 30_000 });

--- a/e2e/tests/whitelabel/whitelabel-deployment.spec.ts
+++ b/e2e/tests/whitelabel/whitelabel-deployment.spec.ts
@@ -45,6 +45,18 @@ test.describe("Whitelabel sign-in is SSO only", () => {
     expect(authorizeUrl.searchParams.get("redirect_uri")).toContain("/api/auth/sso/callback/auth0-whitelabel");
   });
 
+  test("the bare app URL waits for a click rather than starting SSO", async ({ page }) => {
+    const authorizeRequests: string[] = [];
+    await page.route(isIdpRequest, async (route) => {
+      authorizeRequests.push(route.request().url());
+      await route.fulfill({ status: 200, contentType: "text/html", body: "<html>idp stub</html>" });
+    });
+
+    await page.goto("/");
+    await expect(page.getByRole("link", { name: "Sign In" })).toBeVisible({ timeout: 30_000 });
+    expect(authorizeRequests).toEqual([]);
+  });
+
   test("password sign-in is refused", async ({ request }) => {
     const response = await request.post("/api/auth/sign-in/email", {
       data: { email: "someone@partner.test", password: "whatever-password-123" },


### PR DESCRIPTION
Visiting the bare app URL rendered a card with a single **Sign In** button on it, so `app.elmohq.com` cost a click before showing anyone the pitch.

Now `/` sends a signed-out visitor straight to the auth page the deployment opens on:

| Mode | `/` lands on | Why |
| --- | --- | --- |
| cloud | `/auth/register` | Sign-up carries the sales panel, and it's already where the marketing site points buyers (`cloudSignupUrl`) |
| local | `/auth/login`, or `/auth/register` before the bootstrap signup | |
| demo | `/auth/login` | Unchanged — the shared credentials are pre-filled there |
| whitelabel | unchanged (the card) | Its sign-in page hands off to the partner's Auth0 the moment it renders, so redirecting would start an SSO round trip nobody asked for |

The redirect happens in `beforeLoad`, so SSR answers with a 3xx rather than painting a page first. A `ref` on the bare URL is now carried through to sign-up, so a marketing click that lands on `/` instead of `/auth/register` is still attributed.

## Test plan

- `entryRouteForVisitor` is a pure function with unit tests covering all four modes plus the config-not-loaded case
- Each mode's e2e spec now asserts where `/` lands, including that whitelabel does *not* reach the IdP
- `pnpm lint` and `tsc --noEmit` clean; `apps/web` unit tests pass (one pre-existing flake in `api/__tests__/handler.test.ts` that also fails on `main` under full-suite load, and passes in isolation)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0dd65984-2f41-4524-b8df-b42e4f076bb6)
