### PR TITLE
Tighten marketing copy across www

### DIFF
--- a/apps/www/src/components/community.tsx
+++ b/apps/www/src/components/community.tsx
@@ -39,8 +39,7 @@ export function Community() {
 						Talk to us!
 					</h2>
 					<p className="mt-5 max-w-[58ch] text-pretty text-zinc-600 md:text-lg">
-						Hop into our Discord to ask questions and get help straight from the maintainers. We'd love to hear from
-						you.
+						Ask questions and get help straight from the maintainers on Discord.
 					</p>
 					<div className="mt-7 flex flex-wrap items-center gap-3">
 						<a

--- a/apps/www/src/components/cta.tsx
+++ b/apps/www/src/components/cta.tsx
@@ -21,8 +21,8 @@ export function CTA() {
 							Start tracking AI answers today.
 						</h2>
 						<p className="mt-5 max-w-[52ch] text-pretty text-zinc-600 md:text-lg">
-							Sign up for the cloud and we run it for you from ${CLOUD_ENTRY_PRICE_USD}/mo — managed, updated, nothing
-							to deploy. Or run the same open-source product on your own infra for free.
+							Sign up for the cloud and we run everything for you from ${CLOUD_ENTRY_PRICE_USD}/mo: hosting, updates, no
+							deployment. Or run the same open-source product on your own infra for free.
 						</p>
 						<div className="mt-7 flex flex-wrap items-center gap-2">
 							<CloudSignupCTA />

--- a/apps/www/src/components/cta.tsx
+++ b/apps/www/src/components/cta.tsx
@@ -21,8 +21,7 @@ export function CTA() {
 							Start tracking AI answers today.
 						</h2>
 						<p className="mt-5 max-w-[52ch] text-pretty text-zinc-600 md:text-lg">
-							Sign up for the cloud and we run everything for you from ${CLOUD_ENTRY_PRICE_USD}/mo: hosting, updates, no
-							deployment. Or run the same open-source product on your own infra for free.
+							Sign up for the cloud and we run everything for you from ${CLOUD_ENTRY_PRICE_USD}/mo, or run the same open-source product on your own infra for free.
 						</p>
 						<div className="mt-7 flex flex-wrap items-center gap-2">
 							<CloudSignupCTA />

--- a/apps/www/src/components/features.tsx
+++ b/apps/www/src/components/features.tsx
@@ -23,8 +23,7 @@ const features: Feature[] = [
 		num: "01",
 		eyebrow: "DASHBOARD",
 		title: "Your AI visibility command center.",
-		description:
-			"See everything at a glance — current visibility, share of voice, 30-day trends, and the key metrics behind every score.",
+		description: "Current visibility, share of voice, and 30-day trends on one dashboard.",
 		graphic: <OverviewPageGraphic />,
 	},
 	{
@@ -40,7 +39,7 @@ const features: Feature[] = [
 		eyebrow: "SHARE OF VOICE",
 		title: "See how you stack up against the competition.",
 		description:
-			"Compare your brand's mention share against every competitor. A live leaderboard ranks who AI engines name most — so you can see who dominates and where the gaps are.",
+			"Compare your brand's mention share against every competitor. A live leaderboard ranks who AI engines name most, and where you're missing.",
 		graphic: <ShareOfVoicePageGraphic />,
 	},
 	{
@@ -64,7 +63,7 @@ const features: Feature[] = [
 		eyebrow: "OPPORTUNITIES",
 		title: "Know exactly what to do next.",
 		description:
-			"Turn your data into action with AI-generated recommendations — content to create, pages to refresh, and third-party sources to pitch — each ranked by impact.",
+			"Get AI-generated recommendations ranked by impact: content to create, pages to refresh, third-party sources to pitch.",
 		graphic: <OpportunitiesPageGraphic />,
 	},
 	{
@@ -72,7 +71,7 @@ const features: Feature[] = [
 		eyebrow: "PROMPTS",
 		title: "Search, tag, and organize your prompts.",
 		description:
-			"Find any prompt instantly with full-text search and highlight matching. Tag prompts for easy filtering and track visibility scores per prompt.",
+			"Full-text search finds any prompt instantly. Tag them to filter, and track visibility scores per prompt.",
 		graphic: <PromptSearchGraphic />,
 	},
 	{
@@ -80,7 +79,7 @@ const features: Feature[] = [
 		eyebrow: "DEEP DIVE",
 		title: "Inspect every individual AI response.",
 		description:
-			"Drill into any prompt to see exactly what each AI model said, which brands were mentioned, what sources were cited, and how the response was constructed.",
+			"Drill into any prompt to see exactly what each AI model said, which brands were mentioned, and what sources were cited.",
 		graphic: <PromptDetailGraphic />,
 	},
 	{

--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -71,7 +71,7 @@ export function Footer() {
 							<Logo className="text-3xl" />
 						</Link>
 						<p className="mt-5 max-w-[36ch] text-pretty text-sm text-zinc-600">
-							Open source AI visibility tracking and optimization.
+							Elmo is open source: track and improve how AI answers talk about your brand.
 						</p>
 						<div className="mt-5 inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-2.5 py-1 font-mono text-[11px] text-zinc-700">
 							<span className="size-1.5 rounded-full bg-emerald-500" />v{__APP_VERSION__}

--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -71,7 +71,7 @@ export function Footer() {
 							<Logo className="text-3xl" />
 						</Link>
 						<p className="mt-5 max-w-[36ch] text-pretty text-sm text-zinc-600">
-							Elmo is open source: track and improve how AI answers talk about your brand.
+							Elmo is the #1 open source AEO platform. Track and improve how AI answers talk about your brand.
 						</p>
 						<div className="mt-5 inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-2.5 py-1 font-mono text-[11px] text-zinc-700">
 							<span className="size-1.5 rounded-full bg-emerald-500" />v{__APP_VERSION__}

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -58,9 +58,8 @@ export function Hero() {
 							Know How AI Talks About Your Brand
 						</h1>
 						<p className="mt-6 max-w-[58ch] text-pretty text-base text-zinc-600 md:text-lg">
-							Track your brand's visibility across any AI model. Monitor mentions, analyze citations, and benchmark
-							competitors. Run it in our cloud or host it yourself — it's open source either way, so your data stays
-							yours and you'll never get locked in.
+							Track your brand's visibility across any AI model: mentions, citations, and competitor benchmarks. Run it
+							in our cloud or self-host — it's open source, so your data stays yours and you'll never get locked in.
 						</p>
 						<div className="mt-8 flex flex-wrap items-center gap-2">
 							<CloudSignupCTA />

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -58,7 +58,7 @@ export function Hero() {
 							Know How AI Talks About Your Brand
 						</h1>
 						<p className="mt-6 max-w-[58ch] text-pretty text-base text-zinc-600 md:text-lg">
-							Track your brand's visibility across any AI model: mentions, citations, and competitor benchmarks. Run it
+							Track your brand's visibility across any AI model. Monitor mentions, analyze citations, and benchmark competitors. Run it
 							in our cloud or self-host — it's open source, so your data stays yours and you'll never get locked in.
 						</p>
 						<div className="mt-8 flex flex-wrap items-center gap-2">

--- a/apps/www/src/components/not-found.tsx
+++ b/apps/www/src/components/not-found.tsx
@@ -6,7 +6,7 @@ import { Navbar } from "./navbar";
 const suggestedLinks = [
 	{ label: "Documentation", href: "/docs", description: "Get started and learn the API" },
 	{ label: "Features", href: "/features", description: "What Elmo can do for your brand" },
-	{ label: "Pricing", href: "/pricing", description: "Plans for every team size" },
+	{ label: "Pricing", href: "/pricing", description: "Free to self-host; cloud from $29/mo" },
 	{ label: "Roadmap", href: "/roadmap", description: "What we're building next" },
 ];
 
@@ -29,7 +29,7 @@ export function NotFound() {
 								This page doesn't exist
 							</h1>
 							<p className="mx-auto mt-6 max-w-[58ch] text-pretty text-base text-zinc-600 md:text-lg">
-								The page you're looking for may have moved, been renamed, or never existed.
+								The page you're looking for may have moved, or it may never have existed.
 							</p>
 							<div className="mt-8 flex flex-wrap items-center justify-center gap-2">
 								<Link

--- a/apps/www/src/components/off-site-aeo.tsx
+++ b/apps/www/src/components/off-site-aeo.tsx
@@ -82,22 +82,22 @@ const valuePoints: ValuePoint[] = [
 	{
 		icon: <Quote className="size-4" strokeWidth={2.5} />,
 		title: "What is off-site AEO?",
-		body: "Answer engines build replies from the whole web, not just your homepage. They weight sources by authority and corroboration. When several independent, trusted sites describe you the same way, a model is far more confident citing you.",
+		body: "Answer engines build replies from the whole web, not just your homepage. They favor sources other trusted sites agree with. When several independent, trusted sites describe you the same way, a model is far more confident citing you.",
 	},
 	{
 		icon: <Target className="size-4" strokeWidth={2.5} />,
 		title: "Targeted, not spray-and-pray",
-		body: "We don't publish random posts. We start from your AI-visibility data and find the prompts you're missing, the competitors cited instead of you, and the sources those models already trust. Then we plan each placement to close a specific gap or reinforce your brand's authority.",
+		body: "We start from your AI-visibility data: the prompts you're missing and the competitors cited instead of you. Each placement closes one of those gaps.",
 	},
 	{
 		icon: <PenLine className="size-4" strokeWidth={2.5} />,
 		title: "Drafted with AI, and humanized",
-		body: "After we come up with a plan, we create drafts of the guest posts using the best AI models. Then, we humanize the articles so they land under a 25% AI-detection score on both ZeroGPT and Pangram. This human touch-up improves the resiliency of your posts.",
+		body: "After we come up with a plan, we create drafts of the guest posts using the best AI models. Then, we humanize the articles so they land under a 25% AI-detection score on both ZeroGPT and Pangram. That rewrite makes the posts read like human writing, which keeps them from getting flagged or ignored.",
 	},
 	{
 		icon: <CalendarClock className="size-4" strokeWidth={2.5} />,
 		title: "Fresh sources, every month",
-		body: "AI answers lean on recent data. While a one-time burst fades, a steady publishing every month keeps data about your brand and industry current and authoritative. It's a more natural backlink pattern for classic SEO, too.",
+		body: "AI answers favor recent data. A one-time burst fades; publishing every month keeps your brand's data fresh. It's a more natural backlink pattern for classic SEO, too.",
 	},
 ];
 
@@ -107,7 +107,7 @@ export function OffSiteValue() {
 			<div className="mx-auto max-w-6xl px-4 py-16 md:px-6 lg:py-24">
 				<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">/ WHY IT WORKS</p>
 				<h2 className="mt-4 max-w-[24ch] text-4xl font-semibold leading-[1.05] tracking-tight text-balance text-zinc-950 md:text-5xl">
-					Many high-authority data points, built purposefully.
+					More mentions on sites AI already trusts.
 				</h2>
 				<p className="mt-5 max-w-[60ch] text-pretty text-zinc-600 md:text-lg">
 					We give AI answer engines a steady supply of trustworthy sources that mention you in the right context. The
@@ -138,8 +138,8 @@ export function OffSiteValue() {
 						>
 							Jared Rhizor
 						</a>
-						, who's spent the last year finding the levers that move the needle on AI citations by building AEO tooling
-						for top e-commerce and B2B SaaS brands.
+						, who has spent the last year building AEO tooling for top e-commerce and B2B SaaS brands and learning what
+						actually changes AI citations.
 					</p>
 				</div>
 			</div>
@@ -163,7 +163,7 @@ const steps = [
 	{
 		num: "03",
 		title: "Autopilot",
-		body: "We keep publishing on a steady cadence, adjusting targets as your visibility moves, keeping data fresh for AI models.",
+		body: "We keep publishing monthly and adjust targets as your visibility shifts.",
 	},
 ];
 
@@ -173,7 +173,7 @@ export function OffSiteProcess() {
 			<div className="mx-auto max-w-6xl px-4 py-16 md:px-6 lg:py-24">
 				<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">/ HOW IT WORKS</p>
 				<h2 className="mt-4 max-w-[24ch] text-4xl font-semibold leading-[1.05] tracking-tight text-balance text-zinc-950 md:text-5xl">
-					One call, quality posts. Live within 30 days.
+					One call, then live posts within 30 days.
 				</h2>
 
 				<div className="mt-12 grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-zinc-200 bg-zinc-200 md:grid-cols-3">
@@ -216,7 +216,7 @@ const plans: OffSitePlan[] = [
 		id: "starter",
 		tag: "01",
 		name: "Starter",
-		desc: "A focused entry point into off-site AEO.",
+		desc: "Four placements a month to get started.",
 		price: "$1,950",
 		posts: 4,
 		buckets: [
@@ -246,7 +246,7 @@ const plans: OffSitePlan[] = [
 		id: "authority",
 		tag: "03",
 		name: "Authority",
-		desc: "Maximum data points, topped with a flagship.",
+		desc: "The most placements, including one DR60+ site.",
 		price: "$9,950",
 		posts: 14,
 		buckets: [

--- a/apps/www/src/components/pricing.tsx
+++ b/apps/www/src/components/pricing.tsx
@@ -40,8 +40,8 @@ const plans: Plan[] = [
 		features: [
 			"Managed hosting, automatic updates",
 			"Track ChatGPT, Google, Perplexity & more",
-			"Scraped surfaces sampled up to 4× daily",
-			"Premium grounded models on Pro & Business",
+			"We re-check AI answers up to 4× daily",
+			"Models with live web results on Pro & Business",
 			"API access on every plan",
 			"Unlimited seats",
 		],
@@ -68,7 +68,7 @@ const plans: Plan[] = [
 		id: "white-label",
 		tag: "03",
 		name: "White Label",
-		desc: "Provide AEO for all of your customers.",
+		desc: "Offer AEO tracking to your clients.",
 		price: "Custom",
 		priceLabel: "",
 		features: [
@@ -108,7 +108,7 @@ export function Pricing({ as: Heading = "h2" }: { as?: "h1" | "h2" } = {}) {
 				<div>
 					<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">/ PRICING</p>
 					<Heading className="mt-4 max-w-[28ch] text-4xl font-semibold leading-[1.05] tracking-tight text-balance text-zinc-950 md:text-5xl">
-						Run it in our cloud, self-host it, or white-label it for your customers.
+						Run it in our cloud, self-host it, or white-label it — you choose.
 					</Heading>
 				</div>
 

--- a/apps/www/src/components/pricing.tsx
+++ b/apps/www/src/components/pricing.tsx
@@ -40,8 +40,8 @@ const plans: Plan[] = [
 		features: [
 			"Managed hosting, automatic updates",
 			"Track ChatGPT, Google, Perplexity & more",
-			"We re-check AI answers up to 4× daily",
-			"Models with live web results on Pro & Business",
+			"We scrape AI answers up to 4× daily",
+			"Premium grounded models on Pro & Business",
 			"API access on every plan",
 			"Unlimited seats",
 		],

--- a/apps/www/src/components/stats.tsx
+++ b/apps/www/src/components/stats.tsx
@@ -99,11 +99,11 @@ export function Stats() {
 				<div>
 					<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">/ MODEL COVERAGE</p>
 					<h2 className="mt-4 max-w-[28ch] text-4xl font-semibold leading-[1.05] tracking-tight text-balance text-zinc-950 md:text-5xl">
-						Track any AI model.
+						Track every major AI model.
 					</h2>
 					<p className="mt-5 max-w-[58ch] text-pretty text-zinc-600 md:text-lg">
-						See exactly what ChatGPT and other AI search users see exactly with web scraping. Track LLM responses with
-						their APIs or OpenRouter. Bring your own keys.
+						See what ChatGPT users see, via web scraping. Track LLM responses through their APIs or OpenRouter. Bring
+						your own keys.
 					</p>
 				</div>
 

--- a/apps/www/src/lib/faqs.ts
+++ b/apps/www/src/lib/faqs.ts
@@ -44,7 +44,7 @@ export const PRICING_FAQS: FaqItem[] = [
 	{
 		question: "Is there a hosted or cloud version of Elmo?",
 		answer:
-			"Managed cloud hosting is coming soon for teams that would rather not run their own infrastructure. Until then, you can self-host Elmo for free or get in touch about early access and managed deployments.",
+			"Yes. Elmo Cloud is a managed cloud hosting for teams that would rather not run their own infrastructure, starting at $29/mo. You can also self-host Elmo for free, or get in touch about white-label and managed deployments.",
 	},
 	{
 		question: "Can agencies white-label Elmo?",
@@ -54,7 +54,7 @@ export const PRICING_FAQS: FaqItem[] = [
 	{
 		question: "What do I need to run Elmo myself?",
 		answer:
-			"Elmo runs as a Docker Compose stack, all managed with a simple CLI — install it, run the interactive init, and bring everything up in a couple of commands. You can use the bundled database or connect Elmo to your own PostgreSQL database.",
+			"Elmo runs as a Docker Compose stack managed by a CLI. Install it, run the interactive init, and it's up in a couple of commands. You can use the bundled database or connect Elmo to your own PostgreSQL database.",
 	},
 	{
 		question: "Do I need a credit card to get started?",
@@ -69,12 +69,12 @@ export const OFFSITE_FAQS: FaqItem[] = [
 	{
 		question: "How does the off-site AEO service work?",
 		answer:
-			"It starts with a consultancy call where we review how AI answer engines currently talk about you and decide which prompts and gaps to target. Within 30 days, that month's posts are planned, written, humanized, and live on high-authority sites, and you get a report tying each placement to the issue it targets. We then keep publishing for you every month, adjusting the targets as your visibility shifts.",
+			"It starts with a call where we review how AI answer engines currently talk about you and pick the prompts and gaps to target. Within 30 days, that month's posts are planned, written, humanized, and live on high-authority sites, and you get a report tying each placement to the issue it targets. We then keep publishing for you every month, adjusting the targets as your visibility shifts.",
 	},
 	{
 		question: "Are the articles AI-generated?",
 		answer:
-			"Yes, and we're upfront about it. We draft with AI, then it is reworked until it lands under a 25% AI-detection score on both ZeroGPT and Pangram before it goes live. That keeps quality high while keeping your brand mentioned in content the models actually trust and cite.",
+			"Yes, and we're upfront about it. We draft with AI, then it is reworked until it lands under a 25% AI-detection score on both ZeroGPT and Pangram before it goes live. The result reads like human writing, and it lives on sites the models cite.",
 	},
 	{
 		question: "Do you offer refunds?",
@@ -84,12 +84,12 @@ export const OFFSITE_FAQS: FaqItem[] = [
 	{
 		question: "How is this different from buying backlinks?",
 		answer:
-			"It's a similar process. However, we make sure the content is useful for AEO, only place it on high-quality sites, and humanize the text to avoid detection. Many backlink services offer very low-quality placements with high spam scores, non-existent traffic, and gamed DRs, and either make you provide your own content or produce content that's low quality and easily detected as AI.",
+			"It's a similar process. Many backlink services offer low-quality placements with high spam scores and no traffic. They also make you write the content yourself — or generate it, which is easy to detect. We do neither: the content is useful for AEO, it only goes on high-quality sites, and it's humanized.",
 	},
 	{
 		question: "Will this help my traditional SEO too?",
 		answer:
-			"These all provide dofollow links on high-DR domains with actual traffic, so your search rankings should benefit as well. But the primary purpose is to provide more data points to AI searches for AEO.",
+			"These all provide dofollow links on high-DR domains with actual traffic, so your search rankings should benefit as well. But the primary goal is giving AI answer engines more reasons to mention you.",
 	},
 ];
 

--- a/apps/www/src/lib/seo.ts
+++ b/apps/www/src/lib/seo.ts
@@ -7,7 +7,7 @@ export const SITE_NAME = "Elmo";
 // optimization" because answer engines expand the acronym when they search, and
 // carries no pricing so it stays true wherever it is reused.
 export const SITE_DESCRIPTION =
-	"Open source AI visibility and answer engine optimization (AEO) platform for tracking how AI answers mention and cite your brand.";
+	"Open-source answer engine optimization (AEO) platform: track how AI answers mention and cite your brand.";
 const SITE_LOGO_URL = `${SITE_URL}/brand/icons/elmo-icon-512.png`;
 
 export function canonicalUrl(path: string): string {

--- a/apps/www/src/routes/ai-search/index.tsx
+++ b/apps/www/src/routes/ai-search/index.tsx
@@ -6,7 +6,7 @@ import { breadcrumbJsonLd, canonicalUrl, itemListJsonLd, ogMeta } from "@/lib/se
 
 const title = "How to Show Up in AI Search Engines · Elmo";
 const description =
-	"Practical guides to appearing in AI search: how ChatGPT, Perplexity, Google AI Overviews, Gemini, Claude, Copilot, and Grok choose what to cite, and how to become one of their sources.";
+	"Practical guides to appearing in AI search: how engines like ChatGPT, Perplexity, and Google AI Overviews choose what to cite — and how to become one of their sources.";
 
 export const Route = createFileRoute("/ai-search/")({
 	head: () => ({

--- a/apps/www/src/routes/ai-visibility-tools/index.tsx
+++ b/apps/www/src/routes/ai-visibility-tools/index.tsx
@@ -9,8 +9,7 @@ import { DIRECTORY_FAQS } from "@/lib/faqs";
 import { breadcrumbJsonLd, canonicalUrl, faqJsonLd, itemListJsonLd, ogMeta } from "@/lib/seo";
 
 const title = "AI Visibility Tool Directory | Compare AI Search Tools · Elmo";
-const description =
-	"AI visibility software tracks your brand across ChatGPT, Perplexity, and Gemini. Compare 100+ AI visibility and AEO tools, head-to-head with Elmo.";
+const description = "Compare 100+ AI visibility and AEO tools, head-to-head with Elmo.";
 
 // Indexed comparison pages (mirrors the sitemap filter), surfaced as ItemList
 // structured data so AI engines can extract the full directory of tools.
@@ -48,7 +47,7 @@ export const Route = createFileRoute("/ai-visibility-tools/")({
 const browseLinks = [
 	{
 		title: "Compare head-to-head",
-		description: "Side-by-side breakdowns of the leading platforms, with Elmo in the mix.",
+		description: "Side-by-side comparisons, with Elmo included.",
 		href: "/ai-visibility-tools/compare",
 	},
 	{

--- a/apps/www/src/routes/features.tsx
+++ b/apps/www/src/routes/features.tsx
@@ -6,8 +6,7 @@ import { Navbar } from "@/components/navbar";
 import { breadcrumbJsonLd, canonicalUrl, ogMeta } from "@/lib/seo";
 
 const title = "Features — AI Visibility & Citation Tracking · Elmo";
-const description =
-	"AI visibility tracking, citation analysis, competitor intelligence, and more. Everything you need to monitor your brand in AI search.";
+const description = "Track AI visibility, analyze citations, and monitor competitors — all in one tool.";
 
 export const Route = createFileRoute("/features")({
 	head: () => ({

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -17,7 +17,7 @@ const title = `${SITE_NAME} · Open Source AEO & AI Visibility Tracker`;
 // copy. The homepage takes the largest share of search clicks and is the page
 // answer engines cite most, so it gets a full-width description of its own.
 const description =
-	"Elmo tracks your brand's AI visibility in ChatGPT, Perplexity, and Gemini. Open-source answer engine optimization (AEO). Cloud from $29/mo or self-host free.";
+	"Elmo is open-source answer engine optimization (AEO): track your brand's AI visibility in ChatGPT, Perplexity, and Gemini. Cloud from $29/mo or self-host free.";
 
 export const Route = createFileRoute("/")({
 	head: () => ({

--- a/apps/www/src/routes/off-site-aeo.tsx
+++ b/apps/www/src/routes/off-site-aeo.tsx
@@ -8,7 +8,7 @@ import { breadcrumbJsonLd, canonicalUrl, faqJsonLd, ogMeta } from "@/lib/seo";
 
 const title = "Off-Site AEO — Get Cited by AI on High-Authority Sites · Elmo";
 const description =
-	"Managed off-site AEO: we place human-edited guest articles on high-authority (DR20–60+) sites so AI answer engines cite your brand. Targeted to your gaps, refreshed monthly, with a report. Great backlinks, too.";
+	"Managed off-site AEO: we place human-edited guest articles on high-authority (DR20–60+) sites so AI answer engines cite your brand. Placements target your gaps, refresh monthly, and come with a report — plus the backlinks.";
 
 export const Route = createFileRoute("/off-site-aeo")({
 	head: () => ({

--- a/apps/www/src/routes/vision.tsx
+++ b/apps/www/src/routes/vision.tsx
@@ -54,8 +54,8 @@ function VisionPage() {
 								AI visibility monitoring should be a commodity, not a luxury.
 							</h1>
 							<p className="mt-6 max-w-2xl text-lg text-balance text-zinc-600 md:text-xl">
-								The emerging market for "AI search optimization" is full of inflated pricing, opaque methodologies, and
-								venture-funded startups burning cash. We think there's a better way.
+								The "AI search optimization" market is full of inflated pricing and opaque methodologies. We're building
+								something better.
 							</p>
 						</div>
 					</div>
@@ -83,7 +83,7 @@ function VisionPage() {
 								<p>
 									Meanwhile, the AEO space is rife with misinformation. Consultants sell "optimization" services based
 									on flawed assumptions about how LLMs work. Rankings are presented as deterministic when they're
-									probabilistic. Correlation is sold as causation. We believe this hurts everyone.
+									probabilistic. Correlation is sold as causation.
 								</p>
 							</div>
 						</div>
@@ -95,14 +95,11 @@ function VisionPage() {
 					<div className="mx-auto max-w-6xl px-4 md:px-6">
 						<div className="max-w-3xl">
 							<SectionEyebrow num="02" label="OUR APPROACH" />
-							<h2 className="font-heading mt-3 text-3xl text-zinc-950 md:text-4xl">
-								Small, sustainable, built to last
-							</h2>
+							<h2 className="font-heading mt-3 text-3xl text-zinc-950 md:text-4xl">Bootstrapped and built to last</h2>
 							<div className="mt-8 space-y-6 text-[1.0625rem] leading-relaxed text-zinc-600">
 								<p>
 									Elmo is bootstrapped. We don't have investors demanding hyper-growth or a board pushing us toward
-									enterprise-only pricing. That means we need far less to be a success — and far less to stick around
-									long-term.
+									enterprise-only pricing. That means we can succeed on modest revenue — and stay around for years.
 								</p>
 								<p>
 									We believe AI visibility data should be cost-effective to access. The underlying operations — querying
@@ -197,8 +194,7 @@ function VisionPage() {
 									<div className="rounded-md border border-zinc-200 bg-white p-5">
 										<h3 className="font-semibold text-zinc-950">Anti-Slop</h3>
 										<p className="mt-2 text-sm text-zinc-600">
-											We give you the data and context and help you grow your brand's AI presence naturally, without
-											generating AI slop or astroturfing.
+											We give you the data and context to grow your AI presence naturally — no AI slop, no astroturfing.
 										</p>
 									</div>
 								</div>
@@ -212,8 +208,8 @@ function VisionPage() {
 					<div className="mx-auto max-w-6xl px-4 text-center md:px-6">
 						<h2 className="font-heading text-3xl text-zinc-950 md:text-4xl">Sustainable AEO</h2>
 						<p className="mx-auto mt-4 max-w-xl text-lg text-balance text-zinc-600">
-							Elmo is open source, cost-effective, and built for the long haul. If that resonates, we'd love to have
-							you.
+							Elmo is open source, cost-effective, and built for the long haul. If that sounds like your kind of tool,
+							come build with us.
 						</p>
 						<div className="mt-8 flex flex-wrap justify-center gap-3">
 							<a href={CLOUD_SIGNUP_URL} className={buttonVariants({ size: "sm" })}>


### PR DESCRIPTION
## Summary
- Fix copy bugs: duplicated "exactly" in stats section, garbled "a steady publishing" phrase, and pricing FAQ claiming managed cloud is "coming soon" while the pricing page sells it live
- Replace insider jargon with plain language: "scraped surfaces", "grounded models", "resiliency", "corroboration", "levers that move the needle", "topped with a flagship"
- Trim rule-of-three constructions, double em-dash asides, and stock phrases across hero, features, pricing, off-site AEO, vision, 404, directory, and community sections
- Tighten meta descriptions on home, features, off-site AEO, ai-search, and ai-visibility-tools routes, plus the shared SITE_DESCRIPTION

## Test plan
- [ ] `pnpm lint` passes locally
- [ ] Spot-check homepage, pricing, features, off-site AEO, and vision pages in the dev server