### PR TITLE
Launch the installed app at the app root

### DIFF
--- a/.changeset/installed-app-start-url.md
+++ b/.changeset/installed-app-start-url.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Installing Elmo as an app from Chrome now opens the dashboard instead of a blank `/api/` page, and links across the app stay inside the installed window.

--- a/.changeset/installed-app-start-url.md
+++ b/.changeset/installed-app-start-url.md
@@ -1,5 +1,0 @@
----
-"@workspace/web": patch
----
-
-Installing Elmo as an app from Chrome now opens the dashboard instead of a blank `/api/` page, and links across the app stay inside the installed window.

--- a/apps/web/src/routes/api/manifest/index.ts
+++ b/apps/web/src/routes/api/manifest/index.ts
@@ -80,7 +80,11 @@ function buildManifest(): object {
 		short_name: branding.name,
 		name: `${branding.name} - AI Search Optimization`,
 		icons,
-		start_url: ".",
+		// Absolute, because a relative start_url resolves against the manifest's
+		// own URL (/api/manifest) rather than the app root. scope follows it so
+		// the whole dashboard stays inside the installed window.
+		start_url: "/",
+		scope: "/",
 		display: "standalone",
 		theme_color: themeColor,
 		background_color: ELMO_BACKGROUND_COLOR,

--- a/apps/web/src/routes/api/manifest/index.ts
+++ b/apps/web/src/routes/api/manifest/index.ts
@@ -80,9 +80,6 @@ function buildManifest(): object {
 		short_name: branding.name,
 		name: `${branding.name} - AI Search Optimization`,
 		icons,
-		// Absolute, because a relative start_url resolves against the manifest's
-		// own URL (/api/manifest) rather than the app root. scope follows it so
-		// the whole dashboard stays inside the installed window.
 		start_url: "/",
 		scope: "/",
 		display: "standalone",

--- a/e2e/tests/local/local-deployment.spec.ts
+++ b/e2e/tests/local/local-deployment.spec.ts
@@ -128,4 +128,14 @@ test.describe("Local features", () => {
     expect(manifest.short_name).toBe("Elmo");
     expect(manifest.icons.some((icon) => icon.src.startsWith("/icons/elmo-icon"))).toBe(true);
   });
+
+  test("an installed app launches at the app root, not the manifest's own directory", async ({ request }) => {
+    const response = await request.get("/api/manifest");
+    const manifest = (await response.json()) as { start_url: string; scope: string };
+
+    // Resolved the way a browser does it: against the manifest's URL, not the page's.
+    const manifestUrl = "https://elmo.test/api/manifest";
+    expect(new URL(manifest.start_url, manifestUrl).pathname).toBe("/");
+    expect(new URL(manifest.scope, manifestUrl).pathname).toBe("/");
+  });
 });

--- a/e2e/tests/local/local-deployment.spec.ts
+++ b/e2e/tests/local/local-deployment.spec.ts
@@ -133,7 +133,6 @@ test.describe("Local features", () => {
     const response = await request.get("/api/manifest");
     const manifest = (await response.json()) as { start_url: string; scope: string };
 
-    // Resolved the way a browser does it: against the manifest's URL, not the page's.
     const manifestUrl = "https://elmo.test/api/manifest";
     expect(new URL(manifest.start_url, manifestUrl).pathname).toBe("/");
     expect(new URL(manifest.scope, manifestUrl).pathname).toBe("/");


### PR DESCRIPTION
Chrome offers "Install app" on `apps/web` because the site ships a valid PWA manifest at `/api/manifest` — `display: standalone`, a `start_url`, and 192×192/512×512 PNG icons. That has been true since the concrete PNG sizes landed in e9be023; there is no service worker, and Chrome no longer needs one for the desktop install prompt.

Installing it, though, didn't work. `start_url` resolves against the *manifest's* URL rather than the page's, and the manifest is served from `/api/manifest` — so `"."` meant an installed app launched at `/api/`, which has no index route. `scope` was unset and defaults to the same directory, so the entire dashboard sat outside the app's scope and every link would have escaped the installed window back into an ordinary browser tab.

Both are now absolute. Covered by an e2e assertion that resolves the two fields the way a browser does.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/fde0e050-2c71-4494-aace-beb9463b6c54)
