### PR TITLE
Fix RunSummary's reference to a nonexistent GET /runs/{runId} endpoint

### DIFF
--- a/packages/api-spec/src/openapi.json
+++ b/packages/api-spec/src/openapi.json
@@ -1436,7 +1436,7 @@
 				"required": ["brandId", "range", "data"]
 			},
 			"RunSummary": {
-				"description": "A single model answer, without its text. Fetch `GET /runs/{runId}` for the answer itself.",
+				"description": "A single model answer, without its text. Fetch `GET /prompts/{promptId}/runs/{runId}` for the answer itself.",
 				"type": "object",
 				"properties": {
 					"id": {


### PR DESCRIPTION
The RunSummary schema description told users to fetch `GET /runs/{runId}` for the answer text, but no such top-level operation exists. The actual endpoint is `GET /prompts/{promptId}/runs/{runId}` — which the RunsList description already referenced correctly. This updates RunSummary to match.