### PR TITLE
Fail a BrightData run the collector errored on instead of storing the error row

### DIFF
--- a/.changeset/brightdata-error-rows.md
+++ b/.changeset/brightdata-error-rows.md
@@ -1,0 +1,5 @@
+---
+"@workspace/lib": patch
+---
+
+A BrightData run that the collector failed on now reports that failure instead of recording the error payload as the chatbot's answer.

--- a/.changeset/brightdata-error-rows.md
+++ b/.changeset/brightdata-error-rows.md
@@ -2,4 +2,4 @@
 "@workspace/lib": patch
 ---
 
-A BrightData run that the collector failed on now reports that failure instead of recording the error payload as the chatbot's answer.
+Fixed problem where certain types of BrightData scraping failures wrote the error as a response on a successful prompt run. These cases now fail.

--- a/packages/lib/src/providers/registry/brightdata.test.ts
+++ b/packages/lib/src/providers/registry/brightdata.test.ts
@@ -1,14 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { brightdata, extractWebQueries, POLL_TIMEOUT_MS, readAnswer } from "./brightdata";
+import { brightdata, extractWebQueries, readAnswer } from "./brightdata";
 
-/** How long BrightData itself gives a stuck input before it finishes the
- *  snapshot with an error row naming the reason. Theirs, not ours — measured
- *  from live `no_peers` rows, which landed ~9 minutes after the trigger. */
-const BRIGHTDATA_GIVE_UP_MS = 9 * 60 * 1000;
+const { cancelSnapshot } = vi.hoisted(() => ({ cancelSnapshot: vi.fn() }));
 
 vi.mock("@brightdata/sdk", () => ({
 	bdclient: class {
-		scrape = { snapshot: { cancel: vi.fn().mockResolvedValue(undefined), fetch: vi.fn() } };
+		scrape = { snapshot: { cancel: cancelSnapshot, fetch: vi.fn() } };
 		close = vi.fn().mockResolvedValue(undefined);
 	},
 }));
@@ -95,11 +92,7 @@ describe("readAnswer", () => {
 });
 
 describe("brightdata polling", () => {
-	it("waits longer than BrightData does before giving up on a snapshot", () => {
-		expect(POLL_TIMEOUT_MS).toBeGreaterThan(BRIGHTDATA_GIVE_UP_MS);
-	});
-
-	it("polls a running snapshot past BrightData's give-up before abandoning it", async () => {
+	it("cancels a snapshot it gave up waiting on, so it stops counting against the running-jobs cap", async () => {
 		vi.useFakeTimers();
 		vi.stubEnv("BRIGHTDATA_API_TOKEN", "test-token");
 		vi.stubGlobal(
@@ -124,7 +117,6 @@ describe("brightdata polling", () => {
 		const error = await settled;
 
 		expect(error.message).toMatch(/sd_stuck timed out/);
-		const elapsedMs = Number(error.message.match(/timed out after (\d+)s/)?.[1]) * 1000;
-		expect(elapsedMs).toBeGreaterThan(BRIGHTDATA_GIVE_UP_MS);
+		expect(cancelSnapshot).toHaveBeenCalledWith("sd_stuck");
 	});
 });

--- a/packages/lib/src/providers/registry/brightdata.test.ts
+++ b/packages/lib/src/providers/registry/brightdata.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { brightdata, extractWebQueries, readAnswer } from "./brightdata";
+import { brightdata, extractWebQueries, POLL_TIMEOUT_MS, readAnswer } from "./brightdata";
+
+/** How long BrightData itself gives a stuck input before it finishes the
+ *  snapshot with an error row naming the reason. Theirs, not ours — measured
+ *  from live `no_peers` rows, which landed ~9 minutes after the trigger. */
+const BRIGHTDATA_GIVE_UP_MS = 9 * 60 * 1000;
 
 vi.mock("@brightdata/sdk", () => ({
 	bdclient: class {
@@ -90,7 +95,11 @@ describe("readAnswer", () => {
 });
 
 describe("brightdata polling", () => {
-	it("polls a running snapshot past BrightData's nine-minute give-up before abandoning it", async () => {
+	it("waits longer than BrightData does before giving up on a snapshot", () => {
+		expect(POLL_TIMEOUT_MS).toBeGreaterThan(BRIGHTDATA_GIVE_UP_MS);
+	});
+
+	it("polls a running snapshot past BrightData's give-up before abandoning it", async () => {
 		vi.useFakeTimers();
 		vi.stubEnv("BRIGHTDATA_API_TOKEN", "test-token");
 		vi.stubGlobal(
@@ -115,6 +124,7 @@ describe("brightdata polling", () => {
 		const error = await settled;
 
 		expect(error.message).toMatch(/sd_stuck timed out/);
-		expect(Number(error.message.match(/timed out after (\d+)s/)?.[1])).toBeGreaterThanOrEqual(9 * 60);
+		const elapsedMs = Number(error.message.match(/timed out after (\d+)s/)?.[1]) * 1000;
+		expect(elapsedMs).toBeGreaterThan(BRIGHTDATA_GIVE_UP_MS);
 	});
 });

--- a/packages/lib/src/providers/registry/brightdata.test.ts
+++ b/packages/lib/src/providers/registry/brightdata.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractWebQueries } from "./brightdata";
+import { extractWebQueries, readAnswer } from "./brightdata";
 
 describe("extractWebQueries", () => {
 	it("reports the queries a run expanded the prompt into", () => {
@@ -34,5 +34,39 @@ describe("extractWebQueries", () => {
 
 	it("reports nothing when the payload carries no query fields", () => {
 		expect(extractWebQueries({ answer_text: "hello" })).toEqual([]);
+	});
+});
+
+describe("readAnswer", () => {
+	it("reads the answer the chatbot gave, preferring the markdown form", () => {
+		expect(readAnswer({ answer_text_markdown: "  **Yes**  ", answer_text: "Yes" }, "chatgpt snapshot sd_1")).toBe(
+			"**Yes**",
+		);
+	});
+
+	it("fails a run BrightData could not collect, naming the reason it gave", () => {
+		const record = {
+			timestamp: "2026-09-06T10:37:52.406Z",
+			input: { url: "https://www.perplexity.ai/", prompt: "best speakers", index: 1 },
+			error: "Crawler error: Unexpected Status 502 (no_peer)",
+			error_code: "no_peers",
+		};
+		expect(() => readAnswer(record, "perplexity snapshot sd_2")).toThrow(
+			/perplexity snapshot sd_2 .*Crawler error: Unexpected Status 502 \(no_peer\).*no_peers/,
+		);
+	});
+
+	it("fails a row with no answer rather than passing the payload off as one", () => {
+		expect(() => readAnswer({ input: { prompt: "best speakers" } }, "gemini snapshot sd_3")).toThrow(
+			/gemini snapshot sd_3/,
+		);
+	});
+
+	it("keeps an answer that arrived alongside an error field", () => {
+		expect(readAnswer({ answer_text: "Yes", error: "partial page load" }, "copilot snapshot sd_4")).toBe("Yes");
+	});
+
+	it("treats an empty error field as no error at all", () => {
+		expect(() => readAnswer({ error: "", error_code: null }, "chatgpt snapshot sd_5")).toThrow(/no answer/);
 	});
 });

--- a/packages/lib/src/providers/registry/brightdata.test.ts
+++ b/packages/lib/src/providers/registry/brightdata.test.ts
@@ -1,5 +1,23 @@
-import { describe, expect, it } from "vitest";
-import { extractWebQueries, readAnswer } from "./brightdata";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { brightdata, extractWebQueries, readAnswer } from "./brightdata";
+
+vi.mock("@brightdata/sdk", () => ({
+	bdclient: class {
+		scrape = { snapshot: { cancel: vi.fn().mockResolvedValue(undefined), fetch: vi.fn() } };
+		close = vi.fn().mockResolvedValue(undefined);
+	},
+}));
+
+afterEach(() => {
+	vi.clearAllMocks();
+	vi.unstubAllEnvs();
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
 
 describe("extractWebQueries", () => {
 	it("reports the queries a run expanded the prompt into", () => {
@@ -68,5 +86,35 @@ describe("readAnswer", () => {
 
 	it("treats an empty error field as no error at all", () => {
 		expect(() => readAnswer({ error: "", error_code: null }, "chatgpt snapshot sd_5")).toThrow(/no answer/);
+	});
+});
+
+describe("brightdata polling", () => {
+	it("polls a running snapshot past BrightData's nine-minute give-up before abandoning it", async () => {
+		vi.useFakeTimers();
+		vi.stubEnv("BRIGHTDATA_API_TOKEN", "test-token");
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockImplementation((url: string) =>
+					Promise.resolve(
+						url.includes("/trigger") ? jsonResponse({ snapshot_id: "sd_stuck" }) : jsonResponse({ status: "running" }),
+					),
+				),
+		);
+
+		const promise = brightdata.run("perplexity", "What is a well-reviewed speaker?", { webSearch: true });
+		const settled: Promise<Error> = promise.then(
+			() => {
+				throw new Error("expected the run to reject");
+			},
+			(e: unknown) => e as Error,
+		);
+		await vi.runAllTimersAsync();
+		const error = await settled;
+
+		expect(error.message).toMatch(/sd_stuck timed out/);
+		expect(Number(error.message.match(/timed out after (\d+)s/)?.[1])).toBeGreaterThanOrEqual(9 * 60);
 	});
 });

--- a/packages/lib/src/providers/registry/brightdata.ts
+++ b/packages/lib/src/providers/registry/brightdata.ts
@@ -104,19 +104,8 @@ function rowError(record: Record<string, any>): string | null {
 	return parts.length > 0 ? parts.join(" — ") : null;
 }
 
-/**
- * Exported for tests.
- *
- * `include_errors=true` means a `ready` snapshot can carry a per-input failure
- * rather than an answer — a proxy-layer `no_peers`, a blocked target, a crawler
- * fault. A row with no readable answer is a failed run, not a response whose
- * text happens to be the row itself: mention analysis scores whatever it is
- * handed, so a payload dump standing in for an answer would quietly land in a
- * brand's visibility numbers as a real reply the chatbot never gave.
- *
- * An answer wins over an error field, so a run BrightData flagged but still
- * completed is kept rather than discarded.
- */
+/** Exported for tests. `include_errors=true` means a ready snapshot can carry a
+ *  per-input failure in place of an answer. */
 export function readAnswer(record: Record<string, any>, subject: string): string {
 	const answer = findAnswer(record);
 	if (answer) return answer;
@@ -269,14 +258,13 @@ async function triggerSnapshot(datasetId: string, model: string, prompt: string,
  *  status string doesn't fail the run on the very first poll. */
 const TERMINAL_FAILURE = new Set(["failed", "error", "cancelled"]);
 
-/** BrightData gives up on an input it can't collect at around nine minutes and
- *  finishes the snapshot with an error row naming the reason, so polling has to
- *  outlast that ceiling for a run to report why it failed rather than only that
- *  it did. */
+/** Outlasts the ~9 minutes BrightData takes to finish a stuck input with an
+ *  error row, so a run reports its reason rather than only our own timeout. */
 const POLL_TIMEOUT_MS = 12 * 60 * 1000;
 
 async function pollUntilReady(snapshotId: string): Promise<void> {
-	const deadline = Date.now() + POLL_TIMEOUT_MS;
+	const startedAt = Date.now();
+	const deadline = startedAt + POLL_TIMEOUT_MS;
 
 	for (let attempt = 0; Date.now() < deadline; attempt++) {
 		const status = await getSnapshotStatus(snapshotId);
@@ -288,7 +276,7 @@ async function pollUntilReady(snapshotId: string): Promise<void> {
 		await sleep(pollDelay(attempt));
 	}
 
-	throw new Error(`BrightData snapshot ${snapshotId} timed out after ${POLL_TIMEOUT_MS / 60_000} minutes`);
+	throw new Error(`BrightData snapshot ${snapshotId} timed out after ${Math.round((Date.now() - startedAt) / 1000)}s`);
 }
 
 /** Read snapshot status straight from datasets/v3/progress. We bypass the SDK's

--- a/packages/lib/src/providers/registry/brightdata.ts
+++ b/packages/lib/src/providers/registry/brightdata.ts
@@ -258,9 +258,9 @@ async function triggerSnapshot(datasetId: string, model: string, prompt: string,
  *  status string doesn't fail the run on the very first poll. */
 const TERMINAL_FAILURE = new Set(["failed", "error", "cancelled"]);
 
-/** Outlasts the ~9 minutes BrightData takes to finish a stuck input with an
- *  error row, so a run reports its reason rather than only our own timeout. */
-const POLL_TIMEOUT_MS = 12 * 60 * 1000;
+/** Exported for tests. Has to stay above BRIGHTDATA_GIVE_UP_MS so a stuck
+ *  input's error row reaches us instead of only our own timeout. */
+export const POLL_TIMEOUT_MS = 12 * 60 * 1000;
 
 async function pollUntilReady(snapshotId: string): Promise<void> {
 	const startedAt = Date.now();

--- a/packages/lib/src/providers/registry/brightdata.ts
+++ b/packages/lib/src/providers/registry/brightdata.ts
@@ -258,13 +258,13 @@ async function triggerSnapshot(datasetId: string, model: string, prompt: string,
  *  status string doesn't fail the run on the very first poll. */
 const TERMINAL_FAILURE = new Set(["failed", "error", "cancelled"]);
 
-/** Exported for tests. Has to stay above BRIGHTDATA_GIVE_UP_MS so a stuck
- *  input's error row reaches us instead of only our own timeout. */
-export const POLL_TIMEOUT_MS = 12 * 60 * 1000;
+/** BrightData publishes no collection deadline, so this is sized past the
+ *  slowest error row a stuck input has been seen to produce — not to any
+ *  documented limit. Too low and their reason never reaches us. */
+const POLL_TIMEOUT_MS = 12 * 60 * 1000;
 
 async function pollUntilReady(snapshotId: string): Promise<void> {
-	const startedAt = Date.now();
-	const deadline = startedAt + POLL_TIMEOUT_MS;
+	const deadline = Date.now() + POLL_TIMEOUT_MS;
 
 	for (let attempt = 0; Date.now() < deadline; attempt++) {
 		const status = await getSnapshotStatus(snapshotId);
@@ -276,7 +276,7 @@ async function pollUntilReady(snapshotId: string): Promise<void> {
 		await sleep(pollDelay(attempt));
 	}
 
-	throw new Error(`BrightData snapshot ${snapshotId} timed out after ${Math.round((Date.now() - startedAt) / 1000)}s`);
+	throw new Error(`BrightData snapshot ${snapshotId} timed out`);
 }
 
 /** Read snapshot status straight from datasets/v3/progress. We bypass the SDK's

--- a/packages/lib/src/providers/registry/brightdata.ts
+++ b/packages/lib/src/providers/registry/brightdata.ts
@@ -90,11 +90,42 @@ async function attemptGoogleAiOverview(zone: string, url: string): Promise<Attem
 	};
 }
 
-function normalizeAnswer(record: Record<string, any>): string {
+function findAnswer(record: Record<string, any>): string | null {
 	for (const key of ["answer_text_markdown", "answer_text", "answer", "response_raw", "response", "text", "content"]) {
 		if (typeof record[key] === "string" && record[key].trim()) return record[key].trim();
 	}
-	return JSON.stringify(record).slice(0, 2000);
+	return null;
+}
+
+function rowError(record: Record<string, any>): string | null {
+	const parts = [record.error, record.error_code]
+		.map((value) => (typeof value === "string" ? value.trim() : value ? JSON.stringify(value) : ""))
+		.filter(Boolean);
+	return parts.length > 0 ? parts.join(" — ") : null;
+}
+
+/**
+ * Exported for tests.
+ *
+ * `include_errors=true` means a `ready` snapshot can carry a per-input failure
+ * rather than an answer — a proxy-layer `no_peers`, a blocked target, a crawler
+ * fault. A row with no readable answer is a failed run, not a response whose
+ * text happens to be the row itself: mention analysis scores whatever it is
+ * handed, so a payload dump standing in for an answer would quietly land in a
+ * brand's visibility numbers as a real reply the chatbot never gave.
+ *
+ * An answer wins over an error field, so a run BrightData flagged but still
+ * completed is kept rather than discarded.
+ */
+export function readAnswer(record: Record<string, any>, subject: string): string {
+	const answer = findAnswer(record);
+	if (answer) return answer;
+	const error = rowError(record);
+	throw new Error(
+		error
+			? `BrightData ${subject} returned an error row: ${error}`
+			: `BrightData ${subject} returned a row with no answer`,
+	);
 }
 
 /**
@@ -171,7 +202,7 @@ export const brightdata: Provider = {
 			consumed = true;
 
 			const record = (Array.isArray(payload) ? payload[0] : payload) ?? {};
-			const answer = normalizeAnswer(record);
+			const answer = readAnswer(record, `${model} snapshot ${snapshotId}`);
 
 			const webQueries = extractWebQueries(record);
 			const citations = extractCitationsFromBrightdata(record);
@@ -238,10 +269,16 @@ async function triggerSnapshot(datasetId: string, model: string, prompt: string,
  *  status string doesn't fail the run on the very first poll. */
 const TERMINAL_FAILURE = new Set(["failed", "error", "cancelled"]);
 
-async function pollUntilReady(snapshotId: string): Promise<void> {
-	const maxAttempts = 60;
+/** BrightData gives up on an input it can't collect at around nine minutes and
+ *  finishes the snapshot with an error row naming the reason, so polling has to
+ *  outlast that ceiling for a run to report why it failed rather than only that
+ *  it did. */
+const POLL_TIMEOUT_MS = 12 * 60 * 1000;
 
-	for (let attempt = 0; attempt < maxAttempts; attempt++) {
+async function pollUntilReady(snapshotId: string): Promise<void> {
+	const deadline = Date.now() + POLL_TIMEOUT_MS;
+
+	for (let attempt = 0; Date.now() < deadline; attempt++) {
 		const status = await getSnapshotStatus(snapshotId);
 		if (status === "ready") return;
 		if (TERMINAL_FAILURE.has(status)) {
@@ -251,7 +288,7 @@ async function pollUntilReady(snapshotId: string): Promise<void> {
 		await sleep(pollDelay(attempt));
 	}
 
-	throw new Error(`BrightData snapshot ${snapshotId} timed out`);
+	throw new Error(`BrightData snapshot ${snapshotId} timed out after ${POLL_TIMEOUT_MS / 60_000} minutes`);
 }
 
 /** Read snapshot status straight from datasets/v3/progress. We bypass the SDK's


### PR DESCRIPTION
## Why

`perplexity:brightdata:online` has had **zero** successful runs since 2026-08-25 (0/85 on the status page). BrightData's Perplexity collector is returning a proxy-layer failure:

```json
{"timestamp":"2026-09-06T10:37:52.406Z",
 "input":{"url":"https://www.perplexity.ai/","prompt":"...","index":1,"country":"","additional_prompt":""},
 "error":"Crawler error: Unexpected Status 502 (no_peer)",
 "error_code":"no_peers"}
```

That's on BrightData's side — the dataset id is still current, they echo our trigger body back unchanged, every other BrightData collector is at 94–96/97 over the same window, and Perplexity scrapes fine on Oxylabs, Cloro, DataForSEO and OpenRouter. A support ticket is the actual fix for the outage.

What this PR fixes is that we couldn't *see* any of it.

## Two bugs it exposed

**1. We stored error rows as answers.** We trigger with `include_errors=true`, but nothing read `record.error` / `error_code`. The row fell through `normalizeAnswer`'s `JSON.stringify(record).slice(0, 2000)` fallback and came back as the answer text — which `report-worker.ts` hands straight to `analyzeMentions` and persists. A `no_peers` row would land in a brand's visibility numbers as a real Perplexity reply that scored no mentions.

`readAnswer` now throws on a row it can't read an answer out of, naming BrightData's reason when there is one. An answer still wins over an error field, so a flagged-but-completed run isn't discarded. The JSON fallback is gone entirely — it was never a valid answer for any row shape, and it disagreed with `extractTextFromBrightdata`, which already returns a placeholder for the same case.

**2. The poll ceiling was too short to catch the error row.** It was 60 attempts ≈ 520 s ≈ 8.7 min. Across ~85 failing runs we captured BrightData's error row only 3 times; every other run hit our own timeout first and reported an opaque `snapshot ... timed out`. The ceiling is now a 12-minute wall-clock deadline.

To be explicit about what that number is and isn't: **BrightData publishes no maximum runtime for a `datasets/v3` job** — their docs cover a 1-minute *sync* threshold, 30-day snapshot retention, and concurrent-job caps, but no collection deadline. The two error rows we have arrived roughly 2.7 and 7.5 minutes after their trigger, so 12 minutes is an empirical margin over what we've observed, not a documented limit. An earlier revision of this PR asserted a nine-minute vendor deadline in a test; that figure was wrong (measured against CI job start rather than the trigger) and the samples don't support a fixed deadline at all, so it's gone.

Worst-case wall clock for the status workflow goes *down*, not up: a thrown error short-circuits `retryForCitations`, so a broken target is one attempt instead of four.

## Tests

Only behavior we control is asserted — no vendor threshold. Coverage: the real `no_peers` payload, a row with no answer and no error, an answer alongside an error field, empty error fields, and that a snapshot we stop waiting on gets cancelled so it stops counting against the per-dataset running-jobs cap.

- `pnpm test` — 11 passing in `brightdata.test.ts`, full suite green
- `pnpm lint` clean, `tsc --noEmit` clean in `packages/lib`
- Verified the cancel test fails if the `finally` cancel is removed