### PR TITLE
add competitors under the quota lock

### DIFF
--- a/.changeset/competitor-quota-lock.md
+++ b/.changeset/competitor-quota-lock.md
@@ -1,0 +1,5 @@
+---
+"@workspace/web": patch
+---
+
+Fixed the competitor limit being exceeded when several requests added competitors to a brand at the same time.

--- a/apps/web/src/routes/api/v1/competitors/index.ts
+++ b/apps/web/src/routes/api/v1/competitors/index.ts
@@ -7,9 +7,8 @@
  * Protected by API key authentication.
  */
 import { createFileRoute } from "@tanstack/react-router";
-import { db } from "@workspace/lib/db/db";
 import { competitors } from "@workspace/lib/db/schema";
-import { assertCompetitorCap } from "@workspace/lib/entitlements";
+import { assertCompetitorCap, withQuotaLock } from "@workspace/lib/entitlements";
 import { z } from "zod";
 import { clampedPaging } from "@/lib/api/analytics-range";
 import { createApiHandler, withMethodGuard } from "@/lib/api/handler";
@@ -58,21 +57,25 @@ export const Route = createFileRoute("/api/v1/competitors/")({
 				handle: async ({ body, auth }) => {
 					const { brandId, name, domains, aliases } = body;
 
-					await requireBrandInScope(auth, brandId, "body");
+					const brand = await requireBrandInScope(auth, brandId, "body");
 
-					await assertCompetitorCap(brandId, 1);
+					// Check and insert under one lock: otherwise two requests on a
+					// brand's last competitor slot both pass the check.
+					return await withQuotaLock(brand.organizationId, async (tx) => {
+						await assertCompetitorCap(brandId, 1, tx);
 
-					const [inserted] = await db
-						.insert(competitors)
-						.values({
-							brandId,
-							name,
-							domains: dedupeDomains(domains ?? []),
-							aliases: dedupeAliases(aliases ?? []),
-						})
-						.returning();
+						const [inserted] = await tx
+							.insert(competitors)
+							.values({
+								brandId,
+								name,
+								domains: dedupeDomains(domains ?? []),
+								aliases: dedupeAliases(aliases ?? []),
+							})
+							.returning();
 
-					return inserted;
+						return inserted;
+					});
 				},
 			}),
 		}),

--- a/apps/web/src/server/brands.ts
+++ b/apps/web/src/server/brands.ts
@@ -21,6 +21,7 @@ import {
 	assertEnabledModelsAllowed,
 	decideCompetitorCap,
 	getOrgEntitlements,
+	withQuotaLock,
 } from "@workspace/lib/entitlements";
 import { isGroundedApiTarget, resolveProviderAccess, selectTargetsForBrand } from "@workspace/lib/providers";
 import { defaultPlatformPicks, resolvePromptRunPlan } from "@workspace/lib/run-policy";
@@ -536,21 +537,26 @@ export const createCompetitorFromDomainFn = createServerFn({ method: "POST" })
 		}),
 	)
 	.handler(async ({ data }) => {
-		await requireBrandSession(data.brandId);
+		const session = await requireAuthSession();
+		const org = await requireBrandOrganization(session.user.id, data.brandId);
 
 		const domain = cleanAndValidateDomain(data.domain);
 		if (!domain) throw new Error(`Invalid domain: ${data.domain}`);
 
-		await assertCompetitorCap(data.brandId, 1);
+		// Check and insert under one lock: otherwise two requests on a brand's
+		// last competitor slot both pass the check.
+		return await withQuotaLock(org.id, async (tx) => {
+			await assertCompetitorCap(data.brandId, 1, tx);
 
-		const [result] = await db
-			.insert(competitors)
-			.values({
-				brandId: data.brandId,
-				name: data.name.trim(),
-				domains: [domain],
-			})
-			.returning();
+			const [result] = await tx
+				.insert(competitors)
+				.values({
+					brandId: data.brandId,
+					name: data.name.trim(),
+					domains: [domain],
+				})
+				.returning();
 
-		return result;
+			return result;
+		});
 	});

--- a/apps/web/src/server/onboarding-core.ts
+++ b/apps/web/src/server/onboarding-core.ts
@@ -7,7 +7,12 @@ import type { DbConnection } from "@workspace/lib/db/db-connection";
 import { ensureOrganization } from "@workspace/lib/db/provisioning";
 import { brands, competitors, prompts } from "@workspace/lib/db/schema";
 import { claimNewBrandSlug, findUnusedBrandSlug } from "@workspace/lib/db/unique-names";
-import { assertCanAddPrompts, assertCompetitorCap, getBrandOrganizationId } from "@workspace/lib/entitlements";
+import {
+	assertCanAddPrompts,
+	assertCompetitorCap,
+	getBrandOrganizationId,
+	withQuotaLock,
+} from "@workspace/lib/entitlements";
 import { computeSystemTags, sanitizeUserTags } from "@workspace/lib/tag-utils";
 import { count, desc, eq, type SQL } from "drizzle-orm";
 import { z } from "zod";
@@ -383,26 +388,33 @@ export async function saveWizardOnboarding(input: WizardOnboardingInput): Promis
 	if (!existing) throw new BrandNotFoundError(input.brandId);
 	const websiteHost = new URL(existing.website).hostname.replace(/^www\./, "");
 
-	await insertCompetitors({
-		brandId: input.brandId,
-		websiteHost,
-		source: (input.competitors ?? []).map((c) => ({
-			name: c.name,
-			domains: c.domains ?? [],
-			aliases: c.aliases ?? [],
-		})),
-	});
+	// Both inserts check a usage count first, so they run under one lock: two
+	// saves racing each other must not both spend the same last slot.
+	const wizardPromptIds = await withQuotaLock(existing.organizationId, async (tx) => {
+		await insertCompetitors({
+			brandId: input.brandId,
+			websiteHost,
+			source: (input.competitors ?? []).map((c) => ({
+				name: c.name,
+				domains: c.domains ?? [],
+				aliases: c.aliases ?? [],
+			})),
+			conn: tx,
+		});
 
-	const wizardPromptIds = await insertPrompts({
-		brandId: input.brandId,
-		brandName: existing.name,
-		website: existing.website,
-		source: (input.prompts ?? []).map((p) => ({
-			value: p.value,
-			tags: sanitizeUserTags(p.tags ?? []),
-			enabled: p.enabled ?? true,
-		})),
-		dedupeAgainstExisting: true,
+		return insertPrompts({
+			brandId: input.brandId,
+			brandName: existing.name,
+			website: existing.website,
+			source: (input.prompts ?? []).map((p) => ({
+				value: p.value,
+				tags: sanitizeUserTags(p.tags ?? []),
+				enabled: p.enabled ?? true,
+			})),
+			dedupeAgainstExisting: true,
+			conn: tx,
+			organizationId: existing.organizationId,
+		});
 	});
 	await createMultiplePromptJobSchedulers(wizardPromptIds);
 

--- a/packages/lib/src/entitlements/guards.ts
+++ b/packages/lib/src/entitlements/guards.ts
@@ -288,7 +288,7 @@ export async function checkBrandCreate(orgIds: string[]): Promise<Map<string, Wr
 	return decisions;
 }
 
-/** Guard creating `adding` new enabled prompts (or re-enabling that many). */
+/** Guard adding `adding` competitors to a brand. */
 export async function assertCompetitorCap(brandId: string, adding: number, conn: DbConnection = db): Promise<void> {
 	if (adding <= 0) return;
 	const [row] = await conn.select({ value: count() }).from(competitors).where(eq(competitors.brandId, brandId));


### PR DESCRIPTION
Closes #680.

`POST /api/v1/competitors` read the competitor count and inserted as two
unrelated statements, so two requests arriving together both saw the same last
free slot and both took it. Brands and prompts already hold the fix —
`withQuotaLock` serializes an organization's quota-consuming writes and hands
back a transaction to do both steps on.

All three competitor write paths now check and insert under that lock:

- `apps/web/src/routes/api/v1/competitors/index.ts` — the org id comes from the
  brand `requireBrandInScope` was already resolving.
- `apps/web/src/server/brands.ts` (`createCompetitorFromDomainFn`) — the
  dashboard path the issue asked me to check. It swaps `requireBrandSession`
  for `requireBrandOrganization`, which applies the same membership rule against
  the same join and returns the org in the query it would have spent on the
  access check alone.
- `apps/web/src/server/onboarding-core.ts` (`saveWizardOnboarding`) — the second
  dashboard caller of `assertCompetitorCap`, not named in the issue but the same
  defect. Its prompt insert has the same read-then-write shape and has to share
  the transaction, so both inserts moved under one lock. `createBrand`'s
  competitor insert was already running on a caller-supplied transaction and is
  untouched.

`updateCompetitors` is a bulk replace whose resulting count comes entirely from
the payload, so it has no read to race and stays as it is. The wrong docstring
on `assertCompetitorCap` (it described prompts) is corrected.

## Testing

`pnpm lint`, `pnpm test` (522 web + package tests), and `tsc --noEmit` across
`apps/web` and `packages/lib` all pass. I could not run the Bruno API suite or
the Playwright e2e tests — this sandbox has no Postgres — so the competitor
endpoints have not been exercised against a live database. The race itself
isn't reachable from either harness anyway: Bruno runs requests sequentially and
the cap is 500 per brand.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a11dfbb6-cc1c-48dd-bb98-7050cac670ed)
