### PR TITLE
Stop answering an error for a write that already committed

### DIFF
--- a/.changeset/post-commit-scheduler-failures.md
+++ b/.changeset/post-commit-scheduler-failures.md
@@ -1,0 +1,6 @@
+---
+"@workspace/web": patch
+"@workspace/lib": patch
+---
+
+Creating prompts or a brand no longer answers an error when the write itself succeeded and only the job scheduling behind it failed — retrying that error created a second copy of a prompt batch or came back with a conflict on the brand just created.

--- a/apps/web/src/server/__tests__/prompts-core.test.ts
+++ b/apps/web/src/server/__tests__/prompts-core.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The window between a committed write and the queue calls that follow it. A
+ * failure there is not a failed write, and answering it as one gets the batch
+ * created twice by whatever retries — agents on the MCP tools especially.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const scheduler = vi.hoisted(() => ({
+	createPromptJobScheduler: vi.fn(async (_promptId: string) => true),
+	removePromptJobScheduler: vi.fn(async (_promptId: string) => true),
+}));
+vi.mock("@/lib/job-scheduler", () => scheduler);
+
+/** Enough of drizzle for the insert createPrompts makes under the quota lock. */
+vi.mock("@workspace/lib/db/db", () => ({
+	db: {
+		transaction: <T>(fn: (tx: unknown) => Promise<T>): Promise<T> =>
+			fn({
+				execute: async () => undefined,
+				insert: () => ({
+					values: (values: Record<string, unknown>[]) => ({
+						returning: async () => values.map((value, index) => ({ ...value, id: `prompt_${index + 1}` })),
+					}),
+				}),
+			}),
+	},
+}));
+
+const { createPrompts } = await import("@/server/prompts-core");
+
+const BRAND = { id: "brand_1", name: "Elmo", website: "https://elmo.chat", organizationId: "org_1" };
+
+const TWO_PROMPTS = {
+	prompts: [{ value: "best ai visibility tool" }, { value: "how do i track brand mentions" }],
+};
+
+beforeEach(() => {
+	// Local mode resolves to unlimited entitlements without reading a row, so the
+	// quota check in front of the insert needs no billing fixtures.
+	vi.stubEnv("DEPLOYMENT_MODE", "local");
+	scheduler.createPromptJobScheduler.mockClear();
+	scheduler.createPromptJobScheduler.mockImplementation(async () => true);
+	vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	vi.restoreAllMocks();
+});
+
+describe("createPrompts", () => {
+	it("schedules every enabled prompt once the write has committed", async () => {
+		const created = await createPrompts(BRAND, TWO_PROMPTS);
+
+		expect(created.map((prompt) => prompt.id)).toEqual(["prompt_1", "prompt_2"]);
+		expect(scheduler.createPromptJobScheduler.mock.calls).toEqual([["prompt_1"], ["prompt_2"]]);
+	});
+
+	it("leaves a disabled prompt unscheduled", async () => {
+		await createPrompts(BRAND, {
+			prompts: [{ value: "tracked" }, { value: "parked", enabled: false }],
+		});
+
+		expect(scheduler.createPromptJobScheduler.mock.calls).toEqual([["prompt_1"]]);
+	});
+
+	it("returns the created prompts when the queue is unreachable", async () => {
+		scheduler.createPromptJobScheduler.mockRejectedValue(new Error("queue unreachable"));
+
+		const created = await createPrompts(BRAND, TWO_PROMPTS);
+
+		expect(created.map((prompt) => prompt.value)).toEqual(["best ai visibility tool", "how do i track brand mentions"]);
+	});
+
+	it("still schedules the rest of a batch when one prompt cannot be scheduled", async () => {
+		scheduler.createPromptJobScheduler.mockImplementation(async (promptId: string) => {
+			if (promptId === "prompt_1") throw new Error("queue unreachable");
+			return true;
+		});
+
+		await createPrompts(BRAND, TWO_PROMPTS);
+
+		expect(scheduler.createPromptJobScheduler).toHaveBeenCalledWith("prompt_2");
+	});
+});

--- a/apps/web/src/server/onboarding-core.ts
+++ b/apps/web/src/server/onboarding-core.ts
@@ -1,6 +1,7 @@
 /** Split from onboarding.ts so a client component importing a server function
  * does not transitively pull in drizzle and pg. */
 
+import { runAfterCommit } from "@workspace/lib/after-commit";
 import { slugify } from "@workspace/lib/app-urls";
 import { db } from "@workspace/lib/db/db";
 import type { DbConnection } from "@workspace/lib/db/db-connection";
@@ -337,7 +338,7 @@ export async function createBrand(input: CreateBrandInput): Promise<BrandResult>
 	// through the pool.
 	const schedule = () => createMultiplePromptJobSchedulers(promptIds);
 	if (input.afterCommit) input.afterCommit(schedule);
-	else await schedule();
+	else await runAfterCommit(schedule);
 
 	const refreshed = await (input.conn ?? db).query.brands.findFirst({ where: eq(brands.id, input.id) });
 	return buildBrandResult(refreshed!);

--- a/apps/web/src/server/prompts-core.ts
+++ b/apps/web/src/server/prompts-core.ts
@@ -165,7 +165,7 @@ export async function createPrompts(brand: PromptBrand, input: Omit<BulkPromptIn
 
 	// Under the lock, so two batches cannot both spend the last slot.
 	const enabled = rows.filter((row) => row.enabled);
-	const created = await withQuotaLock(brand.organizationId, async (tx) => {
+	return withQuotaLock(brand.organizationId, async (tx, afterCommit) => {
 		await assertPromptSaveAllowed(
 			brand.organizationId,
 			{
@@ -174,16 +174,15 @@ export async function createPrompts(brand: PromptBrand, input: Omit<BulkPromptIn
 			},
 			tx,
 		);
-		return tx.insert(prompts).values(rows).returning();
+		const created = await tx.insert(prompts).values(rows).returning();
+		// Scheduling waits for the commit: a schedule for a rolled-back prompt
+		// would outlive it, and the queue client goes through the pool. One task
+		// per prompt so a prompt that can't be scheduled only costs itself.
+		for (const prompt of created) {
+			if (prompt.enabled) afterCommit(() => createPromptJobScheduler(prompt.id));
+		}
+		return created;
 	});
-
-	// Outside the transaction: a queue hiccup must not roll back prompts the
-	// customer can see; the worker's scheduler picks up what failed.
-	for (const prompt of created) {
-		if (prompt.enabled) await createPromptJobScheduler(prompt.id);
-	}
-
-	return created;
 }
 
 function promptUpdateData(

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -22,6 +22,7 @@
 		"./auth/permissions": "./src/auth/permissions.ts",
 		"./constants": "./src/constants.ts",
 		"./app-urls": "./src/app-urls.ts",
+		"./after-commit": "./src/after-commit.ts",
 		"./expedite": "./src/expedite.ts",
 		"./run-backoff": "./src/run-backoff.ts",
 		"./text-extraction": "./src/text-extraction.ts",

--- a/packages/lib/src/after-commit.test.ts
+++ b/packages/lib/src/after-commit.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runAfterCommit } from "./after-commit";
+
+beforeEach(() => {
+	vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("runAfterCommit", () => {
+	it("awaits the task", async () => {
+		let ran = false;
+		await runAfterCommit(async () => {
+			await Promise.resolve();
+			ran = true;
+		});
+		expect(ran).toBe(true);
+	});
+
+	it("absorbs a failing task rather than failing the write it follows", async () => {
+		await expect(
+			runAfterCommit(async () => {
+				throw new Error("queue unreachable");
+			}),
+		).resolves.toBeUndefined();
+		expect(console.error).toHaveBeenCalled();
+	});
+
+	it("absorbs a task that throws synchronously", async () => {
+		await expect(
+			runAfterCommit((() => {
+				throw new Error("boom");
+			}) as () => Promise<unknown>),
+		).resolves.toBeUndefined();
+	});
+});

--- a/packages/lib/src/after-commit.ts
+++ b/packages/lib/src/after-commit.ts
@@ -1,0 +1,22 @@
+/**
+ * Run a task that was deferred until a write was durable — scheduling a job,
+ * mostly, which has no business holding a transaction open or leaving a
+ * schedule behind for a row that rolled back.
+ *
+ * The row is committed before any of this runs, so a failure here is not a
+ * failed write and must not be answered as one. A caller told its write failed
+ * retries it: a retried prompt batch creates the prompts a second time, and a
+ * retried brand comes back 409 for the brand it just made. Agents driving the
+ * MCP tools retry far more readily than people do.
+ *
+ * Dropping the task costs a cadence, not the data. The worker's maintenance
+ * sweep schedules every enabled prompt that has no pending job, and alerts on
+ * the ones that stay overdue.
+ */
+export async function runAfterCommit(task: () => Promise<unknown>): Promise<void> {
+	try {
+		await task();
+	} catch (error) {
+		console.error("Post-commit task failed; the write it follows is committed and stands:", error);
+	}
+}

--- a/packages/lib/src/entitlements/guards.test.ts
+++ b/packages/lib/src/entitlements/guards.test.ts
@@ -4,8 +4,23 @@ import {
 	resolveEntitlements,
 	UNLIMITED_ENTITLEMENTS,
 } from "@workspace/config/entitlements";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MAX_COMPETITORS, MAX_PROMPTS } from "../constants";
+
+// withQuotaLock is the only thing here that touches a database. The fake
+// transaction records when it committed, so a test can say whether a deferred
+// task ran before or after that.
+const txState = vi.hoisted(() => ({ log: [] as string[] }));
+vi.mock("../db/db", () => ({
+	db: {
+		transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => {
+			const value = await fn({ execute: async () => txState.log.push("lock") });
+			txState.log.push("commit");
+			return value;
+		},
+	},
+}));
+
 import {
 	decideBrandCreate,
 	decideCadenceOverride,
@@ -16,6 +31,7 @@ import {
 	decidePromptCap,
 	promptSaveDelta,
 	type WriteDecision,
+	withQuotaLock,
 } from "./guards";
 
 const NOW = new Date("2026-08-05T12:00:00Z");
@@ -362,5 +378,70 @@ describe("grace and paused standings", () => {
 		});
 		expect(paused.standing).toBe("paused");
 		expect(decidePromptAdd(paused, 0, 1).allowed).toBe(true);
+	});
+});
+
+describe("withQuotaLock post-commit tasks", () => {
+	beforeEach(() => {
+		txState.log = [];
+		vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("runs deferred tasks after the transaction commits, in order", async () => {
+		const value = await withQuotaLock("org_1", async (_tx, afterCommit) => {
+			afterCommit(async () => {
+				txState.log.push("first");
+			});
+			afterCommit(async () => {
+				txState.log.push("second");
+			});
+			txState.log.push("write");
+			return "brand_1";
+		});
+
+		expect(value).toBe("brand_1");
+		expect(txState.log).toEqual(["lock", "write", "commit", "first", "second"]);
+	});
+
+	// The write is durable by then, so answering an error invites a retry that
+	// creates the row twice or collides with the one that exists.
+	it("returns the committed value when a deferred task fails", async () => {
+		const value = await withQuotaLock("org_1", async (_tx, afterCommit) => {
+			afterCommit(async () => {
+				throw new Error("queue unreachable");
+			});
+			return ["prompt_1", "prompt_2"];
+		});
+
+		expect(value).toEqual(["prompt_1", "prompt_2"]);
+	});
+
+	it("still runs the tasks that follow a failing one", async () => {
+		await withQuotaLock("org_1", async (_tx, afterCommit) => {
+			afterCommit(async () => {
+				throw new Error("queue unreachable");
+			});
+			afterCommit(async () => {
+				txState.log.push("later");
+			});
+			return null;
+		});
+
+		expect(txState.log).toContain("later");
+	});
+
+	// Nothing is committed yet, so this one has to reach the caller.
+	it("propagates a failure from inside the transaction", async () => {
+		await expect(
+			withQuotaLock("org_1", async (_tx, afterCommit) => {
+				afterCommit(async () => txState.log.push("scheduled"));
+				throw new Error("over the plan limit");
+			}),
+		).rejects.toThrow("over the plan limit");
+		expect(txState.log).not.toContain("scheduled");
 	});
 });

--- a/packages/lib/src/entitlements/guards.ts
+++ b/packages/lib/src/entitlements/guards.ts
@@ -6,6 +6,7 @@
 import type { Entitlements } from "@workspace/config/entitlements";
 import { MAX_SELF_SERVE_BRANDS, premiumPairings, premiumPlanNames, premiumSlotsUsed } from "@workspace/config/plans";
 import { and, count, eq, inArray, sql } from "drizzle-orm";
+import { runAfterCommit } from "../after-commit";
 import { MAX_COMPETITORS, MAX_PROMPTS } from "../constants";
 import { db } from "../db/db";
 import type { DbConnection } from "../db/db-connection";
@@ -247,6 +248,10 @@ const QUOTA_LOCK_CLASS = 0x656c6d6f;
  * `run` must do all of its work on the `tx` it is handed, checks included.
  * Reaching for the pooled `db` holds this transaction open while waiting for a
  * second connection, which deadlocks the pool under enough concurrent callers.
+ *
+ * Anything handed to `afterCommit` runs once the transaction has committed, in
+ * the order it was registered, and is best-effort: it cannot fail the write it
+ * follows, and one task failing doesn't cost the rest their turn.
  */
 export async function withQuotaLock<T>(
 	organizationId: string,
@@ -257,7 +262,7 @@ export async function withQuotaLock<T>(
 		await tx.execute(sql`select pg_advisory_xact_lock(${QUOTA_LOCK_CLASS}, hashtext(${organizationId}))`);
 		return run(tx, (task) => deferred.push(task));
 	});
-	for (const task of deferred) await task();
+	for (const task of deferred) await runAfterCommit(task);
 	return value;
 }
 


### PR DESCRIPTION
Fixes #677.

`withQuotaLock()` committed its transaction and then awaited the deferred scheduler tasks, so anything they threw reached the caller as a failed write — an HTTP 500 on `POST /api/v1/prompts`, a tool error on the MCP `create_prompts` — for prompts or a brand that are already durable. Retrying that error creates the batch a second time, or comes back 409 for the brand that now exists.

## What changed

- **`packages/lib/src/after-commit.ts`** — new `runAfterCommit(task)`: runs one post-commit task and absorbs whatever it throws, with a comment covering why that failure must not be reported as a failed write.
- **`withQuotaLock`** routes each deferred task through it, so a failure can't fail the committed write and one task failing no longer skips the ones after it. The contract is now stated on the function.
- **`createPrompts`** moved its scheduling loop inside the lock's `afterCommit`, one task per prompt, instead of a bare loop after the call. Same order, same calls, but now one unschedulable prompt only costs itself.
- **`createBrand`**'s direct-schedule path (admin key, no surrounding lock) goes through the same helper.

Option B from the issue rather than an outbox: the worker's `schedule-maintenance` sweep is already the drain. It schedules every enabled prompt with no pending job and reports prompts that stay overdue to Sentry, so a dropped scheduler call costs a cadence, not the work. An outbox would duplicate that machinery.

## Tests

Failure injection over the commit → scheduler window, which nothing covered before:

- `packages/lib/src/after-commit.test.ts` — a throwing task (async or sync) doesn't reach the caller.
- `guards.test.ts` — deferred tasks run after the commit in registration order; a failing one still returns the committed value and doesn't stop the rest; a failure *inside* the transaction still propagates, with nothing scheduled.
- `apps/web/src/server/__tests__/prompts-core.test.ts` — `createPrompts` schedules each enabled prompt and returns the batch with the queue unreachable; one prompt failing to schedule doesn't cost the others theirs.

Two of these fail on `main`'s behavior (verified by reverting the `withQuotaLock` line and re-running).

`pnpm test`, `pnpm lint`, and `check-types` pass.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/14c9c506-b17a-472d-8207-40fdcedace65)
