### PR TITLE
assert the whole announcement body instead of URL substrings

### DIFF
--- a/scripts/discord-release-payload.test.mjs
+++ b/scripts/discord-release-payload.test.mjs
@@ -114,9 +114,14 @@ test("does not let the notes ping the channel or borrow the changelog label", ()
     !payload.content.includes("[Full changelog]"),
     "the changelog label only ever points into this repository",
   );
-  assert.ok(
-    payload.content.includes("https://github.com/other-org/other/pull/7"),
-    "a link to another repository keeps its URL visible",
+
+  const [, body] = payload.content.split("\n\n");
+  assert.deepEqual(
+    body.split("\n"),
+    [
+      `* @everyone @here read https://github.com/other-org/other/pull/7 by @someone in [#8](https://github.com/${REPO}/pull/8)`,
+      "**Full Changelog**: https://evil.example/phish",
+    ],
+    "only this repository's pull requests shorten to #n; everything else keeps its URL in plain sight",
   );
-  assert.ok(!payload.content.includes("[#7]"));
 });


### PR DESCRIPTION
CodeQL flags `payload.content.includes("https://github.com/other-org/other/pull/7")` in the Discord release-payload test as `js/incomplete-url-substring-sanitization` — the query can't tell an assertion about rendered output from an allowlist check on an untrusted URL, so any bare URL passed to `includes()` looks like a host check that arbitrary hosts can slip past.

Nothing here sanitizes a URL, so the fix is to stop expressing the assertion as a substring search. The test now compares the announcement body line by line, which covers both of the things the two `includes()` calls were checking — a foreign repository's link keeps its URL visible, and this repository's shortens to `[#8]` — and pins the passed-through `Full Changelog` line at the same time.

Verified by mutating `maskPullLinks` to shorten every pull request URL regardless of repository: only this test fails.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/fce4214a-5ac3-4749-9bd0-01744de8c942)
