### PR TITLE
Read the AI SDK response types instead of casting them away

### DIFF
--- a/.changeset/openai-web-queries.md
+++ b/.changeset/openai-web-queries.md
@@ -1,0 +1,5 @@
+---
+"@workspace/lib": patch
+---
+
+Prompt runs on the OpenAI API provider now show the search queries the model actually ran, instead of always reporting them as unavailable.

--- a/packages/lib/src/providers/registry/anthropic-api.test.ts
+++ b/packages/lib/src/providers/registry/anthropic-api.test.ts
@@ -58,3 +58,64 @@ describe("anthropic-api run", () => {
 		expect(warn).toHaveBeenCalledWith(expect.stringContaining("hit the output cap"));
 	});
 });
+
+describe("anthropic-api web search handling", () => {
+	const searchBlocks = [
+		{ type: "server_tool_use", id: "srv_1", name: "web_search", input: { query: "elmo aeo" } },
+		{
+			type: "web_search_tool_result",
+			tool_use_id: "srv_1",
+			content: [
+				{
+					type: "web_search_result",
+					url: "https://example.com/a",
+					title: "A",
+					encrypted_content: "long page text",
+					page_age: null,
+				},
+			],
+		},
+	];
+
+	it("reports the query the server-side search issued", async () => {
+		anthropicClient.create.mockResolvedValue({ content: searchBlocks, model: "claude-sonnet-5" });
+
+		const res = await anthropicApi.run("claude", "prompt", { webSearch: true, version: "claude-sonnet-5" });
+
+		expect(res.webQueries).toEqual(["elmo aeo"]);
+	});
+
+	it("drops the fetched page text from what it stores but keeps url and title", async () => {
+		anthropicClient.create.mockResolvedValue({ content: searchBlocks, model: "claude-sonnet-5" });
+
+		const res = await anthropicApi.run("claude", "prompt", { webSearch: true, version: "claude-sonnet-5" });
+		const stored = (res.rawOutput as any).content.find((b: any) => b.type === "web_search_tool_result");
+
+		expect(stored.content).toEqual([{ type: "web_search_result", url: "https://example.com/a", title: "A" }]);
+	});
+
+	it("retries once when the search itself errored", async () => {
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		vi.useFakeTimers();
+		anthropicClient.create
+			.mockResolvedValueOnce({
+				content: [
+					{
+						type: "web_search_tool_result",
+						tool_use_id: "srv_1",
+						content: { type: "web_search_tool_result_error", error_code: "max_uses_exceeded" },
+					},
+				],
+				model: "claude-sonnet-5",
+			})
+			.mockResolvedValue({ content: searchBlocks, model: "claude-sonnet-5" });
+
+		const run = anthropicApi.run("claude", "prompt", { webSearch: true, version: "claude-sonnet-5" });
+		await vi.runAllTimersAsync();
+		const res = await run;
+
+		expect(anthropicClient.create).toHaveBeenCalledTimes(2);
+		expect(res.webQueries).toEqual(["elmo aeo"]);
+		vi.useRealTimers();
+	});
+});

--- a/packages/lib/src/providers/registry/anthropic-api.ts
+++ b/packages/lib/src/providers/registry/anthropic-api.ts
@@ -17,7 +17,7 @@ import type {
 	StructuredResearchResult,
 } from "../types";
 import { structuredResearch } from "./ai-sdk";
-import { sanitizeForJson } from "./scrape-shared";
+import { nonEmptyStrings, sanitizeForJson, sleep } from "./scrape-shared";
 
 const DEFAULT_RESEARCH_MODEL = "claude-sonnet-5";
 
@@ -53,35 +53,41 @@ async function runAnthropic(prompt: string, model: string, options?: ProviderOpt
 
 	// Check for web search errors like max_uses_exceeded and retry once
 	for (const block of response.content) {
-		const b = block as any;
-		if (b.type === "web_search_tool_result" && b.content?.type === "web_search_tool_result_error") {
-			console.warn(`[anthropic-api] web search error: ${b.content.error_code}, retrying in 10s...`);
-			await new Promise((r) => setTimeout(r, 10_000));
-			response = await makeRequest();
-			break;
-		}
+		if (block.type !== "web_search_tool_result") continue;
+		const error = Array.isArray(block.content) ? undefined : block.content;
+		if (error?.type !== "web_search_tool_result_error") continue;
+		console.warn(`[anthropic-api] web search error: ${error.error_code}, retrying in 10s...`);
+		await sleep(10_000);
+		response = await makeRequest();
+		break;
 	}
 
 	warnIfOutputCapped("anthropic-api", model, response.stop_reason);
 
 	const textContent = extractTextFromAnthropic(response);
 
-	const webQueries = response.content
-		.filter((block) => block.type === "server_tool_use" && (block as any).name === "web_search")
-		.map((block) => (block as any).input?.query)
-		.filter(Boolean);
+	const webQueries = nonEmptyStrings(
+		response.content.flatMap((block) =>
+			// A tool's input is typed `unknown` because its shape is tool-specific.
+			block.type === "server_tool_use" && block.name === "web_search"
+				? [(block.input as { query?: unknown } | null)?.query]
+				: [],
+		),
+	);
 
 	const citations = extractCitationsFromAnthropic(response);
 
 	// Strip full page text from web search results to reduce storage.
 	// Only url/title are used for citation extraction.
-	const trimmedContent = response.content.map((block: any) => {
+	const trimmedContent = response.content.map((block) => {
 		if (block.type !== "web_search_tool_result" || !Array.isArray(block.content)) return block;
 		return {
 			...block,
-			content: block.content.map((r: any) =>
-				r.type === "web_search_result" ? { type: r.type, url: r.url, title: r.title } : r,
-			),
+			content: block.content.map((result) => ({
+				type: result.type,
+				url: result.url,
+				title: result.title,
+			})),
 		};
 	});
 

--- a/packages/lib/src/providers/registry/openai-api.test.ts
+++ b/packages/lib/src/providers/registry/openai-api.test.ts
@@ -12,8 +12,13 @@ import { openaiApi } from "./openai-api";
 
 const CAP = API_PROVIDER_MAX_OUTPUT_TOKENS["openai-api"];
 
+/** `sources` and `content` are non-optional on a real generateText result. */
+function generated(over: Record<string, any> = {}) {
+	return { text: "answer", sources: [], content: [], ...over };
+}
+
 beforeEach(() => {
-	aiMock.generateText.mockResolvedValue({ text: "answer" });
+	aiMock.generateText.mockResolvedValue(generated());
 });
 
 afterEach(() => {
@@ -48,10 +53,59 @@ describe("openai-api run", () => {
 
 	it("logs a warning when the response stops on the output cap", async () => {
 		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-		aiMock.generateText.mockResolvedValue({ text: "clipped", finishReason: "length" });
+		aiMock.generateText.mockResolvedValue(generated({ text: "clipped", finishReason: "length" }));
 
 		await openaiApi.run("chatgpt", "prompt", { webSearch: false, version: "gpt-5-mini" });
 
 		expect(warn).toHaveBeenCalledWith(expect.stringContaining("hit the output cap"));
+	});
+});
+
+describe("openai-api citations", () => {
+	it("keeps url sources and ignores document sources", async () => {
+		aiMock.generateText.mockResolvedValue(
+			generated({
+				sources: [
+					{ type: "source", sourceType: "url", id: "1", url: "https://example.com/a", title: "A" },
+					{ type: "source", sourceType: "document", id: "2", mediaType: "application/pdf", title: "B" },
+				],
+			}),
+		);
+
+		const res = await openaiApi.run("chatgpt", "prompt", { webSearch: true, version: "gpt-5-mini" });
+
+		expect(res.citations).toEqual([
+			{ url: "https://example.com/a", title: "A", domain: "example.com", citationIndex: 0 },
+		]);
+	});
+});
+
+describe("openai-api web queries", () => {
+	function searchResult(action: Record<string, any>) {
+		return generated({ content: [{ type: "tool-result", toolName: "web_search", output: { action } }] });
+	}
+
+	it("reports the query the provider-run search actually issued", async () => {
+		aiMock.generateText.mockResolvedValue(searchResult({ type: "search", query: "elmo aeo" }));
+
+		const res = await openaiApi.run("chatgpt", "prompt", { webSearch: true, version: "gpt-5-mini" });
+
+		expect(res.webQueries).toEqual(["elmo aeo"]);
+	});
+
+	it("reports every query when the search fans out", async () => {
+		aiMock.generateText.mockResolvedValue(searchResult({ type: "search", queries: ["one", "two"] }));
+
+		const res = await openaiApi.run("chatgpt", "prompt", { webSearch: true, version: "gpt-5-mini" });
+
+		expect(res.webQueries).toEqual(["one", "two"]);
+	});
+
+	it("reports nothing for non-search actions", async () => {
+		aiMock.generateText.mockResolvedValue(searchResult({ type: "openPage", url: "https://example.com" }));
+
+		const res = await openaiApi.run("chatgpt", "prompt", { webSearch: false, version: "gpt-5-mini" });
+
+		expect(res.webQueries).toEqual([]);
 	});
 });

--- a/packages/lib/src/providers/registry/openai-api.ts
+++ b/packages/lib/src/providers/registry/openai-api.ts
@@ -1,5 +1,5 @@
 import { createOpenAI, openai } from "@ai-sdk/openai";
-import { generateText } from "ai";
+import { generateText, type InferToolOutput } from "ai";
 import { getCredential } from "../../secrets";
 import { extractCitationsFromOpenAI, extractTextFromOpenAI } from "../../text-extraction";
 import {
@@ -20,6 +20,7 @@ import type {
 	StructuredResearchResult,
 } from "../types";
 import { structuredResearch } from "./ai-sdk";
+import { nonEmptyStrings } from "./scrape-shared";
 
 const DEFAULT_RESEARCH_MODEL = "gpt-5-mini";
 
@@ -29,13 +30,26 @@ function getOpenAIResponsesModel(model: string) {
 	return provider.responses(model);
 }
 
+type WebSearchOutput = InferToolOutput<ReturnType<typeof openai.tools.webSearch>>;
+
+/**
+ * The web-search tool runs on OpenAI's side, so the query it actually issued
+ * comes back on the tool *result*, not the call — the call's input is empty.
+ * A single search reports `query`; a fanned-out one reports `queries`.
+ *
+ * `tools` is only passed when web search is on, so the compiler can't tie a
+ * result back to the tool that produced it and types `output` as `unknown`;
+ * callers establish that link by matching `toolName` first. The shape itself is
+ * the SDK's, so a renamed field still fails the build here.
+ */
+function webSearchQueries(output: unknown): string[] {
+	const action = (output as WebSearchOutput).action;
+	if (action?.type !== "search") return [];
+	return nonEmptyStrings([action.query, ...(action.queries ?? [])]);
+}
+
 async function runOpenAI(prompt: string, model: string, options?: ProviderOptions): Promise<ScrapeResult> {
-	const tools: Record<string, any> = {};
-	if (options?.webSearch) {
-		tools.web_search = openai.tools.webSearch({
-			searchContextSize: OPENAI_WEB_SEARCH_CONTEXT_SIZE,
-		}) as any;
-	}
+	const webSearch = options?.webSearch === true;
 
 	const result = await generateText({
 		// Routed through getOpenAIResponsesModel (not the bare `openai` global,
@@ -43,10 +57,12 @@ async function runOpenAI(prompt: string, model: string, options?: ProviderOption
 		model: getOpenAIResponsesModel(model),
 		prompt,
 		maxOutputTokens: API_PROVIDER_MAX_OUTPUT_TOKENS["openai-api"],
-		toolChoice: Object.keys(tools).length > 0 ? "auto" : "none",
-		...(Object.keys(tools).length > 0 ? { tools } : {}),
-		...(Object.keys(tools).length > 0
-			? { providerOptions: { openai: { maxToolCalls: OPENAI_WEB_SEARCH_MAX_TOOL_CALLS } } }
+		toolChoice: webSearch ? "auto" : "none",
+		...(webSearch
+			? {
+					tools: { web_search: openai.tools.webSearch({ searchContextSize: OPENAI_WEB_SEARCH_CONTEXT_SIZE }) },
+					providerOptions: { openai: { maxToolCalls: OPENAI_WEB_SEARCH_MAX_TOOL_CALLS } },
+				}
 			: {}),
 	});
 
@@ -55,9 +71,9 @@ async function runOpenAI(prompt: string, model: string, options?: ProviderOption
 	// The AI SDK doesn't populate result.response.body for the Responses API, so
 	// rebuild the raw output from the parsed result (text + web-search sources)
 	// in the "output" shape the OpenAI extractors expect.
-	const annotations = (result.sources ?? [])
-		.filter((s: any) => s.sourceType === "url" && s.url)
-		.map((s: any) => ({ type: "url_citation", url: s.url, title: s.title }));
+	const annotations = result.sources
+		.filter((source) => source.sourceType === "url")
+		.map((source) => ({ type: "url_citation", url: source.url, title: source.title }));
 	const rawOutput = {
 		output: [
 			{
@@ -67,12 +83,9 @@ async function runOpenAI(prompt: string, model: string, options?: ProviderOption
 		],
 	};
 
-	// The SDK doesn't reliably surface the raw query.
-	const webQueries: string[] = [];
-	for (const part of result.content ?? []) {
-		const q = (part as any)?.input?.query ?? (part as any)?.action?.query;
-		if (typeof q === "string") webQueries.push(q);
-	}
+	const webQueries = result.content.flatMap((part) =>
+		part.type === "tool-result" && part.toolName === "web_search" ? webSearchQueries(part.output) : [],
+	);
 
 	return {
 		rawOutput,
@@ -107,7 +120,7 @@ export const openaiApi: Provider = {
 			...(webSearch
 				? {
 						tools: {
-							web_search: openai.tools.webSearch({ searchContextSize: RESEARCH_WEB_SEARCH_CONTEXT_SIZE }) as any,
+							web_search: openai.tools.webSearch({ searchContextSize: RESEARCH_WEB_SEARCH_CONTEXT_SIZE }),
 						},
 						providerOptions: { openai: { maxToolCalls: RESEARCH_WEB_SEARCH_MAX_USES } },
 					}

--- a/packages/lib/src/providers/registry/sdk-contract.test.ts
+++ b/packages/lib/src/providers/registry/sdk-contract.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Contract tests for the two providers that go through the AI SDKs.
+ *
+ * The other provider tests mock the `ai` package wholesale, so they only assert
+ * what we send — a response-shape change in `ai` / `@ai-sdk/*` / `@anthropic-ai/sdk`
+ * would silently zero out citations without failing anything. These mock only the
+ * *model*, so the real SDK builds the result our extractors then read.
+ */
+import type Anthropic from "@anthropic-ai/sdk";
+import { MockLanguageModelV4 } from "ai/test";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { extractCitationsFromAnthropic, extractTextFromAnthropic } from "../../text-extraction";
+import { anthropicApi } from "./anthropic-api";
+import { openaiApi } from "./openai-api";
+
+// Mock only the *model factory*. The real `ai` package runs, so this exercises
+// generateText / Output.object / result.sources against the installed SDK.
+const model = vi.hoisted(() => ({ current: null as any }));
+
+vi.mock("@ai-sdk/openai", () => {
+	const openai: any = (id: string) => model.current;
+	openai.responses = () => model.current;
+	openai.tools = { webSearch: (o: any) => ({ __webSearch: o }) };
+	return { openai, createOpenAI: () => openai };
+});
+
+vi.mock("@ai-sdk/anthropic", () => {
+	const anthropic: any = (id: string) => model.current;
+	anthropic.tools = { webSearch_20250305: (o: any) => ({ __webSearch: o }) };
+	return { anthropic, createAnthropic: () => anthropic };
+});
+
+vi.mock("../../secrets", () => ({ getCredential: () => "test-key" }));
+
+/** Derived from the mock so it tracks whatever spec version `ai` ships. */
+type GenResult = Awaited<ReturnType<MockLanguageModelV4["doGenerate"]>>;
+
+/** Minimal well-typed generate result; callers override what they care about. */
+function generated(over: Partial<GenResult>): GenResult {
+	return {
+		warnings: [],
+		finishReason: { unified: "stop", raw: "stop" },
+		usage: {
+			inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+			outputTokens: { total: 1, text: 1, reasoning: 0 },
+		},
+		content: [],
+		...over,
+	};
+}
+
+describe("installed ai SDK contract: openai-api run()", () => {
+	it("turns SDK url sources into citations and reads the query off the search result", async () => {
+		model.current = new MockLanguageModelV4({
+			doGenerate: async () =>
+				generated({
+					content: [
+						{ type: "text", text: "Elmo tracks AI visibility." },
+						{
+							type: "source",
+							sourceType: "url",
+							id: "s1",
+							url: "https://example.com/a",
+							title: "Example A",
+						},
+						{
+							type: "tool-call",
+							toolCallId: "t1",
+							toolName: "web_search",
+							input: "{}",
+							providerExecuted: true,
+						},
+						{
+							type: "tool-result",
+							toolCallId: "t1",
+							toolName: "web_search",
+							result: { action: { type: "search", query: "elmo aeo" } },
+						},
+					],
+				}),
+		});
+
+		const res = await openaiApi.run("chatgpt", "prompt", { webSearch: true, version: "gpt-5-mini" });
+
+		expect(res.textContent).toBe("Elmo tracks AI visibility.");
+		expect(res.citations).toEqual([
+			{ url: "https://example.com/a", title: "Example A", domain: "example.com", citationIndex: 0 },
+		]);
+		expect(res.webQueries).toEqual(["elmo aeo"]);
+	});
+});
+
+describe("installed ai SDK contract: Output.object", () => {
+	it("populates result.output with the parsed, schema-validated object", async () => {
+		const schema = z.object({ brand: z.string(), competitors: z.array(z.string()) });
+		const payload = { brand: "Elmo", competitors: ["a", "b"] };
+
+		model.current = new MockLanguageModelV4({
+			doGenerate: async () => generated({ content: [{ type: "text", text: JSON.stringify(payload) }] }),
+		});
+
+		const res = await openaiApi.runStructuredResearch!({ prompt: "p", schema, webSearch: false });
+		expect(res.object).toEqual(payload);
+		expect(res.modelVersion).toBe("gpt-5-mini");
+	});
+});
+
+// --- Anthropic ---------------------------------------------------------------
+
+const anthropicClient = vi.hoisted(() => ({ create: vi.fn() }));
+vi.mock("@anthropic-ai/sdk", () => ({
+	default: class {
+		messages = { create: anthropicClient.create };
+	},
+}));
+
+// Typed as the SDK's own Message so a shape change fails `tsc`, not just runtime.
+const anthropicResponse: Anthropic.Messages.Message = {
+	id: "msg_1",
+	type: "message",
+	role: "assistant",
+	model: "claude-sonnet-5",
+	stop_reason: "end_turn",
+	stop_details: null,
+	stop_sequence: null,
+	container: null,
+	usage: { input_tokens: 1, output_tokens: 1 } as Anthropic.Messages.Usage,
+	content: [
+		{
+			type: "server_tool_use",
+			id: "srv_1",
+			caller: { type: "direct" },
+			name: "web_search",
+			input: { query: "elmo aeo" },
+		},
+		{
+			type: "web_search_tool_result",
+			tool_use_id: "srv_1",
+			caller: { type: "direct" },
+			content: [
+				{
+					type: "web_search_result",
+					url: "https://example.com/a",
+					title: "Example A",
+					encrypted_content: "x",
+					page_age: null,
+				},
+			],
+		},
+		{
+			type: "text",
+			text: "Elmo tracks AI visibility.",
+			citations: [
+				{
+					type: "web_search_result_location",
+					url: "https://example.com/b",
+					title: "Example B",
+					cited_text: "…",
+					encrypted_index: "y",
+				},
+			],
+		},
+	],
+};
+
+describe("installed @anthropic-ai/sdk contract: anthropic-api run()", () => {
+	it("extracts text, both citation shapes, and the web-search query", async () => {
+		anthropicClient.create.mockResolvedValue(anthropicResponse);
+
+		const res = await anthropicApi.run("claude", "prompt", { webSearch: true, version: "claude-sonnet-5" });
+
+		expect(res.textContent).toBe("Elmo tracks AI visibility.");
+		expect(res.webQueries).toEqual(["elmo aeo"]);
+		expect(res.citations.map((c) => c.url)).toEqual(["https://example.com/b", "https://example.com/a"]);
+	});
+
+	it("strips web-search page text from rawOutput but keeps url/title", async () => {
+		anthropicClient.create.mockResolvedValue(anthropicResponse);
+
+		const res = await anthropicApi.run("claude", "prompt", { webSearch: true, version: "claude-sonnet-5" });
+		const block = (res.rawOutput as any).content.find((b: any) => b.type === "web_search_tool_result");
+
+		expect(block.content[0]).toEqual({ type: "web_search_result", url: "https://example.com/a", title: "Example A" });
+	});
+
+	it("re-extracts the same values from stored rawOutput", async () => {
+		anthropicClient.create.mockResolvedValue(anthropicResponse);
+		const res = await anthropicApi.run("claude", "prompt", { webSearch: true, version: "claude-sonnet-5" });
+
+		expect(extractTextFromAnthropic(res.rawOutput)).toBe("Elmo tracks AI visibility.");
+		expect(extractCitationsFromAnthropic(res.rawOutput).map((c) => c.url)).toEqual([
+			"https://example.com/b",
+			"https://example.com/a",
+		]);
+	});
+});
+
+describe("installed ai SDK contract: anthropic Output.object", () => {
+	it("populates result.output with the parsed object", async () => {
+		const schema = z.object({ brand: z.string() });
+		model.current = new MockLanguageModelV4({
+			doGenerate: async () => generated({ content: [{ type: "text", text: JSON.stringify({ brand: "Elmo" }) }] }),
+		});
+
+		const res = await anthropicApi.runStructuredResearch!({ prompt: "p", schema, webSearch: false });
+		expect(res.object).toEqual({ brand: "Elmo" });
+	});
+});
+
+describe("installed ai SDK contract: finishReason unwrapping", () => {
+	// The provider spec models finishReason as { unified, raw }; generateText
+	// flattens it to the bare string warnIfOutputCapped compares against. That
+	// unwrapping is invisible to tsc here (warnIfOutputCapped takes `unknown`),
+	// so assert it directly.
+	it("flattens the provider finish reason so the output-cap warning still fires", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		model.current = new MockLanguageModelV4({
+			doGenerate: async () =>
+				generated({
+					finishReason: { unified: "length", raw: "max_output_tokens" },
+					content: [{ type: "text" as const, text: "clipped" }],
+				}),
+		});
+
+		await openaiApi.run("chatgpt", "prompt", { webSearch: false, version: "gpt-5-mini" });
+
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining("hit the output cap"));
+		warn.mockRestore();
+	});
+});


### PR DESCRIPTION
The two providers that go through the AI SDKs cast their responses to `any` before reading them. Those responses are properly typed discriminated unions, so the casts bought nothing and hid a bug.

## The bug

`openai-api` collected the web-search queries like this:

```ts
const q = (part as any)?.input?.query ?? (part as any)?.action?.query;
```

Neither probe can ever match. `openai.tools.webSearch` is a `ProviderExecutedTool<{}, …>` — its **input is empty**, and `action` lives on the tool **result's output**, not on the part. So `webQueries` was always empty and `reportedWebQueries` always fell back to `unavailable`. Reading the real type also surfaced `queries` (plural), for when a search fans out, which the old code had no way to see.

## Everything else is a straight narrowing

- `result.sources` is a union discriminated on `sourceType`, so `.filter((source) => source.sourceType === "url")` narrows natively — no cast, and `url`/`title` come back typed. The `?? []` guards were dropped: both `sources` and `content` are non-optional, so the type now enforces what the guard used to.
- `response.content` is `ContentBlock[]`. Switching on `block.type` narrows it, which makes the web-search error retry and the page-text trimming readable — and makes explicit something that was previously accidental: `WebSearchToolResultBlock.content` is `WebSearchToolResultError | Array<WebSearchResultBlock>`, which is why one branch treats it as an object and the other as an array.
- `tools: Record<string, any>` and two `as any` on `openai.tools.webSearch(...)` were unnecessary; the anthropic adapter already passed its tool through the same slot uncast.
- Reused the existing `sleep` and `nonEmptyStrings` helpers from `scrape-shared` rather than re-rolling them.

One cast remains, named and documented: `tools` is only passed when web search is on, so the compiler can't tie a `tool-result` back to the tool that produced it and types `output` as `unknown`. The asserted shape is still derived from the SDK via `InferToolOutput`, so a renamed field fails the build.

## Tests

The existing `openai-api` tests mocked `generateText` as `{ text: "answer" }` — a response the real SDK cannot produce, since `sources` and `content` are non-optional. That fake shape is what let the dead probe survive. The mock is now realistic, plus coverage for the behavior that changed: url-vs-document sources, single and fanned-out search queries, non-search actions, and on the anthropic side the query capture, the page-text trimming, and the error retry.

Verified against both the current SDK versions on `main` and the newer ones in #705 — typechecks and passes on both, so it won't collide when that lands.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/27359277-ac34-474c-8af7-e8b7228b8312)
