### PR TITLE
Add sponsors section to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ A web app serves the dashboard and REST API, a worker schedules and executes pro
 </p>
 
 <br />
-<br />
 
 <a href="https://github.com/sponsors/elmohq"><strong>Become a sponsor →</strong></a>
 

--- a/README.md
+++ b/README.md
@@ -164,8 +164,6 @@ A web app serves the dashboard and REST API, a worker schedules and executes pro
   </a>
 </p>
 
-<br />
-
 <a href="https://github.com/sponsors/elmohq"><strong>Become a sponsor →</strong></a>
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -156,6 +156,19 @@ A web app serves the dashboard and REST API, a worker schedules and executes pro
 - [API reference](https://www.elmohq.com/docs/api) — the REST API for brands, prompts, competitors, snapshots, and reports
 - [AI Visibility Tool Directory](https://www.elmohq.com/ai-visibility-tools) — 100+ AEO/GEO tools compared
 
+## Sponsors
+
+<p align="left">
+  <a href="https://www.llumohq.com/">
+    <img src="https://nynjceth7hnajxhe.public.blob.vercel-storage.com/sponsors/llumo.png" alt="Llumo" width="78">
+  </a>
+</p>
+
+<br />
+<br />
+
+<a href="https://github.com/sponsors/elmohq"><strong>Become a sponsor →</strong></a>
+
 ## Contact
 
 - [Discord](https://discord.gg/s24nubCtKz)


### PR DESCRIPTION
Adds a Sponsors section to the README with the current sponsor (Llumo) logo, hot-linked from blob storage and sized for a small sponsor placement, linking to llumohq.com, plus a CTA to become a sponsor via GitHub Sponsors.