### PR TITLE
ask every Cloro task for markdown

### DIFF
--- a/.changeset/cloro-markdown-answers.md
+++ b/.changeset/cloro-markdown-answers.md
@@ -1,0 +1,5 @@
+---
+"@workspace/lib": patch
+---
+
+Answers scraped through Cloro now keep their formatting and inline citations instead of arriving as one flat paragraph.

--- a/apps/web/src/components/__tests__/response-markdown.test.tsx
+++ b/apps/web/src/components/__tests__/response-markdown.test.tsx
@@ -31,7 +31,7 @@ const SURFACES: [name: string, provider: string, rawOutput: unknown][] = [
 	["brightdata AI Overview", "brightdata", [{ ai_overview: { markdown: ANSWER } }]],
 	["oxylabs ChatGPT", "oxylabs", { results: [{ content: { markdown_text: ANSWER } }] }],
 	["oxylabs Perplexity", "oxylabs", { results: [{ content: { answer_results_md: ANSWER } }] }],
-	["cloro chatbot", "cloro", { text: ANSWER }],
+	["cloro chatbot", "cloro", { markdown: ANSWER, text: "flattened" }],
 	["cloro AI Overview", "cloro", { aioverview: { markdown: ANSWER, text: "flattened" } }],
 	["dataforseo scraper", "dataforseo", { tasks: [{ result: [{ markdown: ANSWER, sources: [] }] }] }],
 	[

--- a/packages/lib/src/providers/registry/cloro.test.ts
+++ b/packages/lib/src/providers/registry/cloro.test.ts
@@ -1,10 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cloro } from "./cloro";
 
-// A completed ChatGPT task `response`: the answer in both shapes Cloro returns
-// it — `markdown` with its inline citations, `text` with them stripped — plus
-// the two source arrays (the `sources` reference panel and the inline
-// `citationPills`), which overlap on one URL to exercise de-duplication.
+// A completed ChatGPT task `response`: the answer text plus the two source
+// arrays (the `sources` reference panel and the inline `citationPills`), which
+// overlap on one URL to exercise de-duplication.
 const CHATGPT_RESPONSE = {
 	text: "The Sonos Era 300 is a well-reviewed speaker released recently.",
 	markdown:
@@ -138,8 +137,7 @@ describe("cloro provider", () => {
 		});
 		expect(fetchMock.mock.calls[1][0]).toBe("https://api.cloro.dev/v1/async/task/task-1");
 
-		// The markdown the task asked for, with its inline citations, not the
-		// flattened `text` beside it.
+		// The markdown the task asked for, not the flattened `text` beside it.
 		expect(result.textContent).toContain("**Sonos Era 300**");
 		// whathifi appears in both `sources` and `citationPills`; techradar only in
 		// the pills — so two distinct citations after de-duplication.
@@ -232,9 +230,8 @@ describe("cloro provider", () => {
 		expect(result.citations.map((c) => c.domain)).toEqual(["cnet.com", "google.com"]);
 	});
 
-	// Markdown is opt-in per task and free, and it is the only field carrying the
-	// answer's inline citations. A surface left out of the request silently
-	// downgrades to `text`, which reads as an answer that cited nothing.
+	// Markdown is opt-in per task, and a surface left out of the request silently
+	// downgrades to `text` — the same answer with its citations stripped.
 	it.each([
 		["chatgpt", "CHATGPT", { markdown: true, searchQueries: true }],
 		["perplexity", "PERPLEXITY", { markdown: true }],

--- a/packages/lib/src/providers/registry/cloro.test.ts
+++ b/packages/lib/src/providers/registry/cloro.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cloro } from "./cloro";
 
-// A completed ChatGPT task `response`: the answer text plus the two source
-// arrays (the `sources` reference panel and the inline `citationPills`), which
-// overlap on one URL to exercise de-duplication.
+// A completed ChatGPT task `response`: the answer in both shapes Cloro returns
+// it — `markdown` with its inline citations, `text` with them stripped — plus
+// the two source arrays (the `sources` reference panel and the inline
+// `citationPills`), which overlap on one URL to exercise de-duplication.
 const CHATGPT_RESPONSE = {
 	text: "The Sonos Era 300 is a well-reviewed speaker released recently.",
+	markdown:
+		"The **Sonos Era 300** is a well-reviewed speaker released recently. ([Sonos Era 300 review](https://www.whathifi.com/reviews/sonos-era-300))",
 	model: "gpt-5-3-mini",
 	sources: [{ position: 1, url: "https://www.whathifi.com/reviews/sonos-era-300", label: "Sonos Era 300 review" }],
 	citationPills: [
@@ -48,6 +51,8 @@ const AI_OVERVIEW_RESPONSE = {
 // follow-up questions under `related_queries`.
 const PERPLEXITY_RESPONSE = {
 	text: "The Sonos Era 100 lasts longer than the Bose SoundLink Flex.",
+	markdown:
+		"The **Sonos Era 100** lasts longer than the Bose SoundLink Flex. ([Era 100 review](https://www.soundguys.com/era-100-review))",
 	sources: [{ position: 1, url: "https://www.soundguys.com/era-100-review", label: "Era 100 review" }],
 	search_model_queries: ["Compare the Sonos Era 100 and the Bose SoundLink Flex"],
 	related_queries: ["Which is better for a pool party", "What about the JBL Charge 6"],
@@ -125,11 +130,17 @@ describe("cloro provider", () => {
 		});
 		expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
 			taskType: "CHATGPT",
-			payload: { prompt: "What is a well-reviewed speaker?", country: "US", include: { searchQueries: true } },
+			payload: {
+				prompt: "What is a well-reviewed speaker?",
+				country: "US",
+				include: { markdown: true, searchQueries: true },
+			},
 		});
 		expect(fetchMock.mock.calls[1][0]).toBe("https://api.cloro.dev/v1/async/task/task-1");
 
-		expect(result.textContent).toContain("Sonos Era 300");
+		// The markdown the task asked for, with its inline citations, not the
+		// flattened `text` beside it.
+		expect(result.textContent).toContain("**Sonos Era 300**");
 		// whathifi appears in both `sources` and `citationPills`; techradar only in
 		// the pills — so two distinct citations after de-duplication.
 		expect(result.citations).toHaveLength(2);
@@ -221,6 +232,33 @@ describe("cloro provider", () => {
 		expect(result.citations.map((c) => c.domain)).toEqual(["cnet.com", "google.com"]);
 	});
 
+	// Markdown is opt-in per task and free, and it is the only field carrying the
+	// answer's inline citations. A surface left out of the request silently
+	// downgrades to `text`, which reads as an answer that cited nothing.
+	it.each([
+		["chatgpt", "CHATGPT", { markdown: true, searchQueries: true }],
+		["perplexity", "PERPLEXITY", { markdown: true }],
+		["copilot", "COPILOT", { markdown: true }],
+		["gemini", "GEMINI", { markdown: true }],
+		["google-ai-mode", "AIMODE", { markdown: true }],
+		// The overview is one section of a SERP response, so the flag rides inside
+		// the block that asks for it rather than sitting at the top level.
+		["google-ai-overview", "GOOGLE", { aioverview: { markdown: true } }],
+	])("asks %s for markdown", async (model, taskType, include) => {
+		vi.useFakeTimers();
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse({ success: true, task: { id: "task-md", status: "QUEUED" } }))
+			.mockResolvedValueOnce(jsonResponse({ task: { id: "task-md", status: "COMPLETED" }, response: {} }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const promise = cloro.run(model, "best speakers");
+		await vi.runAllTimersAsync();
+		await promise;
+
+		expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({ taskType, payload: { include } });
+	});
+
 	it("keeps polling through transient and no-content status responses", async () => {
 		vi.useFakeTimers();
 		const fetchMock = vi
@@ -238,7 +276,7 @@ describe("cloro provider", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(4);
 		expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
 			taskType: "PERPLEXITY",
-			payload: { prompt: "What is a well-reviewed speaker?", country: "US" },
+			payload: { prompt: "What is a well-reviewed speaker?", country: "US", include: { markdown: true } },
 		});
 		expect(result.textContent).toContain("Sonos Era 300");
 	});

--- a/packages/lib/src/providers/registry/cloro.ts
+++ b/packages/lib/src/providers/registry/cloro.ts
@@ -11,19 +11,6 @@ import { failureDetails, isTransientStatus, pollDelay, queriesFromKeys, response
 // surface that hides its fan-out queries behind an `include` flag.
 type CloroTaskConfig = { taskType: string; field: "prompt" | "query"; include: Record<string, unknown> };
 
-/**
- * Every task asks for markdown, which Cloro only returns when requested.
- *
- * It is the answer as the engine laid it out — headings, lists, tables — and
- * the only field carrying the inline `[label](url)` citations that mark which
- * claim each source backs. The `text` beside it is the same answer with both
- * thrown away, so an answer read from `text` cannot be told apart from one the
- * engine wrote without citing anything. Markdown costs no extra credits.
- *
- * The Google Search task takes the flag inside its `aioverview` block instead:
- * there the answer is one section of a SERP response rather than the response
- * itself, and a top-level `markdown` would mean the whole page.
- */
 const CLORO_TASKS: Record<string, CloroTaskConfig> = {
 	chatgpt: { taskType: "CHATGPT", field: "prompt", include: { markdown: true, searchQueries: true } },
 	perplexity: { taskType: "PERPLEXITY", field: "prompt", include: { markdown: true } },

--- a/packages/lib/src/providers/registry/cloro.ts
+++ b/packages/lib/src/providers/registry/cloro.ts
@@ -9,14 +9,27 @@ import { failureDetails, isTransientStatus, pollDelay, queriesFromKeys, response
 // send a `prompt`, while Google AI Overview rides on the Google Search task and
 // sends a `query` with the AI Overview block requested. ChatGPT is the only
 // surface that hides its fan-out queries behind an `include` flag.
-type CloroTaskConfig = { taskType: string; field: "prompt" | "query"; include?: Record<string, unknown> };
+type CloroTaskConfig = { taskType: string; field: "prompt" | "query"; include: Record<string, unknown> };
 
+/**
+ * Every task asks for markdown, which Cloro only returns when requested.
+ *
+ * It is the answer as the engine laid it out — headings, lists, tables — and
+ * the only field carrying the inline `[label](url)` citations that mark which
+ * claim each source backs. The `text` beside it is the same answer with both
+ * thrown away, so an answer read from `text` cannot be told apart from one the
+ * engine wrote without citing anything. Markdown costs no extra credits.
+ *
+ * The Google Search task takes the flag inside its `aioverview` block instead:
+ * there the answer is one section of a SERP response rather than the response
+ * itself, and a top-level `markdown` would mean the whole page.
+ */
 const CLORO_TASKS: Record<string, CloroTaskConfig> = {
-	chatgpt: { taskType: "CHATGPT", field: "prompt", include: { searchQueries: true } },
-	perplexity: { taskType: "PERPLEXITY", field: "prompt" },
-	copilot: { taskType: "COPILOT", field: "prompt" },
-	gemini: { taskType: "GEMINI", field: "prompt" },
-	"google-ai-mode": { taskType: "AIMODE", field: "prompt" },
+	chatgpt: { taskType: "CHATGPT", field: "prompt", include: { markdown: true, searchQueries: true } },
+	perplexity: { taskType: "PERPLEXITY", field: "prompt", include: { markdown: true } },
+	copilot: { taskType: "COPILOT", field: "prompt", include: { markdown: true } },
+	gemini: { taskType: "GEMINI", field: "prompt", include: { markdown: true } },
+	"google-ai-mode": { taskType: "AIMODE", field: "prompt", include: { markdown: true } },
 	"google-ai-overview": { taskType: "GOOGLE", field: "query", include: { aioverview: { markdown: true } } },
 };
 
@@ -174,8 +187,7 @@ export const cloro: Provider = {
 			throw new Error(`Cloro: no task mapping for model "${model}". Supported: ${Object.keys(CLORO_TASKS).join(", ")}`);
 		}
 
-		const payload: Record<string, any> = { [task.field]: prompt, country: CLORO_COUNTRY };
-		if (task.include) payload.include = task.include;
+		const payload: Record<string, any> = { [task.field]: prompt, country: CLORO_COUNTRY, include: task.include };
 
 		const response = await runAsyncTask(task.taskType, payload);
 		const answer = cloroAnswer(response) ?? {};

--- a/packages/lib/src/text-extraction.ts
+++ b/packages/lib/src/text-extraction.ts
@@ -331,8 +331,10 @@ export function extractTextFromCloro(rawOutput: any): string {
 	try {
 		const answer = cloroAnswer(rawOutput);
 		if (!answer) return "No content in Cloro output.";
-		// `markdown` first: the AI Overview task is asked for it explicitly, and
-		// `text` is the same answer with its formatting flattened away.
+		// `markdown` first: every task asks for it, and it is the only field that
+		// carries the answer's inline citations — `text` is the same answer with
+		// those and its formatting flattened away. Runs stored before the request
+		// asked for markdown only have `text`, so the fallback stays.
 		for (const key of ["markdown", "text"]) {
 			if (typeof answer[key] === "string" && answer[key].trim()) return answer[key].trim();
 		}

--- a/packages/lib/src/text-extraction.ts
+++ b/packages/lib/src/text-extraction.ts
@@ -331,10 +331,9 @@ export function extractTextFromCloro(rawOutput: any): string {
 	try {
 		const answer = cloroAnswer(rawOutput);
 		if (!answer) return "No content in Cloro output.";
-		// `markdown` first: every task asks for it, and it is the only field that
-		// carries the answer's inline citations — `text` is the same answer with
-		// those and its formatting flattened away. Runs stored before the request
-		// asked for markdown only have `text`, so the fallback stays.
+		// `markdown` carries the answer's inline citations; `text` is the same
+		// answer with those and its formatting flattened away. Runs stored before
+		// the request asked for markdown only have `text`.
 		for (const key of ["markdown", "text"]) {
 			if (typeof answer[key] === "string" && answer[key].trim()) return answer[key].trim();
 		}


### PR DESCRIPTION
## What

Cloro returns `markdown` only when `include.markdown` is set, and only the Google AI Overview task asked for it. The five other surfaces — ChatGPT, Perplexity, Copilot, Gemini, Google AI Mode — sent no markdown flag, so `extractTextFromCloro`'s `["markdown", "text"]` preference always fell through to `text`.

Per [Cloro's docs](https://cloro.dev/docs/api-reference/endpoint/chatgpt/citation-pills):

> The `markdown` field carries the same citations as inline `[label](url)` links; `text` carries plain text without them.

So every Cloro chatbot answer Elmo stored was the answer with its headings, lists and tables flattened and its inline citations stripped — indistinguishable from an answer the engine wrote citing nothing. Cloro was the only provider in the table doing this; BrightData, Oxylabs, Olostep and DataForSEO's scraper all read a markdown field already.

`include.markdown` is a common parameter on every endpoint and [costs no extra credits](https://cloro.dev/docs/guides/making-requests/sync#markdown-format).

## Changes

- Every Cloro task now sends `include.markdown: true`. The Google Search task keeps its existing `include.aioverview: { markdown: true }` — there the answer is one section of a SERP response, so a top-level `markdown` would ask for the whole page.
- `include` is no longer optional on `CloroTaskConfig`, since every task has one now.
- Corrected the comment on the field-preference loop, which described the ordering as a live preference when only one surface exercised it.
- Table-driven test asserting each of the six task types requests markdown, so a surface added later can't silently ship without it.

## Checked the other providers

Not broken — none of them need an opt-in:

| Provider | Markdown source |
| --- | --- |
| Oxylabs | `parse: true` already set; `markdown_text` / `answer_results_md` come with the parsed shape |
| BrightData | `answer_text_markdown` is a dataset column, no request flag |
| Olostep | parser IDs return `markdown_content` / `answer_markdown` |
| DataForSEO LLM Scraper / AI Overview | returns `markdown` natively, already preferred |
| DataForSEO LLM Responses | no markdown option exists — `sections[].text` is the only answer field the API offers, and it carries `[7]`-style citation markers |

## Worth knowing

`analyzeMentions` substring-matches brand and competitor *domains* against the answer text. Cloro chatbot answers now carry source URLs inline, so a competitor that is cited but never named can start counting as mentioned on those surfaces. That is already how every other markdown-bearing provider behaves (including Cloro's own AI Overview), so this makes Cloro consistent rather than introducing something new — but it will move Cloro-sourced mention rates slightly. Tightening mention detection would be a separate change.

Existing stored runs only have `text`, so the fallback in the extractor stays.

## Testing

`pnpm lint` clean. `packages/lib` 538 passing, `apps/web` 617 passing.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e48c2356-68ee-4b44-a332-8e2667761ebb)
