### PR TITLE
Raise marketing-site conversion: distinct hero, guarantee, tracked CTAs on every page, demo upsell

### DIFF
--- a/.changeset/cloud-guarantee-demo-signin.md
+++ b/.changeset/cloud-guarantee-demo-signin.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+The demo signs you in on arrival and offers Elmo Cloud from its header, and the cloud plan picker now recommends Basic and states the 7-day money-back guarantee.

--- a/apps/web/src/components/demo-cloud-cta.tsx
+++ b/apps/web/src/components/demo-cloud-cta.tsx
@@ -1,0 +1,31 @@
+import { IconCloud } from "@tabler/icons-react";
+import { useRouteContext } from "@tanstack/react-router";
+import { cloudSignupUrl } from "@workspace/config/referrals";
+import type { ClientConfig } from "@workspace/config/types";
+import { buttonVariants } from "@workspace/ui/components/button";
+import { cn } from "@workspace/ui/lib/utils";
+import { trackEventBeforeNavigation } from "@/lib/posthog";
+
+const SIGNUP_URL = cloudSignupUrl("demo-app");
+
+/**
+ * The one ask the demo makes. A visitor clicking through sample data is the
+ * most qualified reader we have, and until now the demo never suggested the
+ * next step. Rendered only on a read-only deployment.
+ */
+export function DemoCloudCta() {
+	const context = useRouteContext({ strict: false }) as { clientConfig?: ClientConfig };
+	if (!context.clientConfig?.features.readOnly) return null;
+
+	return (
+		<a
+			href={SIGNUP_URL}
+			onClick={() => trackEventBeforeNavigation("cta_click", { destination: "cloud-signup", source: "demo-app" })}
+			className={cn(buttonVariants({ size: "sm" }), "ml-auto shrink-0")}
+		>
+			<IconCloud className="size-4" />
+			<span className="hidden sm:inline">Track your own brand</span>
+			<span className="sm:hidden">Your brand</span>
+		</a>
+	);
+}

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -11,6 +11,7 @@ import { Separator } from "@workspace/ui/components/separator";
 import { SidebarTrigger } from "@workspace/ui/components/sidebar";
 import { cn } from "@workspace/ui/lib/utils";
 import { Fragment } from "react";
+import { DemoCloudCta } from "@/components/demo-cloud-cta";
 import { type Crumb, useBreadcrumbs } from "@/lib/breadcrumbs";
 
 // `transition-none` overrides the link's own `transition-colors`: the rail and
@@ -64,6 +65,7 @@ export function SiteHeader() {
 						})}
 					</BreadcrumbList>
 				</Breadcrumb>
+				<DemoCloudCta />
 			</div>
 		</header>
 	);

--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -32,6 +32,34 @@ export function trackEvent(
 	posthog.capture(eventName, properties);
 }
 
+/**
+ * For an event fired by a click that immediately leaves the page (a checkout
+ * redirect, an OAuth hop): sent as a beacon at once, so the navigation cannot
+ * cancel it.
+ */
+export function trackEventBeforeNavigation(
+	eventName: string,
+	properties?: Record<string, string | number | boolean | undefined>,
+): void {
+	if (!initialized) return;
+	posthog.capture(eventName, properties, { send_instantly: true, transport: "sendBeacon" });
+}
+
+/**
+ * Recording is off by default and switched on only for the pages where
+ * someone is deciding whether to pay. It records nothing unless the PostHog
+ * project has recordings enabled, and input values are masked by default.
+ */
+export function startSessionRecording(): void {
+	if (!initialized) return;
+	posthog.startSessionRecording();
+}
+
+export function stopSessionRecording(): void {
+	if (!initialized) return;
+	posthog.stopSessionRecording();
+}
+
 export function setPersonProperties(properties: Record<string, string | number | boolean | undefined>): void {
 	if (!initialized) return;
 	posthog.people.set(properties);

--- a/apps/web/src/lib/signup-funnel.ts
+++ b/apps/web/src/lib/signup-funnel.ts
@@ -1,0 +1,35 @@
+/**
+ * Bridges the one gap in the signup funnel that no page can see on its own:
+ * the email verification link opens in a fresh tab, so the page it lands on
+ * has no idea a signup preceded it. The sign-up page leaves this marker, and
+ * the first signed-in page consumes it to report the verification.
+ */
+
+const KEY = "elmo:signup-pending-verification";
+
+export interface PendingVerification {
+	ref?: string;
+}
+
+export function markVerificationPending(pending: PendingVerification): void {
+	try {
+		window.localStorage.setItem(KEY, JSON.stringify(pending));
+	} catch {
+		// Private mode or a full store: the funnel loses one step, nothing else.
+	}
+}
+
+/** Reads and clears the marker, so a verification is reported once. */
+export function consumeVerificationPending(): PendingVerification | null {
+	try {
+		const raw = window.localStorage.getItem(KEY);
+		if (!raw) return null;
+		window.localStorage.removeItem(KEY);
+		const parsed: unknown = JSON.parse(raw);
+		if (typeof parsed !== "object" || parsed === null) return {};
+		const ref = (parsed as { ref?: unknown }).ref;
+		return typeof ref === "string" ? { ref } : {};
+	} catch {
+		return null;
+	}
+}

--- a/apps/web/src/routes/_authed.tsx
+++ b/apps/web/src/routes/_authed.tsx
@@ -17,7 +17,8 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { SiteHeader } from "@/components/site-header";
 import { useShellScope } from "@/hooks/use-shell-scope";
 import { identifyCrispUser } from "@/lib/crisp";
-import { identifyUser, setPersonProperties } from "@/lib/posthog";
+import { identifyUser, setPersonProperties, trackEvent } from "@/lib/posthog";
+import { consumeVerificationPending } from "@/lib/signup-funnel";
 import { viewerQuery } from "@/lib/viewer/queries";
 
 export const Route = createFileRoute("/_authed")({
@@ -49,16 +50,23 @@ function AuthedLayout() {
 		if (!user || identifiedRef.current === user.id) return;
 		identifiedRef.current = user.id;
 
-		identifyUser(user.id, {
-			email: user.email,
-			name: user.name,
-			deployment_mode: context.clientConfig?.mode,
-		});
-		setPersonProperties({
-			deployment_mode: context.clientConfig?.mode,
-		});
+		// The demo signs every visitor in as one shared account. Identifying
+		// them would fold every visitor into that one person and cut the trail
+		// that began on the marketing site, so the demo stays anonymous.
+		if (!context.clientConfig?.features.readOnly) {
+			identifyUser(user.id, {
+				email: user.email,
+				name: user.name,
+				deployment_mode: context.clientConfig?.mode,
+			});
+			setPersonProperties({
+				deployment_mode: context.clientConfig?.mode,
+			});
+			const pending = consumeVerificationPending();
+			if (pending) trackEvent("email_verified", { ref: pending.ref });
+		}
 		identifyCrispUser({ id: user.id, email: user.email, name: user.name });
-	}, [context.session?.user, context.clientConfig?.mode]);
+	}, [context.session?.user, context.clientConfig?.mode, context.clientConfig?.features.readOnly]);
 
 	return <Shell />;
 }

--- a/apps/web/src/routes/_authed/choose-plan.tsx
+++ b/apps/web/src/routes/_authed/choose-plan.tsx
@@ -11,7 +11,7 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
-import type { PlanKey } from "@workspace/config/plans";
+import { MONEY_BACK_GUARANTEE_DAYS, type PlanKey, RECOMMENDED_PLAN } from "@workspace/config/plans";
 import { authClient } from "@workspace/lib/auth/client";
 import { Alert, AlertDescription } from "@workspace/ui/components/alert";
 import { Badge } from "@workspace/ui/components/badge";
@@ -22,6 +22,7 @@ import { useEffect, useState } from "react";
 import { z } from "zod";
 import { PlanComparison } from "@/components/plan-comparison";
 import { forgetPaywall } from "@/lib/billing/queries";
+import { startSessionRecording, stopSessionRecording, trackEvent, trackEventBeforeNavigation } from "@/lib/posthog";
 import { pageHead } from "@/lib/route-head";
 import { getPaywallStateFn, type PaywallRequired, type PaywallState } from "@/server/billing";
 
@@ -77,6 +78,7 @@ function ActivatingOrganization({ organizationId }: { organizationId?: string })
 			for (let i = 0; i < 30 && !cancelled; i++) {
 				const state = await getPaywallStateFn({ data: { organizationId } });
 				if (!state.needsPlan) {
+					trackEvent("checkout_completed", { organization_id: organizationId });
 					forgetPaywall(queryClient);
 					navigate({ to: "/app" });
 					return;
@@ -105,9 +107,16 @@ function PlanPicker({ paywall }: { paywall: PaywallRequired }) {
 	const [error, setError] = useState<string | null>(null);
 	const isAdmin = paywall.isOrgAdmin;
 
+	// Where the decision to pay is made, so the one page worth watching.
+	useEffect(() => {
+		startSessionRecording();
+		return stopSessionRecording;
+	}, []);
+
 	const subscribe = async (plan: PlanKey) => {
 		setSubscribing(plan);
 		setError(null);
+		trackEventBeforeNavigation("checkout_started", { plan, annual });
 		const origin = window.location.origin;
 		const { error: upgradeError } = await authClient.subscription.upgrade({
 			plan,
@@ -128,7 +137,10 @@ function PlanPicker({ paywall }: { paywall: PaywallRequired }) {
 		<div className="mx-auto max-w-6xl space-y-8 p-8">
 			<div className="space-y-2 text-center">
 				<h1 className="text-3xl font-bold">Choose your plan</h1>
-				<p className="text-muted-foreground">Start tracking how AI answer engines talk about your brand.</p>
+				<p className="text-muted-foreground">
+					Start tracking how AI answer engines talk about your brand. Cancel anytime, {MONEY_BACK_GUARANTEE_DAYS}-day
+					money-back guarantee.
+				</p>
 				<div className="flex items-center justify-center gap-3 pt-2">
 					<span className={annual ? "text-muted-foreground" : "font-medium"}>Monthly</span>
 					<Switch checked={annual} onCheckedChange={setAnnual} aria-label="Annual billing" />
@@ -153,7 +165,7 @@ function PlanPicker({ paywall }: { paywall: PaywallRequired }) {
 
 			<PlanComparison
 				annual={annual}
-				highlightPlan="pro"
+				highlightPlan={RECOMMENDED_PLAN}
 				renderAction={(plan) => (
 					<Button
 						className="w-full"

--- a/apps/web/src/routes/auth/login.tsx
+++ b/apps/web/src/routes/auth/login.tsx
@@ -17,11 +17,12 @@ import { Button } from "@workspace/ui/components/button";
 import { Input } from "@workspace/ui/components/input";
 import { Label } from "@workspace/ui/components/label";
 import { Separator } from "@workspace/ui/components/separator";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { z } from "zod";
 import { AuthSplitLayout } from "@/components/auth/auth-split-layout";
 import { SalesFooterLinks, SalesPanel } from "@/components/auth/sales-panel";
 import FullPageCard from "@/components/full-page-card";
+import { trackEventBeforeNavigation } from "@/lib/posthog";
 import { safeReturnTo } from "@/lib/return-to";
 import { buildTitle, getAppName } from "@/lib/route-head";
 
@@ -140,10 +141,10 @@ export function SSOLogin({ destination = "/app" }: { destination?: string }) {
 
 export function DemoLogin({ destination = "/app" }: { destination?: string }) {
 	const [error, setError] = useState<string | null>(null);
-	const [loading, setLoading] = useState(false);
+	const [loading, setLoading] = useState(true);
+	const attempted = useRef(false);
 
-	async function handleSubmit(e: React.FormEvent) {
-		e.preventDefault();
+	const signIn = useCallback(async () => {
 		setError(null);
 		setLoading(true);
 
@@ -159,10 +160,23 @@ export function DemoLogin({ destination = "/app" }: { destination?: string }) {
 			setError("Something went wrong. Please try again.");
 			setLoading(false);
 		}
+	}, [destination]);
+
+	// The credentials are public, so there is nothing for a visitor to type:
+	// the page signs them in on arrival, and the button is only for a retry.
+	useEffect(() => {
+		if (attempted.current) return;
+		attempted.current = true;
+		void signIn();
+	}, [signIn]);
+
+	function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		void signIn();
 	}
 
 	return (
-		<FullPageCard title="Sign in">
+		<FullPageCard title={loading ? "Signing in to the demo..." : "Sign in"}>
 			<form onSubmit={handleSubmit} className="space-y-4 w-full">
 				<DemoCredentialsCallout />
 				{error && (
@@ -228,6 +242,7 @@ export function EmailPasswordLogin({
 				return;
 			}
 
+			trackEventBeforeNavigation("login_completed", { method: "email" });
 			window.location.href = destination;
 		} catch {
 			setError("Something went wrong. Please try again.");
@@ -248,7 +263,10 @@ export function EmailPasswordLogin({
 						type="button"
 						variant="outline"
 						className="w-full"
-						onClick={() => authClient.signIn.social({ provider: "google", callbackURL: destination })}
+						onClick={() => {
+							trackEventBeforeNavigation("login_started", { method: "google" });
+							authClient.signIn.social({ provider: "google", callbackURL: destination });
+						}}
 					>
 						<IconBrandGoogle className="size-4" />
 						Continue with Google

--- a/apps/web/src/routes/auth/register.tsx
+++ b/apps/web/src/routes/auth/register.tsx
@@ -8,7 +8,7 @@
 
 import { IconBrandGoogle } from "@tabler/icons-react";
 import { createFileRoute, Link, useNavigate, useRouteContext } from "@tanstack/react-router";
-import { CLOUD_ENTRY_PRICE_USD } from "@workspace/config/plans";
+import { CLOUD_ENTRY_PRICE_USD, MONEY_BACK_GUARANTEE_DAYS } from "@workspace/config/plans";
 import type { ClientConfig } from "@workspace/config/types";
 import { authClient } from "@workspace/lib/auth/client";
 import { Alert, AlertDescription } from "@workspace/ui/components/alert";
@@ -16,13 +16,15 @@ import { Button } from "@workspace/ui/components/button";
 import { Input } from "@workspace/ui/components/input";
 import { Label } from "@workspace/ui/components/label";
 import { Separator } from "@workspace/ui/components/separator";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { z } from "zod";
 import { AuthSplitLayout } from "@/components/auth/auth-split-layout";
 import { SalesFooterLinks, SalesPanel } from "@/components/auth/sales-panel";
 import FullPageCard from "@/components/full-page-card";
+import { startSessionRecording, stopSessionRecording, trackEvent, trackEventBeforeNavigation } from "@/lib/posthog";
 import { safeReturnTo } from "@/lib/return-to";
 import { buildTitle, getAppName } from "@/lib/route-head";
+import { markVerificationPending } from "@/lib/signup-funnel";
 
 export const Route = createFileRoute("/auth/register")({
 	validateSearch: z.object({
@@ -86,10 +88,19 @@ export function RegisterForm({
 	const [resending, setResending] = useState(false);
 	const source = isCloud ? "cloud-signup" : "self-hosted-signup";
 
+	// Only where someone is deciding whether to pay; a self-hosted admin
+	// creating the bootstrap account is not a funnel.
+	useEffect(() => {
+		if (!isCloud) return;
+		startSessionRecording();
+		return stopSessionRecording;
+	}, [isCloud]);
+
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
 		setError(null);
 		setLoading(true);
+		trackEvent("signup_started", { method: "email", ref: incomingRef });
 
 		try {
 			const result = await authClient.signUp.email({
@@ -105,7 +116,10 @@ export function RegisterForm({
 				return;
 			}
 
+			trackEvent("signup_completed", { method: "email", ref: incomingRef });
+
 			if (isCloud) {
+				markVerificationPending({ ref: incomingRef });
 				setPendingVerification(true);
 				setLoading(false);
 				return;
@@ -147,7 +161,7 @@ export function RegisterForm({
 			title={isCloud ? "Start tracking your AI visibility" : "Create your admin account"}
 			subtitle={
 				isCloud
-					? `Plans start at $${CLOUD_ENTRY_PRICE_USD}/mo. Cancel any time.`
+					? `Plans start at $${CLOUD_ENTRY_PRICE_USD}/mo. Cancel any time, ${MONEY_BACK_GUARANTEE_DAYS}-day money-back guarantee.`
 					: "This is the owner account for your self-hosted instance."
 			}
 			pitch={<SalesPanel variant={isCloud ? "cloud" : "self-hosted"} source={source} />}
@@ -159,7 +173,10 @@ export function RegisterForm({
 						type="button"
 						variant="outline"
 						className="w-full"
-						onClick={() => authClient.signIn.social({ provider: "google", callbackURL: safeReturnTo(returnTo) })}
+						onClick={() => {
+							trackEventBeforeNavigation("signup_started", { method: "google", ref: incomingRef });
+							authClient.signIn.social({ provider: "google", callbackURL: safeReturnTo(returnTo) });
+						}}
 					>
 						<IconBrandGoogle className="size-4" />
 						Continue with Google

--- a/apps/www/src/components/ai-visibility-software-hub.tsx
+++ b/apps/www/src/components/ai-visibility-software-hub.tsx
@@ -1,6 +1,4 @@
-import { Link } from "@tanstack/react-router";
-import { buttonVariants } from "@workspace/ui/components/button";
-import { ArrowRight } from "lucide-react";
+import { CloudSignupCTA, SelfHostCTA } from "./cta-buttons";
 
 const LINK = "font-medium text-blue-700 underline underline-offset-2 hover:text-blue-900";
 
@@ -137,8 +135,8 @@ export function AiVisibilitySoftwareHub() {
 							</p>
 							<p>
 								That matters in a market full of opaque scoring and inflated pricing. With Elmo you own your data and
-								avoid vendor lock-in: the self-hosted core is free, with a managed cloud option on the way. To see how
-								it compares with the rest of the field, read our roundup of the{" "}
+								avoid vendor lock-in: the self-hosted core is free, and Elmo Cloud runs it for you from $29/mo. To see
+								how it compares with the rest of the field, read our roundup of the{" "}
 								<a className={LINK} href="/blog/best-ai-visibility-tools">
 									best AI visibility tools
 								</a>{" "}
@@ -149,19 +147,9 @@ export function AiVisibilitySoftwareHub() {
 								.
 							</p>
 						</div>
-						<div className="mt-8 flex flex-wrap gap-3">
-							<Link to="/docs" className={buttonVariants({ size: "sm" })}>
-								Read the docs
-								<ArrowRight className="size-3.5" />
-							</Link>
-							<a
-								href="https://github.com/elmohq/elmo"
-								target="_blank"
-								rel="noopener noreferrer"
-								className={buttonVariants({ variant: "outline", size: "sm" })}
-							>
-								Star on GitHub
-							</a>
+						<div className="mt-8 flex flex-wrap items-center gap-2">
+							<CloudSignupCTA source="marketing-directory" />
+							<SelfHostCTA source="marketing-directory" />
 						</div>
 					</div>
 				</div>

--- a/apps/www/src/components/blog-post-layout.tsx
+++ b/apps/www/src/components/blog-post-layout.tsx
@@ -10,6 +10,7 @@ import { ArrowLeft } from "lucide-react";
 import type { ComponentPropsWithoutRef } from "react";
 import { Suspense } from "react";
 import { AuthorByline } from "@/components/author-byline";
+import { CloudCallout } from "@/components/cloud-callout";
 import { Footer } from "@/components/footer";
 import { getMDXComponents } from "@/components/mdx";
 import { Navbar } from "@/components/navbar";
@@ -102,6 +103,9 @@ export function BlogPostLayout({ data }: { data: BlogPostLoaderData }) {
 						<Suspense>{clientLoader.useContent(data.path)}</Suspense>
 						{data.faq && data.faq.length > 0 && <PostFaq items={data.faq} />}
 					</article>
+					<div className="mt-14">
+						<CloudCallout variant="blog" />
+					</div>
 				</main>
 				<Footer />
 			</div>

--- a/apps/www/src/components/cloud-callout.tsx
+++ b/apps/www/src/components/cloud-callout.tsx
@@ -1,0 +1,31 @@
+import { CLOUD_ENTRY_PRICE_USD, MONEY_BACK_GUARANTEE_DAYS } from "@workspace/config/plans";
+import { CloudSignupCTA, SelfHostCTA } from "./cta-buttons";
+
+type Variant = "docs" | "blog";
+
+/**
+ * The cloud offer, placed where a reader is most likely to want it. In the
+ * docs that is the point where self-hosting starts to look like work (API
+ * keys, scraper accounts); on the blog it is the end of a post that just
+ * explained why any of this matters. Available to MDX as <CloudCallout />.
+ */
+export function CloudCallout({ variant = "docs" }: { variant?: Variant }) {
+	const source = variant === "blog" ? "marketing-blog" : "marketing-docs";
+	const heading = variant === "blog" ? "Track how AI answers talk about your brand" : "Don't want to self-host?";
+	const body =
+		variant === "blog"
+			? `Elmo is open source. Run it in our cloud from $${CLOUD_ENTRY_PRICE_USD}/mo with a ${MONEY_BACK_GUARANTEE_DAYS}-day money-back guarantee, or self-host it for free.`
+			: `Elmo Cloud runs this same product for you from $${CLOUD_ENTRY_PRICE_USD}/mo, with a ${MONEY_BACK_GUARANTEE_DAYS}-day money-back guarantee. No Docker, no API keys, no scraper accounts.`;
+
+	return (
+		<aside className="not-prose my-8 rounded-md border border-blue-200 bg-blue-50/40 p-6">
+			<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-blue-600">/ Elmo Cloud</p>
+			<h2 className="mt-2 text-xl font-semibold tracking-tight text-zinc-950">{heading}</h2>
+			<p className="mt-2 max-w-[60ch] text-pretty text-sm leading-relaxed text-zinc-600">{body}</p>
+			<div className="mt-4 flex flex-wrap items-center gap-2">
+				<CloudSignupCTA source={source} />
+				{variant === "blog" && <SelfHostCTA source={source} />}
+			</div>
+		</aside>
+	);
+}

--- a/apps/www/src/components/competitor-comparison.tsx
+++ b/apps/www/src/components/competitor-comparison.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
+import { CLOUD_ENTRY_PRICE_USD, MONEY_BACK_GUARANTEE_DAYS } from "@workspace/config/plans";
 import { Badge } from "@workspace/ui/components/badge";
-import { buttonVariants } from "@workspace/ui/components/button";
 import { AlertTriangle, ArrowLeft, Check, ExternalLink, X } from "lucide-react";
 import {
 	CATEGORY_LABELS,
@@ -14,6 +14,7 @@ import {
 	getScreenshotUrl,
 	isLowDR,
 } from "@/lib/competitors";
+import { CloudSignupCTA, SelfHostCTA } from "./cta-buttons";
 import { Faq } from "./faq";
 
 function FeatureRow({ label, elmo, competitor }: { label: string; elmo: boolean; competitor: boolean }) {
@@ -113,10 +114,11 @@ export function CompetitorComparison({ competitor }: { competitor: Competitor })
 							<Badge variant="secondary">Open Source</Badge>
 							<Badge variant="secondary">Self-Hosted</Badge>
 							<Badge variant="secondary">White-Label</Badge>
+							<Badge variant="secondary">Cloud from ${CLOUD_ENTRY_PRICE_USD}/mo</Badge>
 						</div>
 						<p className="mt-3 text-sm text-zinc-600">
-							Open-source AEO platform. Self-host for free, forever. Track AI visibility across ChatGPT, Claude, and
-							Google AI Overviews with full transparency.
+							Open-source AEO platform. Self-host for free, forever, or let us run it from ${CLOUD_ENTRY_PRICE_USD}
+							/mo. Track AI visibility across ChatGPT, Claude, and Google AI Overviews with full transparency.
 						</p>
 					</div>
 					<div>
@@ -287,8 +289,8 @@ export function CompetitorComparison({ competitor }: { competitor: Competitor })
 						<div className="rounded-md border border-zinc-200 bg-white p-5">
 							<h3 className="font-semibold text-zinc-950">Self-host for free, forever</h3>
 							<p className="mt-2 text-sm text-zinc-600">
-								Run Elmo on your own infrastructure. The core platform is free and always will be, even when we release
-								a cloud version of Elmo.
+								Run Elmo on your own infrastructure. The core platform is free and always will be. Elmo Cloud runs the
+								same code for teams that would rather not host it.
 							</p>
 						</div>
 						<div className="rounded-md border border-zinc-200 bg-white p-5">
@@ -315,23 +317,15 @@ export function CompetitorComparison({ competitor }: { competitor: Competitor })
 			{/* CTA */}
 			<section className="border-b border-zinc-200 bg-white py-16 lg:py-24">
 				<div className="mx-auto max-w-3xl px-4 text-center md:px-6">
-					<h2 className="font-heading text-3xl text-zinc-950 md:text-4xl">Ready to track your AI visibility?</h2>
+					<h2 className="font-heading text-3xl text-zinc-950 md:text-4xl">Switching from {competitor.name}?</h2>
 					<p className="mx-auto mt-4 max-w-xl text-lg text-balance text-zinc-600">
-						Deploy Elmo in minutes and start monitoring how ChatGPT, Claude, and Google AI Overviews talk about your
-						brand.
+						Elmo Cloud runs the same open-source product from ${CLOUD_ENTRY_PRICE_USD}/mo with a{" "}
+						{MONEY_BACK_GUARANTEE_DAYS}-day money-back guarantee, or self-host it for free. Either way, every export is
+						yours.
 					</p>
-					<div className="mt-8 flex flex-wrap justify-center gap-3">
-						<Link to="/docs" className={buttonVariants({ size: "sm" })}>
-							Deploy Elmo
-						</Link>
-						<a
-							href="https://github.com/elmohq/elmo"
-							target="_blank"
-							rel="noopener noreferrer"
-							className={buttonVariants({ variant: "outline", size: "sm" })}
-						>
-							View on GitHub
-						</a>
+					<div className="mt-8 flex flex-wrap items-center justify-center gap-2">
+						<CloudSignupCTA source="marketing-comparison" />
+						<SelfHostCTA source="marketing-comparison" />
 					</div>
 				</div>
 			</section>

--- a/apps/www/src/components/competitor-directory.tsx
+++ b/apps/www/src/components/competitor-directory.tsx
@@ -1,5 +1,4 @@
 import { Link } from "@tanstack/react-router";
-import { buttonVariants } from "@workspace/ui/components/button";
 import { Check, X } from "lucide-react";
 import { useState } from "react";
 import {
@@ -14,6 +13,7 @@ import {
 	getPopularityGrade,
 	sortedCompetitors,
 } from "@/lib/competitors";
+import { CloudSignupCTA, SelfHostCTA } from "./cta-buttons";
 
 function FeatureIcon({ has }: { has: boolean }) {
 	return has ? <Check className="mx-auto h-4 w-4 text-blue-600" /> : <X className="mx-auto h-4 w-4 text-zinc-300" />;
@@ -94,18 +94,9 @@ export function CompetitorDirectory() {
 					<p className="mx-auto mt-4 max-w-xl text-lg text-balance text-zinc-600">
 						Open source, self-hosted, and transparent. Track AI visibility without vendor lock-in or inflated pricing.
 					</p>
-					<div className="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-						<Link to="/docs" className={buttonVariants({ size: "sm" })}>
-							Read the Docs
-						</Link>
-						<a
-							href="https://github.com/elmohq/elmo"
-							target="_blank"
-							rel="noopener noreferrer"
-							className={buttonVariants({ variant: "outline", size: "sm" })}
-						>
-							View on GitHub
-						</a>
+					<div className="mt-6 flex flex-wrap items-center justify-center gap-2">
+						<CloudSignupCTA source="marketing-directory" />
+						<SelfHostCTA source="marketing-directory" />
 					</div>
 				</div>
 			</section>

--- a/apps/www/src/components/cta-buttons.tsx
+++ b/apps/www/src/components/cta-buttons.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
-import { CLOUD_SIGNUP_URL } from "@workspace/config/plans";
+import { cloudSignupUrl, type ReferralSource } from "@workspace/config/referrals";
 import { ArrowRight, ArrowUpRight } from "lucide-react";
+import { type CtaDestination, trackCta } from "@/lib/analytics";
 import { externalRel } from "@/lib/external-link";
 
 const PRIMARY_CLS =
@@ -8,101 +9,70 @@ const PRIMARY_CLS =
 const GHOST_CLS =
 	"inline-flex h-8 items-center gap-1.5 rounded-md bg-white px-3 text-sm font-medium leading-none text-zinc-900 ring-1 ring-zinc-200 hover:bg-zinc-50 hover:ring-zinc-300";
 
-function Anchor({
-	to,
-	href,
-	external,
-	cls,
-	children,
-}: {
-	to?: string;
-	href?: string;
-	external?: boolean;
-	cls: string;
-	children: React.ReactNode;
-}) {
-	if (to) {
-		return (
-			<Link to={to} className={cls}>
-				{children}
-			</Link>
-		);
-	}
-	if (href) {
-		return (
-			<a href={href} className={cls} {...(external ? { target: "_blank", rel: externalRel(href) } : {})}>
-				{children}
-			</a>
-		);
-	}
-	return null;
-}
-
-function PrimaryCTA({
-	to,
-	href,
-	external,
-	children,
-	className = "",
-}: {
-	to?: string;
-	href?: string;
-	external?: boolean;
-	children: React.ReactNode;
-	className?: string;
-}) {
-	return (
-		<Anchor to={to} href={href} external={external} cls={`${PRIMARY_CLS} ${className}`}>
-			{children}
-		</Anchor>
-	);
-}
-
-function GhostCTA({
-	to,
-	href,
-	external,
-	children,
-	className = "",
-}: {
-	to?: string;
-	href?: string;
-	external?: boolean;
-	children: React.ReactNode;
-	className?: string;
-}) {
-	return (
-		<Anchor to={to} href={href} external={external} cls={`${GHOST_CLS} ${className}`}>
-			{children}
-		</Anchor>
-	);
-}
-
 /**
  * The two halves of every call to action on the site, in this order: cloud is
  * what we sell, self-hosting is what makes it trustworthy. Signup opens in the
  * same tab — a conversion click should navigate, not spawn a background tab.
+ *
+ * Every button names the surface it sits on. The signup link carries it as
+ * `ref` so the app can attribute the account, and the click event carries it so
+ * the funnel can be read per button rather than per site.
  */
-export function CloudSignupCTA({ label = "Start with Cloud" }: { label?: string }) {
+export function CloudSignupCTA({
+	source,
+	label = "Start with Cloud",
+	className = "",
+}: {
+	source: ReferralSource;
+	label?: string;
+	className?: string;
+}) {
 	return (
-		<PrimaryCTA href={CLOUD_SIGNUP_URL}>
+		<a
+			href={cloudSignupUrl(source)}
+			onClick={() => trackCta("cloud-signup", source)}
+			className={`${PRIMARY_CLS} ${className}`}
+		>
 			{label}
 			<ArrowRight className="size-3.5" />
-		</PrimaryCTA>
+		</a>
 	);
 }
 
-export function SelfHostCTA({ label = "Self-host free" }: { label?: string }) {
-	return <GhostCTA to="/docs">{label}</GhostCTA>;
+export function SelfHostCTA({
+	source,
+	label = "Self-host free",
+	className = "",
+}: {
+	source: ReferralSource;
+	label?: string;
+	className?: string;
+}) {
+	return (
+		<Link to="/docs" onClick={() => trackCta("self-host", source)} className={`${GHOST_CLS} ${className}`}>
+			{label}
+		</Link>
+	);
 }
 
 /** Third-tier link for the option that supports a CTA without competing with it. */
-export function QuietCTA({ href, children }: { href: string; children: React.ReactNode }) {
+export function QuietCTA({
+	href,
+	source,
+	destination,
+	children,
+}: {
+	href: string;
+	source: ReferralSource;
+	destination: CtaDestination;
+	children: React.ReactNode;
+}) {
 	return (
 		<a
 			href={href}
 			target="_blank"
 			rel={externalRel(href)}
+			onClick={() => trackCta(destination, source)}
 			className="group inline-flex items-center gap-1 px-1 text-sm font-medium text-zinc-600 hover:text-zinc-950"
 		>
 			{children}

--- a/apps/www/src/components/cta.tsx
+++ b/apps/www/src/components/cta.tsx
@@ -1,5 +1,6 @@
-import { CLOUD_ENTRY_PRICE_USD } from "@workspace/config/plans";
+import { CLOUD_ENTRY_PRICE_USD, MONEY_BACK_GUARANTEE_DAYS } from "@workspace/config/plans";
 import { bookDemoUrl } from "@workspace/config/referrals";
+import { trackCta } from "@/lib/analytics";
 import { externalRel } from "@/lib/external-link";
 import { CloudSignupCTA, QuietCTA, SelfHostCTA } from "./cta-buttons";
 import { QuickstartBlock } from "./quickstart-block";
@@ -21,13 +22,16 @@ export function CTA() {
 							Start tracking AI answers today.
 						</h2>
 						<p className="mt-5 max-w-[52ch] text-pretty text-zinc-600 md:text-lg">
-							Sign up for the cloud and we run everything for you from ${CLOUD_ENTRY_PRICE_USD}/mo, or run the same
-							open-source product on your own infra for free.
+							Sign up for the cloud and we run everything for you from ${CLOUD_ENTRY_PRICE_USD}/mo, backed by a{" "}
+							{MONEY_BACK_GUARANTEE_DAYS}-day money-back guarantee. Or run the same open-source product on your own
+							infra for free.
 						</p>
 						<div className="mt-7 flex flex-wrap items-center gap-2">
-							<CloudSignupCTA />
-							<SelfHostCTA />
-							<QuietCTA href="https://github.com/elmohq/elmo">View source</QuietCTA>
+							<CloudSignupCTA source="marketing-cta" />
+							<SelfHostCTA source="marketing-cta" />
+							<QuietCTA href="https://github.com/elmohq/elmo" source="marketing-cta" destination="github">
+								View source
+							</QuietCTA>
 						</div>
 						{/* A fourth button would flatten the three above it, so the call
 						    that suits someone still deciding is offered as a sentence. */}
@@ -37,6 +41,7 @@ export function CTA() {
 								href={DEMO_URL}
 								target="_blank"
 								rel={externalRel(DEMO_URL)}
+								onClick={() => trackCta("book-demo", "marketing-cta")}
 								className="font-medium text-zinc-700 underline underline-offset-2 hover:text-zinc-950"
 							>
 								Book a 30-minute demo

--- a/apps/www/src/components/directory-shell.tsx
+++ b/apps/www/src/components/directory-shell.tsx
@@ -1,8 +1,10 @@
 import { Link } from "@tanstack/react-router";
+import { CLOUD_ENTRY_PRICE_USD, MONEY_BACK_GUARANTEE_DAYS } from "@workspace/config/plans";
 import { Badge } from "@workspace/ui/components/badge";
 import { buttonVariants } from "@workspace/ui/components/button";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import type { ReactNode } from "react";
+import { CloudSignupCTA, SelfHostCTA } from "./cta-buttons";
 
 export function DirectoryBackLink({ label = "AI Visibility Tool Directory" }: { label?: string }) {
 	return (
@@ -54,14 +56,13 @@ export function DirectoryElmoBanner({
 				<div className="rounded-md border border-blue-200 bg-blue-50/40 p-6">
 					<h2 className="font-heading text-xl text-zinc-950">Elmo: the open-source alternative</h2>
 					<p className="mt-2 max-w-3xl text-sm leading-relaxed text-zinc-600">{pitch}</p>
-					<div className="mt-4 flex flex-wrap gap-3">
-						<Link to="/docs" className={buttonVariants({ size: "sm" })}>
-							Deploy Elmo
-						</Link>
+					<div className="mt-4 flex flex-wrap items-center gap-2">
+						<CloudSignupCTA source="marketing-directory" />
+						<SelfHostCTA source="marketing-directory" />
 						<Link
 							to="/ai-visibility-tools/$slug"
 							params={{ slug: comparison.slug }}
-							className={buttonVariants({ variant: "outline", size: "sm" })}
+							className={buttonVariants({ variant: "ghost", size: "sm" })}
 						>
 							Elmo vs {comparison.name}
 							<ArrowRight className="h-3.5 w-3.5" />
@@ -79,21 +80,12 @@ export function ElmoCta() {
 			<div className="mx-auto max-w-3xl px-4 text-center md:px-6">
 				<h2 className="font-heading text-3xl text-zinc-950 md:text-4xl">Ready to track your AI visibility?</h2>
 				<p className="mx-auto mt-4 max-w-xl text-lg text-balance text-zinc-600">
-					Deploy Elmo in minutes and start monitoring how ChatGPT, Claude, and Google AI Overviews talk about your
-					brand. Open source, self-hosted, free.
+					Start in our cloud from ${CLOUD_ENTRY_PRICE_USD}/mo with a {MONEY_BACK_GUARANTEE_DAYS}-day money-back
+					guarantee, or self-host the same open-source product for free.
 				</p>
-				<div className="mt-8 flex flex-wrap justify-center gap-3">
-					<Link to="/docs" className={buttonVariants({ size: "sm" })}>
-						Deploy Elmo
-					</Link>
-					<a
-						href="https://github.com/elmohq/elmo"
-						target="_blank"
-						rel="noopener noreferrer"
-						className={buttonVariants({ variant: "outline", size: "sm" })}
-					>
-						View on GitHub
-					</a>
+				<div className="mt-8 flex flex-wrap items-center justify-center gap-2">
+					<CloudSignupCTA source="marketing-directory" />
+					<SelfHostCTA source="marketing-directory" />
 				</div>
 			</div>
 		</section>

--- a/apps/www/src/components/hero.tsx
+++ b/apps/www/src/components/hero.tsx
@@ -1,10 +1,13 @@
 import MuxPlayer from "@mux/mux-player-react";
-import { CLOUD_ENTRY_PRICE_USD } from "@workspace/config/plans";
+import { CLOUD_ENTRY_PRICE_USD, MONEY_BACK_GUARANTEE_DAYS } from "@workspace/config/plans";
+import { demoSiteUrl } from "@workspace/config/referrals";
+import { CUSTOMER_QUOTES } from "@workspace/ui/brand/customers";
 import { G2Stars } from "@workspace/ui/brand/g2-rating";
 import { ArrowUpRight } from "lucide-react";
 import { CloudSignupCTA, QuietCTA, SelfHostCTA } from "./cta-buttons";
 import { CustomerLogosInline } from "./customer-logos";
-import { QuickstartBlock } from "./quickstart-block";
+
+const LIVE_DEMO_URL = demoSiteUrl("marketing-hero");
 
 function DemoVideo() {
 	return (
@@ -29,6 +32,33 @@ function DemoVideo() {
 	);
 }
 
+/**
+ * The rating and the shortest customer line, on one row under the buttons:
+ * the moment someone is deciding whether to click is the moment a third party
+ * vouching for the price is worth the most.
+ */
+function HeroProof() {
+	const { quote, author, company, companyUrl, mark } = CUSTOMER_QUOTES.speakeasy;
+	return (
+		<figure className="mt-8 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
+			<G2Stars />
+			<blockquote className="text-zinc-700">“{quote}”</blockquote>
+			<figcaption className="flex items-center gap-1.5 text-zinc-500">
+				<span>{author} at</span>
+				<a
+					href={companyUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					aria-label={company}
+					className="inline-flex items-center text-zinc-950 transition-opacity hover:opacity-80"
+				>
+					{mark}
+				</a>
+			</figcaption>
+		</figure>
+	);
+}
+
 export function Hero() {
 	return (
 		<section className="relative border-b border-zinc-200 bg-white">
@@ -37,7 +67,7 @@ export function Hero() {
 				className="pointer-events-none absolute inset-0 [background-image:linear-gradient(to_right,rgb(0_0_0/0.04)_1px,transparent_1px),linear-gradient(to_bottom,rgb(0_0_0/0.04)_1px,transparent_1px)] [background-size:48px_48px] [mask-image:linear-gradient(to_bottom,black,transparent_85%)]"
 			/>
 			<div className="relative mx-auto max-w-6xl px-4 pb-16 pt-16 md:px-6 lg:pb-24 lg:pt-24">
-				<div className="grid items-start gap-10 lg:grid-cols-12 lg:gap-12">
+				<div className="grid items-center gap-10 lg:grid-cols-12 lg:gap-12">
 					<div className="lg:col-span-7">
 						<div className="flex flex-wrap items-center gap-2">
 							<span className="inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-2.5 py-1 font-mono text-[11px] text-zinc-700">
@@ -52,28 +82,30 @@ export function Hero() {
 								Star on GitHub
 								<ArrowUpRight className="size-3 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
 							</a>
-							<G2Stars className="ml-auto" />
 						</div>
-						<h1 className="mt-7 max-w-[18ch] text-5xl font-semibold leading-[1.05] tracking-tight text-balance text-zinc-950 sm:text-6xl lg:text-[4.25rem] lg:leading-[1.0]">
-							Know How AI Talks About Your Brand
+						<h1 className="mt-7 max-w-[16ch] text-5xl font-semibold leading-[1.05] tracking-tight text-balance text-zinc-950 sm:text-6xl lg:text-[4.25rem] lg:leading-[1.0]">
+							Your brand, according to ChatGPT.
 						</h1>
 						<p className="mt-6 max-w-[58ch] text-pretty text-base text-zinc-600 md:text-lg">
-							Track your brand's visibility across any AI model. Monitor mentions, analyze citations, and benchmark
-							competitors. Run it in our cloud or self-host — it's open source, so your data stays yours and you'll
-							never get locked in.
+							Elmo records what ChatGPT, Perplexity, Gemini, Claude, and Google AI Overviews say about you: every
+							mention, every citation, every competitor named instead, tracked daily. It's open source, so run it in our
+							cloud or on your own servers and keep the data either way.
 						</p>
 						<div className="mt-8 flex flex-wrap items-center gap-2">
-							<CloudSignupCTA />
-							<SelfHostCTA />
-							<QuietCTA href="https://demo.elmohq.com">Live demo</QuietCTA>
+							<CloudSignupCTA source="marketing-hero" />
+							<SelfHostCTA source="marketing-hero" />
+							<QuietCTA href={LIVE_DEMO_URL} source="marketing-hero" destination="live-demo">
+								Live demo
+							</QuietCTA>
 						</div>
 						<p className="mt-3 text-sm text-zinc-500">
-							Managed cloud from ${CLOUD_ENTRY_PRICE_USD}/mo. Self-hosting is free forever.
+							Cloud from ${CLOUD_ENTRY_PRICE_USD}/mo, cancel anytime, {MONEY_BACK_GUARANTEE_DAYS}-day money-back
+							guarantee. Self-hosting is free forever.
 						</p>
+						<HeroProof />
 						<CustomerLogosInline />
 					</div>
-					<aside className="flex flex-col gap-4 lg:col-span-5">
-						<QuickstartBlock />
+					<aside className="lg:col-span-5">
 						<DemoVideo />
 					</aside>
 				</div>

--- a/apps/www/src/components/mdx.tsx
+++ b/apps/www/src/components/mdx.tsx
@@ -2,6 +2,7 @@ import { FeedbackBlock } from "@workspace/docs/components/feedback/client";
 import type { ActionResponse, BlockFeedback } from "@workspace/docs/components/feedback/schema";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
+import { CloudCallout } from "@/components/cloud-callout";
 import { ProviderCTA } from "@/components/provider-cta";
 import { YouTubeEmbed } from "@/components/youtube-embed";
 
@@ -24,6 +25,7 @@ export function getMDXComponents(components?: MDXComponents) {
 		),
 		YouTube: YouTubeEmbed,
 		ProviderCTA,
+		CloudCallout,
 		...components,
 	} satisfies MDXComponents;
 }

--- a/apps/www/src/components/navbar.tsx
+++ b/apps/www/src/components/navbar.tsx
@@ -1,5 +1,5 @@
 import { Link, useLoaderData } from "@tanstack/react-router";
-import { CLOUD_SIGNUP_URL } from "@workspace/config/plans";
+import { cloudLoginUrl, cloudSignupUrl } from "@workspace/config/referrals";
 import { Button } from "@workspace/ui/components/button";
 import {
 	NavigationMenu,
@@ -9,16 +9,22 @@ import {
 } from "@workspace/ui/components/navigation-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "@workspace/ui/components/popover";
 import { ArrowRight } from "lucide-react";
+import { trackCta } from "@/lib/analytics";
 import { formatStarCount } from "@/lib/github-stars";
 import { Logo } from "./logo";
 
 const navigationLinks = [
+	{ href: "/features", label: "Features" },
 	{ href: "/pricing", label: "Pricing" },
 	{ href: "/changelog", label: "Changelog" },
 	{ href: "/roadmap", label: "Roadmap" },
 	{ href: "/vision", label: "Vision" },
 	{ href: "/docs", label: "Docs" },
 ];
+
+const SIGNUP_URL = cloudSignupUrl("marketing-navbar");
+// A customer coming back had no way in from the site short of the sign-up page.
+const LOGIN_URL = cloudLoginUrl("marketing-navbar");
 
 export function Navbar() {
 	const rootData = useLoaderData({ from: "__root__" });
@@ -69,6 +75,15 @@ export function Navbar() {
 											</NavigationMenuLink>
 										</NavigationMenuItem>
 									))}
+									<NavigationMenuItem className="w-full border-t border-zinc-200 pt-1">
+										<NavigationMenuLink
+											href={LOGIN_URL}
+											onClick={() => trackCta("cloud-login", "marketing-navbar")}
+											className="py-1.5"
+										>
+											Log in
+										</NavigationMenuLink>
+									</NavigationMenuItem>
 								</NavigationMenuList>
 							</PopoverContent>
 						</Popover>
@@ -123,10 +138,18 @@ export function Navbar() {
 						)}
 					</a>
 					<a
-						href={CLOUD_SIGNUP_URL}
+						href={LOGIN_URL}
+						onClick={() => trackCta("cloud-login", "marketing-navbar")}
+						className="hidden h-8 items-center px-2 text-sm font-medium text-zinc-600 hover:text-zinc-950 md:inline-flex"
+					>
+						Log in
+					</a>
+					<a
+						href={SIGNUP_URL}
+						onClick={() => trackCta("cloud-signup", "marketing-navbar")}
 						className="inline-flex h-8 items-center gap-1.5 rounded-md bg-blue-600 px-3 text-sm font-medium leading-none text-white ring-1 ring-blue-600 hover:bg-blue-700"
 					>
-						Sign up
+						Get started
 						<ArrowRight className="size-3.5" />
 					</a>
 				</div>

--- a/apps/www/src/components/pricing.tsx
+++ b/apps/www/src/components/pricing.tsx
@@ -1,15 +1,22 @@
 import { Link } from "@tanstack/react-router";
 import {
 	CLOUD_ENTRY_PRICE_USD,
-	CLOUD_SIGNUP_URL,
+	MONEY_BACK_GUARANTEE_DAYS,
 	PLAN_KEYS,
 	PLANS,
+	type PlanDefinition,
 	planPlatformBreakdown,
+	RECOMMENDED_PLAN,
 } from "@workspace/config/plans";
+import { cloudSignupUrl } from "@workspace/config/referrals";
 import { PlatformTier } from "@workspace/ui/brand/platform-tier";
 import { ArrowRight, Check } from "lucide-react";
+import { trackCta } from "@/lib/analytics";
 import { ContactForm } from "./contact-form";
 import { WaitlistForm } from "./waitlist-form";
+
+const SIGNUP_URL = cloudSignupUrl("marketing-pricing");
+const GUARANTEE = `${MONEY_BACK_GUARANTEE_DAYS}-day money-back guarantee`;
 
 interface Plan {
 	id: string;
@@ -18,12 +25,14 @@ interface Plan {
 	desc: string;
 	price: string;
 	priceLabel: string;
+	/** The commitment, stated under the price where the price is decided on. */
+	note?: string;
 	/** Draws the eye to the option we want picked; exactly one plan sets it. */
 	featured?: boolean;
 	features: string[];
 	cta:
-		| { type: "link"; text: string; href: string }
-		| { type: "external"; text: string; href: string }
+		| { type: "cloud"; text: string }
+		| { type: "self-host"; text: string }
 		| { type: "waitlist" }
 		| { type: "contact" };
 }
@@ -36,6 +45,7 @@ const plans: Plan[] = [
 		desc: "We host it, update it, and keep it running.",
 		price: `From $${CLOUD_ENTRY_PRICE_USD}`,
 		priceLabel: "/ mo",
+		note: `Cancel anytime. ${GUARANTEE}.`,
 		featured: true,
 		features: [
 			"Managed hosting, automatic updates",
@@ -45,7 +55,7 @@ const plans: Plan[] = [
 			"API access on every plan",
 			"Unlimited seats",
 		],
-		cta: { type: "external", text: "Start with Cloud", href: CLOUD_SIGNUP_URL },
+		cta: { type: "cloud", text: "Start with Cloud" },
 	},
 	{
 		id: "self-hosted",
@@ -62,7 +72,7 @@ const plans: Plan[] = [
 			"Full source code access",
 			"Community support",
 		],
-		cta: { type: "link", text: "Self-host free", href: "/docs" },
+		cta: { type: "self-host", text: "Self-host free" },
 	},
 	{
 		id: "white-label",
@@ -101,6 +111,79 @@ function formButtonClass(featured?: boolean): string {
 		: `${base} [&_button]:bg-white [&_button]:text-zinc-900 [&_button]:ring-zinc-200 [&_button]:hover:bg-zinc-50 [&_button]:hover:ring-zinc-300`;
 }
 
+function RecommendedPill() {
+	return (
+		<span className="rounded-full bg-blue-600 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.15em] text-white">
+			Recommended
+		</span>
+	);
+}
+
+function PlanAction({ plan }: { plan: Plan }) {
+	const { cta, featured } = plan;
+	switch (cta.type) {
+		case "cloud":
+			return (
+				<a
+					href={SIGNUP_URL}
+					onClick={() => trackCta("cloud-signup", "marketing-pricing")}
+					className={cardCtaClass(featured)}
+				>
+					{cta.text}
+					<ArrowRight className="size-3.5" />
+				</a>
+			);
+		case "self-host":
+			return (
+				<Link to="/docs" onClick={() => trackCta("self-host", "marketing-pricing")} className={cardCtaClass(featured)}>
+					{cta.text}
+					<ArrowRight className="size-3.5" />
+				</Link>
+			);
+		case "waitlist":
+			return <WaitlistForm source="pricing" />;
+		case "contact":
+			return <ContactForm source="pricing" />;
+	}
+}
+
+function PlanCard({ plan }: { plan: Plan }) {
+	return (
+		<div className={`flex flex-col justify-between p-6 lg:p-8 ${plan.featured ? "bg-blue-50/50" : "bg-white"}`}>
+			<div>
+				<div className="flex items-center gap-2">
+					<span className="font-mono text-[11px] uppercase tracking-[0.18em] text-blue-600 tabular-nums">
+						{plan.tag}
+					</span>
+					{plan.featured && <RecommendedPill />}
+				</div>
+				<h3 className="mt-5 text-2xl font-semibold tracking-tight text-zinc-950">{plan.name}</h3>
+				<p className="mt-2 max-w-[36ch] text-pretty text-sm text-zinc-600">{plan.desc}</p>
+				<div className="mt-6 border-y border-zinc-200 py-4">
+					<div className="flex items-baseline gap-2">
+						<span className="text-4xl font-semibold tracking-tight text-zinc-950 tabular-nums">{plan.price}</span>
+						{plan.priceLabel && (
+							<span className="font-mono text-[11px] uppercase tracking-[0.15em] text-zinc-500">{plan.priceLabel}</span>
+						)}
+					</div>
+					{plan.note && <p className="mt-2 text-xs text-zinc-500">{plan.note}</p>}
+				</div>
+				<ul className="mt-6 space-y-2.5 text-sm text-zinc-700">
+					{plan.features.map((f) => (
+						<li key={f} className="flex items-start gap-2">
+							<Check className="mt-0.5 size-3.5 shrink-0 text-blue-600" strokeWidth={3} />
+							<span>{f}</span>
+						</li>
+					))}
+				</ul>
+			</div>
+			<div className={`mt-8 ${formButtonClass(plan.featured)}`}>
+				<PlanAction plan={plan} />
+			</div>
+		</div>
+	);
+}
+
 export function Pricing({ as: Heading = "h2" }: { as?: "h1" | "h2" } = {}) {
 	return (
 		<section id="pricing" className="border-b border-zinc-200 bg-white">
@@ -108,69 +191,63 @@ export function Pricing({ as: Heading = "h2" }: { as?: "h1" | "h2" } = {}) {
 				<div>
 					<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">/ PRICING</p>
 					<Heading className="mt-4 max-w-[28ch] text-4xl font-semibold leading-[1.05] tracking-tight text-balance text-zinc-950 md:text-5xl">
-						Run it in our cloud, self-host it, or white-label it — you choose.
+						Start at ${CLOUD_ENTRY_PRICE_USD}/mo. Or self-host for free.
 					</Heading>
+					<p className="mt-5 max-w-[58ch] text-pretty text-zinc-600 md:text-lg">
+						Every cloud plan is backed by a {GUARANTEE}, and agencies can white-label the whole thing.
+					</p>
 				</div>
 
 				<div className="mt-12 grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-zinc-200 bg-zinc-200 md:grid-cols-3">
 					{plans.map((plan) => (
-						<div
-							key={plan.id}
-							className={`flex flex-col justify-between p-6 lg:p-8 ${plan.featured ? "bg-blue-50/50" : "bg-white"}`}
-						>
-							<div>
-								<div className="flex items-center gap-2">
-									<span className="font-mono text-[11px] uppercase tracking-[0.18em] text-blue-600 tabular-nums">
-										{plan.tag}
-									</span>
-									{plan.featured && (
-										<span className="rounded-full bg-blue-600 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.15em] text-white">
-											Recommended
-										</span>
-									)}
-								</div>
-								<h3 className="mt-5 text-2xl font-semibold tracking-tight text-zinc-950">{plan.name}</h3>
-								<p className="mt-2 max-w-[36ch] text-pretty text-sm text-zinc-600">{plan.desc}</p>
-								<div className="mt-6 flex items-baseline gap-2 border-y border-zinc-200 py-4">
-									<span className="text-4xl font-semibold tracking-tight text-zinc-950 tabular-nums">{plan.price}</span>
-									{plan.priceLabel && (
-										<span className="font-mono text-[11px] uppercase tracking-[0.15em] text-zinc-500">
-											{plan.priceLabel}
-										</span>
-									)}
-								</div>
-								<ul className="mt-6 space-y-2.5 text-sm text-zinc-700">
-									{plan.features.map((f) => (
-										<li key={f} className="flex items-start gap-2">
-											<Check className="mt-0.5 size-3.5 shrink-0 text-blue-600" strokeWidth={3} />
-											<span>{f}</span>
-										</li>
-									))}
-								</ul>
-							</div>
-							<div className={`mt-8 ${formButtonClass(plan.featured)}`}>
-								{plan.cta.type === "link" && (
-									<Link to={plan.cta.href} className={cardCtaClass(plan.featured)}>
-										{plan.cta.text}
-										<ArrowRight className="size-3.5" />
-									</Link>
-								)}
-								{plan.cta.type === "external" && (
-									<a href={plan.cta.href} className={cardCtaClass(plan.featured)}>
-										{plan.cta.text}
-										<ArrowRight className="size-3.5" />
-									</a>
-								)}
-								{plan.cta.type === "waitlist" && <WaitlistForm source="pricing" />}
-								{plan.cta.type === "contact" && <ContactForm source="pricing" />}
-							</div>
-						</div>
+						<PlanCard key={plan.id} plan={plan} />
 					))}
 				</div>
 
 				<CloudPlans />
+				<Compared />
 			</div>
 		</section>
+	);
+}
+
+/**
+ * The one comparison a buyer of this category makes, in the terms the
+ * sign-up page already uses, with the head-to-head pages for the detail.
+ */
+function Compared() {
+	const basic = PLANS[RECOMMENDED_PLAN];
+	return (
+		<div className="mt-16 rounded-lg border border-zinc-200 bg-zinc-50 p-6 lg:p-8">
+			<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">/ COMPARED</p>
+			<h3 className="mt-3 max-w-[32ch] text-2xl font-semibold tracking-tight text-zinc-950 md:text-3xl">
+				{basic.standardRunsPerDay}× Profound's daily runs, at the same price.
+			</h3>
+			<p className="mt-3 max-w-[60ch] text-pretty text-sm text-zinc-600 md:text-base">
+				{basic.name} samples every tracked prompt {basic.standardRunsPerDay} times a day across {basic.platformPicks}{" "}
+				platforms for ${basic.monthlyPriceUsd}/mo, and because Elmo is open source you can check how every number is
+				produced.
+			</p>
+			<div className="mt-5 flex flex-wrap gap-x-5 gap-y-2 text-sm font-medium">
+				<Link
+					to="/ai-visibility-tools/$slug"
+					params={{ slug: "elmo-vs-profound" }}
+					className="text-zinc-700 underline underline-offset-2 hover:text-zinc-950"
+				>
+					Elmo vs Profound
+				</Link>
+				<Link
+					to="/ai-visibility-tools/$slug"
+					params={{ slug: "elmo-vs-peec-ai" }}
+					className="text-zinc-700 underline underline-offset-2 hover:text-zinc-950"
+				>
+					Elmo vs Peec AI
+				</Link>
+				<Link to="/ai-visibility-tools" className="text-zinc-700 underline underline-offset-2 hover:text-zinc-950">
+					All 200+ tools
+				</Link>
+			</div>
+		</div>
 	);
 }
 
@@ -184,57 +261,9 @@ function CloudPlans() {
 			<p className="mt-2 max-w-[52ch] text-sm text-zinc-600">Annual billing saves two months.</p>
 
 			<div className="mt-8 grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-zinc-200 bg-zinc-200 sm:grid-cols-2 lg:grid-cols-5">
-				{PLAN_KEYS.map((key) => {
-					const plan = PLANS[key];
-					const breakdown = planPlatformBreakdown(plan);
-					return (
-						<div key={key} className="flex flex-col bg-white p-5">
-							<h4 className="text-lg font-semibold tracking-tight text-zinc-950">{plan.name}</h4>
-							<div className="mt-2 flex items-baseline gap-1">
-								<span className="text-2xl font-semibold tracking-tight text-zinc-950 tabular-nums">
-									${plan.monthlyPriceUsd}
-								</span>
-								<span className="font-mono text-[10px] uppercase tracking-[0.15em] text-zinc-500">/ mo</span>
-							</div>
-							<p className="mt-1 text-xs text-zinc-500 tabular-nums">${plan.annualPriceUsd}/yr</p>
-
-							<ul className="mt-4 space-y-1.5 text-xs text-zinc-700">
-								<li>
-									{plan.maxBrands} brand{plan.maxBrands === 1 ? "" : "s"}
-								</li>
-								<li>{plan.maxPrompts} tracked prompts</li>
-							</ul>
-
-							{/* The pick tiers all spend the same budget, so they sit together
-							    under what the plan lets you choose. */}
-							<div className="mt-4 space-y-2.5 border-t border-zinc-100 pt-4">
-								<p className="text-xs font-medium text-zinc-900">{breakdown.pickHeading}</p>
-								{breakdown.pickGroups.map((group) => (
-									<PlatformTier
-										key={group.id}
-										label={group.label}
-										runsPerDay={group.runsPerDay}
-										models={group.models}
-									/>
-								))}
-							</div>
-
-							{/* Chosen per prompt and added to the picks above, not swapped for
-							    one of them, and paid out of a metered pool. Omitted entirely on
-							    plans that don't sell it, rather than advertising an absence. */}
-							{breakdown.premium && (
-								<div className="mt-4 border-t border-zinc-100 pt-4">
-									<PlatformTier
-										label={breakdown.premium.label}
-										runsPerDay={breakdown.premium.runsPerDay}
-										models={breakdown.premium.models}
-									/>
-									<p className="mt-1 text-[11px] leading-snug text-zinc-500">{breakdown.premium.summary}</p>
-								</div>
-							)}
-						</div>
-					);
-				})}
+				{PLAN_KEYS.map((key) => (
+					<CloudPlanCard key={key} plan={PLANS[key]} recommended={key === RECOMMENDED_PLAN} />
+				))}
 				<div className="flex flex-col bg-white p-5">
 					<h4 className="text-lg font-semibold tracking-tight text-zinc-950">Custom</h4>
 					<div className="mt-2 text-2xl font-semibold tracking-tight text-zinc-950">Let&apos;s talk</div>
@@ -250,15 +279,66 @@ function CloudPlans() {
 				</div>
 			</div>
 
-			<div className="mt-6 flex flex-wrap gap-3">
+			<div className="mt-6 flex flex-wrap items-center gap-x-4 gap-y-3">
 				<a
-					href={CLOUD_SIGNUP_URL}
+					href={SIGNUP_URL}
+					onClick={() => trackCta("cloud-signup", "marketing-pricing")}
 					className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md bg-blue-600 px-4 text-sm font-medium leading-none text-white ring-1 ring-blue-600 hover:bg-blue-700"
 				>
-					Sign up
+					Start with Cloud
 					<ArrowRight className="size-3.5" />
 				</a>
+				<p className="text-sm text-zinc-500">Cancel anytime. Not for you in the first week? Full refund.</p>
 			</div>
+		</div>
+	);
+}
+
+function CloudPlanCard({ plan, recommended }: { plan: PlanDefinition; recommended: boolean }) {
+	const breakdown = planPlatformBreakdown(plan);
+	return (
+		<div className={`flex flex-col p-5 ${recommended ? "bg-blue-50/50" : "bg-white"}`}>
+			<div className="flex flex-wrap items-center gap-2">
+				<h4 className="text-lg font-semibold tracking-tight text-zinc-950">{plan.name}</h4>
+				{recommended && <RecommendedPill />}
+			</div>
+			<div className="mt-2 flex items-baseline gap-1">
+				<span className="text-2xl font-semibold tracking-tight text-zinc-950 tabular-nums">
+					${plan.monthlyPriceUsd}
+				</span>
+				<span className="font-mono text-[10px] uppercase tracking-[0.15em] text-zinc-500">/ mo</span>
+			</div>
+			<p className="mt-1 text-xs text-zinc-500 tabular-nums">${plan.annualPriceUsd}/yr</p>
+
+			<ul className="mt-4 space-y-1.5 text-xs text-zinc-700">
+				<li>
+					{plan.maxBrands} brand{plan.maxBrands === 1 ? "" : "s"}
+				</li>
+				<li>{plan.maxPrompts} tracked prompts</li>
+			</ul>
+
+			{/* The pick tiers all spend the same budget, so they sit together
+							    under what the plan lets you choose. */}
+			<div className="mt-4 space-y-2.5 border-t border-zinc-100 pt-4">
+				<p className="text-xs font-medium text-zinc-900">{breakdown.pickHeading}</p>
+				{breakdown.pickGroups.map((group) => (
+					<PlatformTier key={group.id} label={group.label} runsPerDay={group.runsPerDay} models={group.models} />
+				))}
+			</div>
+
+			{/* Chosen per prompt and added to the picks above, not swapped for
+							    one of them, and paid out of a metered pool. Omitted entirely on
+							    plans that don't sell it, rather than advertising an absence. */}
+			{breakdown.premium && (
+				<div className="mt-4 border-t border-zinc-100 pt-4">
+					<PlatformTier
+						label={breakdown.premium.label}
+						runsPerDay={breakdown.premium.runsPerDay}
+						models={breakdown.premium.models}
+					/>
+					<p className="mt-1 text-[11px] leading-snug text-zinc-500">{breakdown.premium.summary}</p>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/apps/www/src/components/testimonial.tsx
+++ b/apps/www/src/components/testimonial.tsx
@@ -30,10 +30,6 @@ function Testimonial({ quote, author, company, companyUrl, mark }: CustomerQuote
 	);
 }
 
-export function SpeakeasyTestimonial() {
-	return <Testimonial {...CUSTOMER_QUOTES.speakeasy} />;
-}
-
 export function TradeSitesTestimonial() {
 	return <Testimonial {...CUSTOMER_QUOTES.tradesites} />;
 }

--- a/apps/www/src/lib/analytics.ts
+++ b/apps/www/src/lib/analytics.ts
@@ -1,0 +1,23 @@
+import type { ReferralSource } from "@workspace/config/referrals";
+import { trackEventBeforeNavigation } from "./posthog";
+
+/** Where a call to action sends someone. */
+export type CtaDestination = "cloud-signup" | "cloud-login" | "self-host" | "live-demo" | "book-demo" | "github";
+
+declare global {
+	interface Window {
+		plausible?: (event: string, options?: { props?: Record<string, string | number | boolean> }) => void;
+	}
+}
+
+/**
+ * One click on a call to action, reported to both backends: Plausible for the
+ * goal funnel, PostHog for the per-person journey that carries on in the app
+ * under the same distinct id.
+ */
+export function trackCta(destination: CtaDestination, source: ReferralSource): void {
+	if (typeof window === "undefined") return;
+	const page = window.location.pathname;
+	window.plausible?.("CTA Click", { props: { destination, source, page } });
+	trackEventBeforeNavigation("cta_click", { destination, source, page });
+}

--- a/apps/www/src/lib/faqs.ts
+++ b/apps/www/src/lib/faqs.ts
@@ -1,3 +1,5 @@
+import { CLOUD_ENTRY_PRICE_USD, MONEY_BACK_GUARANTEE_DAYS } from "@workspace/config/plans";
+
 export interface FaqItem {
 	question: string;
 	answer: string;
@@ -43,8 +45,16 @@ export const PRICING_FAQS: FaqItem[] = [
 	},
 	{
 		question: "Is there a hosted or cloud version of Elmo?",
+		answer: `Yes. Elmo Cloud is managed hosting for teams that would rather not run their own infrastructure, starting at $${CLOUD_ENTRY_PRICE_USD}/mo with a ${MONEY_BACK_GUARANTEE_DAYS}-day money-back guarantee. You can also self-host Elmo for free, or get in touch about white-label and managed deployments.`,
+	},
+	{
+		question: "Is there a free trial?",
+		answer: `No. Every cloud plan comes with a ${MONEY_BACK_GUARANTEE_DAYS}-day money-back guarantee instead: if Elmo isn't right for you in the first week, email hello@elmohq.com and we refund the full amount. If you want to look before paying anything, the live demo is open to everyone and self-hosting is free.`,
+	},
+	{
+		question: "Can I cancel any time?",
 		answer:
-			"Yes. Elmo Cloud is a managed cloud hosting for teams that would rather not run their own infrastructure, starting at $29/mo. You can also self-host Elmo for free, or get in touch about white-label and managed deployments.",
+			"Yes. Cancel from your billing settings whenever you like. Your plan stays active until the end of the period you've paid for, and your data stays readable after that.",
 	},
 	{
 		question: "Can agencies white-label Elmo?",
@@ -58,8 +68,7 @@ export const PRICING_FAQS: FaqItem[] = [
 	},
 	{
 		question: "Do I need a credit card to get started?",
-		answer:
-			"No. Self-hosting Elmo does not require an account or a credit card. Clone the open-source repository, deploy with the CLI, and start tracking your AI visibility.",
+		answer: `Not to self-host: that needs no account and no card. Deploy with the CLI and start tracking. Elmo Cloud is paid from day one, from $${CLOUD_ENTRY_PRICE_USD}/mo, and refundable in full for ${MONEY_BACK_GUARANTEE_DAYS} days.`,
 	},
 ];
 

--- a/apps/www/src/lib/posthog.ts
+++ b/apps/www/src/lib/posthog.ts
@@ -34,6 +34,18 @@ export function trackEvent(
 	posthog.capture(eventName, properties);
 }
 
+/**
+ * For an event fired by a click that immediately leaves the page: sent as a
+ * beacon at once, so the navigation cannot cancel it.
+ */
+export function trackEventBeforeNavigation(
+	eventName: string,
+	properties?: Record<string, string | number | boolean | undefined>,
+): void {
+	if (!initialized) return;
+	posthog.capture(eventName, properties, { send_instantly: true, transport: "sendBeacon" });
+}
+
 export function identifyByEmail(email: string): void {
 	if (!initialized) return;
 	posthog.identify(email, { email });

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -79,6 +79,11 @@ export const Route = createRootRoute({
 		scripts: [
 			websiteJsonLd(),
 			organizationJsonLd(),
+			// Queues plausible() calls made before the deferred script arrives.
+			{
+				children:
+					"window.plausible=window.plausible||function(){(window.plausible.q=window.plausible.q||[]).push(arguments)}",
+			},
 			{
 				src: "/api/plausible/js/script",
 				defer: true,

--- a/apps/www/src/routes/glossary/$slug.tsx
+++ b/apps/www/src/routes/glossary/$slug.tsx
@@ -1,5 +1,7 @@
-import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { CLOUD_ENTRY_PRICE_USD } from "@workspace/config/plans";
 import { ArrowLeft, ArrowRight } from "lucide-react";
+import { CloudSignupCTA, SelfHostCTA } from "@/components/cta-buttons";
 import { Footer } from "@/components/footer";
 import { Navbar } from "@/components/navbar";
 import { type GlossaryTerm, getGlossaryTerm, glossaryTerms } from "@/data/glossary";
@@ -115,19 +117,15 @@ function GlossaryTermPage() {
 					<div className="mx-auto max-w-3xl px-4 text-center md:px-6">
 						<h2 className="font-heading text-2xl text-zinc-950">See it in your own data</h2>
 						<p className="mx-auto mt-3 max-w-xl text-zinc-600">
-							Elmo is an open-source AI visibility platform. Self-host it for free and track how AI answer engines
-							mention and cite your brand.
+							Elmo is an open-source AI visibility platform. Run it in our cloud from ${CLOUD_ENTRY_PRICE_USD}/mo or
+							self-host it for free, and track how AI answer engines mention and cite your brand.
 						</p>
-						<div className="mt-6 flex flex-wrap justify-center gap-3">
-							<Link
-								to="/docs"
-								className="inline-flex h-9 items-center rounded-md bg-blue-600 px-4 text-sm font-medium text-white hover:bg-blue-700"
-							>
-								Get started
-							</Link>
+						<div className="mt-6 flex flex-wrap items-center justify-center gap-2">
+							<CloudSignupCTA source="marketing-glossary" />
+							<SelfHostCTA source="marketing-glossary" />
 							<a
 								href="/ai-visibility-tools"
-								className="inline-flex h-9 items-center rounded-md border border-zinc-200 bg-white px-4 text-sm font-medium text-zinc-700 hover:text-zinc-950"
+								className="inline-flex h-8 items-center px-1 text-sm font-medium text-zinc-600 hover:text-zinc-950"
 							>
 								Compare tools
 							</a>

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -8,7 +8,7 @@ import { Hero } from "@/components/hero";
 import { Navbar } from "@/components/navbar";
 import { Pricing } from "@/components/pricing";
 import { Stats } from "@/components/stats";
-import { SpeakeasyTestimonial, TradeSitesTestimonial } from "@/components/testimonial";
+import { TradeSitesTestimonial } from "@/components/testimonial";
 import { HOME_FAQS } from "@/lib/faqs";
 import { canonicalUrl, faqJsonLd, ogMeta, SITE_NAME, softwareApplicationJsonLd } from "@/lib/seo";
 
@@ -43,7 +43,6 @@ function HomePage() {
 			<main>
 				<Hero />
 				<Stats />
-				<SpeakeasyTestimonial />
 				<Features />
 				<TradeSitesTestimonial />
 				<Community />

--- a/apps/www/src/routes/vision.tsx
+++ b/apps/www/src/routes/vision.tsx
@@ -1,7 +1,5 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { CLOUD_SIGNUP_URL } from "@workspace/config/plans";
-import { buttonVariants } from "@workspace/ui/components/button";
-import { ArrowRight } from "lucide-react";
+import { createFileRoute } from "@tanstack/react-router";
+import { CloudSignupCTA, QuietCTA, SelfHostCTA } from "@/components/cta-buttons";
 import { Footer } from "@/components/footer";
 import { Navbar } from "@/components/navbar";
 import { breadcrumbJsonLd, canonicalUrl, ogMeta } from "@/lib/seo";
@@ -211,22 +209,12 @@ function VisionPage() {
 							Elmo is open source, cost-effective, and built for the long haul. If that sounds like your kind of tool,
 							come build with us.
 						</p>
-						<div className="mt-8 flex flex-wrap justify-center gap-3">
-							<a href={CLOUD_SIGNUP_URL} className={buttonVariants({ size: "sm" })}>
-								Start with Cloud
-								<ArrowRight className="size-3.5" />
-							</a>
-							<Link to="/docs" className={buttonVariants({ variant: "outline", size: "sm" })}>
-								Self-host free
-							</Link>
-							<a
-								href="https://github.com/elmohq/elmo"
-								target="_blank"
-								rel="noopener noreferrer"
-								className={buttonVariants({ variant: "outline", size: "sm" })}
-							>
+						<div className="mt-8 flex flex-wrap items-center justify-center gap-2">
+							<CloudSignupCTA source="marketing-vision" />
+							<SelfHostCTA source="marketing-vision" />
+							<QuietCTA href="https://github.com/elmohq/elmo" source="marketing-vision" destination="github">
 								Star on GitHub
-							</a>
+							</QuietCTA>
 						</div>
 					</div>
 				</section>

--- a/packages/config/src/plans.ts
+++ b/packages/config/src/plans.ts
@@ -485,3 +485,16 @@ export const CLOUD_SIGNUP_URL = `${CLOUD_APP_URL}/auth/register`;
 
 /** Lowest self-serve monthly price among all plans. */
 export const CLOUD_ENTRY_PRICE_USD = Math.min(...PLAN_KEYS.map((key) => PLANS[key].monthlyPriceUsd));
+
+/**
+ * The plan singled out wherever the ladder is shown. Starter is the price the
+ * site leads with, but it tracks one platform once a day; Basic is the first
+ * plan that delivers what the homepage describes, so it is the one to point at.
+ */
+export const RECOMMENDED_PLAN: PlanKey = "basic";
+
+/**
+ * How long after first checkout a customer can ask for a full refund. Quoted
+ * wherever a plan is sold, so it lives with the plans rather than in copy.
+ */
+export const MONEY_BACK_GUARANTEE_DAYS = 7;

--- a/packages/config/src/referrals.test.ts
+++ b/packages/config/src/referrals.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { bookDemoUrl, cloudPricingUrl, cloudSignupUrl, demoSiteUrl, marketingUrl } from "./referrals";
+import { bookDemoUrl, cloudLoginUrl, cloudPricingUrl, cloudSignupUrl, demoSiteUrl, marketingUrl } from "./referrals";
 
 /**
  * The contract every one of these has to keep: land on the right page, and say
@@ -10,6 +10,7 @@ describe("referral links", () => {
 	const builders = {
 		marketing: () => marketingUrl("/docs", "cli"),
 		signup: () => cloudSignupUrl("cli"),
+		login: () => cloudLoginUrl("cli"),
 		pricing: () => cloudPricingUrl("cli"),
 		demo: () => bookDemoUrl("cli"),
 		liveDemo: () => demoSiteUrl("cli"),
@@ -22,6 +23,7 @@ describe("referral links", () => {
 	it("points each destination at its own page", () => {
 		expect(marketingUrl("/docs", "cloud-signin")).toBe("https://www.elmohq.com/docs?ref=cloud-signin");
 		expect(cloudSignupUrl("cloud-signin")).toBe("https://app.elmohq.com/auth/register?ref=cloud-signin");
+		expect(cloudLoginUrl("marketing-navbar")).toBe("https://app.elmohq.com/auth/login?ref=marketing-navbar");
 		expect(cloudPricingUrl("cloud-signin")).toBe("https://www.elmohq.com/pricing?ref=cloud-signin");
 		expect(bookDemoUrl("cloud-signin")).toBe("https://cal.com/jrhizor/elmo?ref=cloud-signin");
 		expect(demoSiteUrl("cloud-signin")).toBe("https://demo.elmohq.com/?ref=cloud-signin");

--- a/packages/config/src/referrals.ts
+++ b/packages/config/src/referrals.ts
@@ -25,7 +25,19 @@ export type ReferralSource =
 	| "self-hosted-signup"
 	| "cloud-signin"
 	| "cloud-signup"
-	| "marketing-cta";
+	| "demo-app"
+	// The marketing site, one source per surface, so a signup can be traced to
+	// the button that started it rather than to the site as a whole.
+	| "marketing-navbar"
+	| "marketing-hero"
+	| "marketing-pricing"
+	| "marketing-cta"
+	| "marketing-blog"
+	| "marketing-docs"
+	| "marketing-directory"
+	| "marketing-comparison"
+	| "marketing-glossary"
+	| "marketing-vision";
 
 function tagged(url: string, ref: ReferralSource): string {
 	const link = new URL(url);
@@ -41,6 +53,11 @@ export function marketingUrl(path: string, ref: ReferralSource): string {
 /** Cloud registration, tagged with where the click came from. */
 export function cloudSignupUrl(ref: ReferralSource): string {
 	return tagged(`${CLOUD_APP_URL}/auth/register`, ref);
+}
+
+/** Cloud sign-in, tagged with where the click came from. */
+export function cloudLoginUrl(ref: ReferralSource): string {
+	return tagged(`${CLOUD_APP_URL}/auth/login`, ref);
 }
 
 /** The cloud pricing table, tagged with where the click came from. */

--- a/packages/deployment/src/email-templates.ts
+++ b/packages/deployment/src/email-templates.ts
@@ -6,6 +6,8 @@
  * organization name) are HTML-escaped before landing in markup.
  */
 
+import { MONEY_BACK_GUARANTEE_DAYS } from "@workspace/config/plans";
+
 export interface EmailContent {
 	subject: string;
 	html: string;
@@ -44,10 +46,10 @@ export function verificationEmail(input: { url: string }): EmailContent {
 		subject: "Verify your email address",
 		html: wrapHtml(
 			"Verify your email address",
-			"Click the button below to verify your email and finish signing up.",
+			`Click the button below to verify your email and finish signing up. Every Elmo Cloud plan is backed by a ${MONEY_BACK_GUARANTEE_DAYS}-day money-back guarantee.`,
 			url,
 		),
-		text: `Verify your email address by visiting this link: ${url}`,
+		text: `Verify your email address by visiting this link: ${url}\n\nEvery Elmo Cloud plan is backed by a ${MONEY_BACK_GUARANTEE_DAYS}-day money-back guarantee.`,
 	};
 }
 

--- a/packages/docs/content/docs/getting-started.mdx
+++ b/packages/docs/content/docs/getting-started.mdx
@@ -10,6 +10,8 @@ description: Get Elmo running on your infrastructure in under 5 minutes using th
 - At least one AI provider API key (OpenAI, Anthropic, or OpenRouter)
 - **(Recommended)** A scraping provider to track the real ChatGPT and Google AI Mode experiences — see [Providers](/docs/user-guide/providers)
 
+<CloudCallout />
+
 ## Install the CLI
 
 ```bash

--- a/packages/docs/content/docs/user-guide/providers.mdx
+++ b/packages/docs/content/docs/user-guide/providers.mdx
@@ -32,6 +32,8 @@ Which surfaces each one reaches:
 Cost estimates assume Elmo's default cadence of about 5 runs/day per target across 2 surfaces (ChatGPT + Google AI Mode), so roughly 300 evaluations/mo per prompt.
 </Callout>
 
+<CloudCallout />
+
 <Callout title="How we make money on this page">
 Every scraping-provider link on this page is an Elmo affiliate link. If you sign up through one, we get a small kickback at no extra cost to you. This is one of the ways we fund work on the project. Our rankings are based on repeated testing we publish on the [provider status page](https://www.elmohq.com/status).
 


### PR DESCRIPTION
## Why

The cloud funnel could not be measured (no CTA click events, untagged signup links, no funnel events in the app), the highest-intent pages (blog, docs, tool directory, comparison pages, the live demo) never asked for a cloud signup, and the hero read like every competitor's. This PR fixes all three without adding a trial or a free tier: cloud stays paid from day one, now with a 7-day money-back guarantee stated wherever a plan is sold.

## Marketing site

- **Hero**: headline is now “Your brand, according to ChatGPT.” (competitor H1s cluster around “own / become / win the answer”; this one doesn't). The quickstart terminal moves out of the hero (it stays in the closing CTA section), the Speakeasy line and G2 stars sit directly under the buttons, and the microcopy states the price, cancel-anytime, and the guarantee.
- **Navbar**: adds Features and a Log in link (returning customers had no way in), and the button reads Get started.
- **Pricing**: headline “Start at $29/mo. Or self-host for free.”, guarantee on the Cloud card and under the plan grid, Basic marked Recommended in the grid, a “Compared” block reusing the sign-up page's “4× Profound's daily runs, same price” claim with links to the head-to-head pages, and three FAQ answers (free trial, cancel, credit card) that were wrong or missing for cloud buyers.
- **Content pages**: every blog post ends with a cloud/self-host callout; Quick Start and Providers docs get a “Don't want to self-host?” callout at the point where API keys and scraper accounts come up; the tool directory, category/alternatives banners, comparison pages, industry pages, AI-search pages, glossary, and vision page all switch from “Deploy Elmo → docs” to the shared Start with Cloud / Self-host free pair. Comparison pages close with “Switching from X?”. Two stale “cloud is on the way” lines are fixed.
- **Attribution**: every CTA carries a `ref` per surface (`marketing-hero`, `marketing-pricing`, `marketing-blog`, …) and fires a `CTA Click` Plausible event and a `cta_click` PostHog event with destination, source, and page. A queue snippet keeps clicks that happen before the deferred Plausible script arrives.

## Web app (cloud + demo only; no-ops elsewhere)

- Funnel events: `signup_started`, `signup_completed`, `email_verified` (via a localStorage marker consumed on the first signed-in page), `login_started`/`login_completed`, `checkout_started`, `checkout_completed`. All go through the existing `trackEvent`, which is a no-op when PostHog isn't initialised (telemetry off, non-cloud without a key).
- Session recording is started only on the cloud sign-up page and the plan picker, and stopped on leave. It records nothing unless recordings are enabled in the PostHog project.
- The demo no longer identifies visitors as the shared demo user in PostHog (that was merging every visitor into one person and severing the trail from www, which shares the same project key and root-domain cookie).
- Demo signs visitors in on arrival instead of showing a form, and the header carries a “Track your own brand” button to cloud signup (`ref=demo-app`).
- Plan picker recommends Basic instead of Pro (the $29 anchor on the site made a $299 recommendation jarring) and states the guarantee. Sign-up subtitle and the verification email mention the guarantee too.

`RECOMMENDED_PLAN` and `MONEY_BACK_GUARANTEE_DAYS` live in `packages/config/src/plans.ts`, so changing either updates the site, the paywall, and the email together.

## Deliberately not done

- No trial, no free tier, no free one-off snapshot (per discussion).
- Skipping the org picker after checkout and lifecycle nudge emails: app work beyond this PR's scope.
- UTM forwarding from landing page to signup: `ref` plus the shared PostHog identity across `*.elmohq.com` covers attribution for now.

## Things to check after merge

- Production `CLOUD_SIGNUP_ALLOWLIST` must be `*`; the register form fails closed with “invite-only” otherwise, which would waste every new click.
- If you'd rather keep Pro highlighted on the paywall, change `RECOMMENDED_PLAN`.
- Alternative headlines, if this one doesn't land: “Track every AI answer that mentions your brand. Or doesn't.” / “Every AI answer about your brand, on the record.” / “What AI tells your customers about you.”

## Verification

`pnpm lint` clean; `tsc --noEmit` clean for www, web, config, deployment; unit tests pass (config 105, deployment 47, web 510). Every changed marketing page was rendered with the dev server and checked for the new copy and tagged links.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0d05edea-9eb2-4c3d-a482-025089637eb2)
