### PR TITLE
Stop the cloud card from implying Starter tracks every platform

### DIFF
--- a/apps/www/src/components/pricing.tsx
+++ b/apps/www/src/components/pricing.tsx
@@ -39,7 +39,7 @@ const plans: Plan[] = [
 		featured: true,
 		features: [
 			"Managed hosting, automatic updates",
-			"Track ChatGPT, Google, Perplexity & more",
+			"Track ChatGPT on Starter; more platforms on higher plans",
 			"Scraped surfaces sampled up to 4× daily",
 			"Premium grounded models on Pro & Business",
 			"API access on every plan",


### PR DESCRIPTION
The Cloud card's "Track ChatGPT, Google, Perplexity & more" line sat under a "From $29/mo" price, but the Starter plan at that price tracks ChatGPT only — the multi-platform menu starts at Basic ($99/mo). Reword the line so the entry price isn't oversold.