### PR TITLE
Generate one opportunities report per brand at a time

### DIFF
--- a/.changeset/opportunities-generation-lock.md
+++ b/.changeset/opportunities-generation-lock.md
@@ -1,0 +1,6 @@
+---
+"@workspace/web": patch
+"@workspace/api-spec": patch
+---
+
+Fixed opportunities reports being generated many times over for the same brand: generation now happens one caller at a time, and `GET /brands/{brandId}/opportunities` and the `get_opportunities` MCP tool only ever read the stored report, answering `not-generated` when there isn't one yet.

--- a/apps/web/src/lib/mcp/tools/analytics.ts
+++ b/apps/web/src/lib/mcp/tools/analytics.ts
@@ -94,12 +94,14 @@ export const getQueryFanout = analyticsTool({
 	},
 });
 
-/** No window: this reads the newest stored report, whenever it was generated. */
+/** No window: this reads the newest stored report, whenever it was generated,
+ * and never asks for a new one — writing a report costs an LLM call, which is
+ * not something a tool declaring `readOnly` may spend. */
 export const getOpportunities = defineTool({
 	name: "get_opportunities",
 	title: "Get the latest opportunities report",
 	description:
-		"The most recent stored opportunities report for a brand: what to write, what to fix, and the risks Elmo found. `status` says whether there was enough data to write one.",
+		"The most recent stored opportunities report for a brand: what to write, what to fix, and the risks Elmo found. `status` says whether a report has been written yet, and whether there was enough data to write one. Elmo decides when to produce a new one; this tool never triggers generation.",
 	scopes: ["analytics:read"],
 	readOnly: true,
 	input: { brandId: brandIdArg },

--- a/apps/web/src/routes/_authed/app/org/$org/brand/$brand/opportunities.tsx
+++ b/apps/web/src/routes/_authed/app/org/$org/brand/$brand/opportunities.tsx
@@ -33,6 +33,10 @@ function OpportunitiesPage() {
 		content = <LoadingState />;
 	} else if (error) {
 		content = <EmptyCard>Couldn't generate recommendations right now. Reload the page to try again.</EmptyCard>;
+	} else if (data?.reason === "generating") {
+		content = (
+			<EmptyCard>Your first set of recommendations is being generated — check back in a few minutes.</EmptyCard>
+		);
 	} else if (!data || data.reason === "insufficient-data" || !data.report) {
 		content = (
 			<EmptyCard>

--- a/apps/web/src/routes/api/v1/brands/$brandId/opportunities.ts
+++ b/apps/web/src/routes/api/v1/brands/$brandId/opportunities.ts
@@ -1,6 +1,7 @@
 /**
- * No POST to regenerate: producing a report spends provider budget with nothing
- * metering it per call. Elmo decides when one is stale.
+ * No POST to regenerate, and the GET doesn't either: producing a report spends
+ * provider budget with nothing metering it per call. Elmo decides when one is
+ * stale, so this endpoint only ever reads what it already wrote.
  */
 import { createFileRoute } from "@tanstack/react-router";
 import { createApiHandler, withMethodGuard } from "@/lib/api/handler";

--- a/apps/web/src/server/__tests__/opportunities-generation.test.ts
+++ b/apps/web/src/server/__tests__/opportunities-generation.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Generating a report is a paid LLM call, so the things that bound the spend —
+ * the freshness gate, the per-brand lock, and read surfaces that only read —
+ * are behavior worth pinning down.
+ *
+ * The fake `db` models the two bits of Postgres this leans on: an append-only
+ * report table, and advisory locks that a second holder cannot take.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const DAY_MS = 86_400_000;
+const BRAND = "brand_1";
+
+const state = vi.hoisted(() => ({
+	reports: [] as Array<{ brandId: string; report: unknown; model: string | null; createdAt: Date }>,
+	locks: new Set<string>(),
+	/** Simulates a concurrent writer committing between a read and the lock. */
+	afterReportRead: null as null | (() => void),
+}));
+
+const llm = vi.hoisted(() => {
+	let entered!: () => void;
+	let release!: () => void;
+	return {
+		calls: 0,
+		fails: false,
+		entered: new Promise<void>((resolve) => {
+			entered = resolve;
+		}),
+		release: new Promise<void>((resolve) => {
+			release = resolve;
+		}),
+		signalEntered: () => entered(),
+		finish: () => release(),
+		reset() {
+			this.calls = 0;
+			this.fails = false;
+			this.entered = new Promise<void>((resolve) => {
+				entered = resolve;
+			});
+			this.release = new Promise<void>((resolve) => {
+				release = resolve;
+			});
+		},
+	};
+});
+
+vi.mock("@workspace/lib/db/db", async () => {
+	const { brandOpportunities, brands } = await import("@workspace/lib/db/schema");
+
+	// One brand per test, so the `where` clauses have nothing to narrow.
+	function rowsFor(table: unknown) {
+		if (table === brandOpportunities) {
+			const rows = [...state.reports].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+			const hook = state.afterReportRead;
+			state.afterReportRead = null;
+			hook?.();
+			return rows;
+		}
+		if (table === brands) return [{ name: "Acme", website: "https://acme.test", additionalDomains: [] }];
+		return [];
+	}
+
+	/** Every builder method chains; awaiting the chain runs the "query". */
+	function select() {
+		let table: unknown;
+		const chain: Record<string | symbol, unknown> = new Proxy(
+			{},
+			{
+				get(_target, prop) {
+					if (prop === "then") {
+						return (resolve: (rows: unknown[]) => unknown) => Promise.resolve(rowsFor(table)).then(resolve);
+					}
+					return (value: unknown) => {
+						if (prop === "from") table = value;
+						return chain;
+					};
+				},
+			},
+		);
+		return chain;
+	}
+
+	const client = {
+		query: async (text: string, params: unknown[]) => {
+			const key = String(params[1]);
+			if (text.includes("pg_try_advisory_lock")) {
+				if (state.locks.has(key)) return { rows: [{ locked: false }] };
+				state.locks.add(key);
+				return { rows: [{ locked: true }] };
+			}
+			if (text.includes("pg_advisory_unlock")) state.locks.delete(key);
+			return { rows: [] };
+		},
+		release: () => {},
+	};
+
+	return {
+		db: {
+			select,
+			insert: () => ({
+				values: (row: { brandId: string; report: unknown; model: string | null }) => ({
+					returning: async () => {
+						const saved = { ...row, createdAt: new Date() };
+						state.reports.push(saved);
+						return [{ createdAt: saved.createdAt }];
+					},
+				}),
+			}),
+			$client: { connect: async () => client },
+		},
+	};
+});
+
+vi.mock("@workspace/lib/onboarding", () => ({
+	runStructuredCompletionPrompt: async () => {
+		llm.calls += 1;
+		llm.signalEntered();
+		if (llm.fails) throw new Error("provider refused");
+		await llm.release;
+		return {
+			object: {
+				summary: ["Competitors own the roundups"],
+				opportunities: [
+					{
+						category: "outreach",
+						title: "Get into the CRM roundups",
+						why: "Rivals are cited there and you are not.",
+						relatedPrompts: ["best crm for startups"],
+					},
+				],
+				risks: ["Roundup editors move slowly"],
+			},
+			modelVersion: "test-model",
+		};
+	},
+}));
+
+vi.mock("@/server/prompt-resolution", () => ({
+	resolveFilteredPrompts: async () => [{ id: "prompt_1", value: "best crm for startups", systemTags: [], tags: [] }],
+}));
+
+vi.mock("@/lib/postgres-read", () => ({
+	getPerPromptRunStats: async () => [{ prompt_id: "prompt_1", runs: 12, brand_mention_rate: 0.25 }],
+	getPerPromptDailyCompetitorMentions: async () => [],
+	getPerPromptDailyCitationStats: async () => [],
+	getPerPromptCitationPages: async () => [],
+	getBrandMentionRateByModel: async () => [],
+}));
+
+const { resolveOpportunities, storedOpportunities } = await import("@/server/opportunities");
+const { publishedOpportunities } = await import("@/server/opportunities-core");
+
+function storeReport(title: string, ageDays: number) {
+	state.reports.push({
+		brandId: BRAND,
+		report: {
+			summary: [],
+			risks: [],
+			opportunities: [
+				{
+					category: "outreach",
+					title,
+					why: "stored",
+					relatedPrompts: [],
+					yourCitations: [],
+					competitorCitations: [],
+				},
+			],
+		},
+		model: "stored-model",
+		createdAt: new Date(Date.now() - ageDays * DAY_MS),
+	});
+}
+
+const titles = (report: { opportunities: Array<{ title: string }> } | null) =>
+	(report?.opportunities ?? []).map((o) => o.title);
+
+beforeEach(() => {
+	state.reports.length = 0;
+	state.locks.clear();
+	state.afterReportRead = null;
+	llm.reset();
+});
+
+describe("resolveOpportunities", () => {
+	it("serves a report that is still within the refresh window without generating one", async () => {
+		storeReport("Stored opportunity", 1);
+		llm.finish();
+
+		const result = await resolveOpportunities(BRAND);
+
+		expect(titles(result.report)).toEqual(["Stored opportunity"]);
+		expect(llm.calls).toBe(0);
+	});
+
+	it("generates once when two callers find the same stale report", async () => {
+		storeReport("Stored opportunity", 30);
+
+		const first = resolveOpportunities(BRAND);
+		await llm.entered;
+		const second = await resolveOpportunities(BRAND);
+		llm.finish();
+
+		expect(titles((await first).report)).toEqual(["Get into the CRM roundups"]);
+		// The second caller is served the stale report rather than paying again.
+		expect(titles(second.report)).toEqual(["Stored opportunity"]);
+		expect(llm.calls).toBe(1);
+		expect(state.reports).toHaveLength(2);
+	});
+
+	it("tells a caller with nothing stored that a report is on its way", async () => {
+		const first = resolveOpportunities(BRAND);
+		await llm.entered;
+		const second = await resolveOpportunities(BRAND);
+		llm.finish();
+		await first;
+
+		expect(second.reason).toBe("generating");
+		expect(second.report).toBeNull();
+		expect(llm.calls).toBe(1);
+	});
+
+	it("serves the report a concurrent caller wrote while it waited for the lock", async () => {
+		state.afterReportRead = () => storeReport("Just written", 0);
+		llm.finish();
+
+		const result = await resolveOpportunities(BRAND);
+
+		expect(titles(result.report)).toEqual(["Just written"]);
+		expect(llm.calls).toBe(0);
+	});
+
+	it("releases the lock when generation fails, so the next caller can try", async () => {
+		llm.fails = true;
+
+		await expect(resolveOpportunities(BRAND)).rejects.toThrow("Failed to generate");
+		expect(state.locks.size).toBe(0);
+
+		llm.reset();
+		llm.finish();
+		const retry = await resolveOpportunities(BRAND);
+
+		expect(titles(retry.report)).toEqual(["Get into the CRM roundups"]);
+	});
+});
+
+describe("read-only surfaces", () => {
+	it("serves a long-stale report as-is rather than generating a replacement", async () => {
+		storeReport("Stored opportunity", 90);
+		llm.finish();
+
+		const published = await publishedOpportunities(BRAND);
+
+		expect(published.status).toBe("ready");
+		expect(published.opportunities.map((o) => o.title)).toEqual(["Stored opportunity"]);
+		expect(llm.calls).toBe(0);
+	});
+
+	it("reports a brand with no stored report as not-generated", async () => {
+		llm.finish();
+
+		const published = await publishedOpportunities(BRAND);
+
+		expect(published.status).toBe("not-generated");
+		expect(published.opportunities).toEqual([]);
+		expect(published.generatedAt).toBeNull();
+		expect(llm.calls).toBe(0);
+	});
+
+	it("never takes the generation lock", async () => {
+		storeReport("Stored opportunity", 90);
+		llm.finish();
+
+		await storedOpportunities(BRAND);
+
+		expect(state.locks.size).toBe(0);
+	});
+});

--- a/apps/web/src/server/opportunities-core.ts
+++ b/apps/web/src/server/opportunities-core.ts
@@ -3,11 +3,12 @@
  * returning it whole would make whatever the generator wrote part of this
  * contract.
  */
-import type { CitedPage, ReportOpportunity } from "./opportunities";
-import { resolveOpportunities } from "./opportunities";
+import type { CitedPage, OpportunitiesResponse, ReportOpportunity } from "./opportunities";
+import { storedOpportunities } from "./opportunities";
 
-/** So a caller never has to tell "none" from "not enough data yet". */
-type OpportunitiesStatus = "ready" | "insufficient-data";
+/** So a caller never has to tell "none" from "not enough data yet" — or from a
+ * brand nobody has generated a report for. */
+type OpportunitiesStatus = "ready" | "insufficient-data" | "not-generated";
 
 interface PublishedOpportunity {
 	category: ReportOpportunity["category"];
@@ -28,13 +29,18 @@ export interface PublishedOpportunities {
 	risks: string[];
 }
 
+function statusOf(result: OpportunitiesResponse): OpportunitiesStatus {
+	if ((result.report?.opportunities.length ?? 0) > 0) return "ready";
+	return result.reason === "not-generated" ? "not-generated" : "insufficient-data";
+}
+
 export async function publishedOpportunities(brandId: string): Promise<PublishedOpportunities> {
-	const result = await resolveOpportunities(brandId, "UTC");
+	const result = await storedOpportunities(brandId);
 	const opportunities = result.report?.opportunities ?? [];
 
 	return {
 		brandId,
-		status: opportunities.length > 0 ? "ready" : "insufficient-data",
+		status: statusOf(result),
 		generatedAt: result.lastEvaluatedAt,
 		model: result.model,
 		summary: result.report?.summary ?? [],

--- a/apps/web/src/server/opportunities.ts
+++ b/apps/web/src/server/opportunities.ts
@@ -15,6 +15,8 @@
  * honors ONBOARDING_LLM_TARGET / the preference order). Reports are persisted to
  * the brand_opportunities table (append-only) and served as-is until the latest
  * is older than REFRESH_AFTER_DAYS, so a normal page load doesn't trigger an LLM call.
+ * Generation is reached through `resolveOpportunities` alone, one caller at a
+ * time per brand; `storedOpportunities` is the read that never pays for one.
  */
 import { db } from "@workspace/lib/db/db";
 import { brandOpportunities, brands, competitors } from "@workspace/lib/db/schema";
@@ -125,7 +127,11 @@ export interface OpportunitiesReport extends Omit<RawReport, "opportunities"> {
 	opportunities: ReportOpportunity[];
 }
 
-type OpportunitiesReason = "insufficient-data" | null;
+/**
+ * `not-generated` and `generating` are only ever answered by a caller that
+ * won't generate: a read-only surface, or one that lost the race for the lock.
+ */
+type OpportunitiesReason = "insufficient-data" | "not-generated" | "generating" | null;
 export interface OpportunitiesResponse {
 	report: OpportunitiesReport | null;
 	reason: OpportunitiesReason;
@@ -543,41 +549,92 @@ async function generateValidReport(prompt: string): Promise<{ report: RawReport;
 	return null;
 }
 
-/**
- * Generation is inline and synchronous — there is no queue, so a caller either
- * gets the current report or waits for the one it just caused. The freshness
- * gate is what bounds the spend.
- */
-export async function resolveOpportunities(brandId: string, timezone = "UTC"): Promise<OpportunitiesResponse> {
+/** Advisory locks share one namespace per database; this class keeps generation
+ * locks off `withQuotaLock`'s, which key on an id from the same space. */
+const GENERATION_LOCK_CLASS = 0x6f707074;
+
+type StoredReport = typeof brandOpportunities.$inferSelect;
+
+async function latestStoredReport(brandId: string): Promise<StoredReport | undefined> {
 	const [latest] = await db
 		.select()
 		.from(brandOpportunities)
 		.where(eq(brandOpportunities.brandId, brandId))
 		.orderBy(desc(brandOpportunities.createdAt))
 		.limit(1);
-	const lastEvaluatedAt = latest?.createdAt.toISOString() ?? null;
-	const servedModel = latest?.model ?? null;
-	const isFresh = latest && Date.now() - new Date(latest.createdAt).getTime() < REFRESH_AFTER_DAYS * 86_400_000;
-	const serveStored = () => ({
-		report: withoutRepeats(latest.report as OpportunitiesReport),
+	return latest;
+}
+
+const isFresh = (stored: StoredReport) => Date.now() - stored.createdAt.getTime() < REFRESH_AFTER_DAYS * 86_400_000;
+
+function serveStored(stored: StoredReport): OpportunitiesResponse {
+	return {
+		report: withoutRepeats(stored.report as OpportunitiesReport),
 		reason: null,
 		generatedFor: null,
-		lastEvaluatedAt,
-		model: servedModel,
-	});
-	if (latest && isFresh) return serveStored();
+		lastEvaluatedAt: stored.createdAt.toISOString(),
+		model: stored.model,
+	};
+}
+
+const nothingStored = (reason: OpportunitiesReason): OpportunitiesResponse => ({
+	report: null,
+	reason,
+	generatedFor: null,
+	lastEvaluatedAt: null,
+	model: null,
+});
+
+/**
+ * Run `generate` holding the brand's generation lock, or answer null if another
+ * caller already holds it.
+ *
+ * The lock is session-scoped rather than transaction-scoped like
+ * `withQuotaLock`'s: it has to cover an LLM call, and a transaction left open
+ * that long pins a snapshot as well as a connection. Nobody queues for it
+ * either — a caller that can't have it has something better to answer with than
+ * a wait on a report it cannot speed up.
+ */
+async function withGenerationLock<T>(brandId: string, generate: () => Promise<T>): Promise<T | null> {
+	const client = await db.$client.connect();
+	let locked = false;
+	try {
+		const result = await client.query<{ locked: boolean }>("select pg_try_advisory_lock($1, hashtext($2)) as locked", [
+			GENERATION_LOCK_CLASS,
+			brandId,
+		]);
+		locked = result.rows[0]?.locked === true;
+		return locked ? await generate() : null;
+	} finally {
+		try {
+			if (locked) {
+				await client.query("select pg_advisory_unlock($1, hashtext($2))", [GENERATION_LOCK_CLASS, brandId]);
+			}
+		} catch {
+			// The session is what holds the lock — if it's gone, so is the lock.
+		}
+		client.release();
+	}
+}
+
+/** Only ever called with the brand's generation lock held. */
+async function generateOpportunities(brandId: string, timezone: string): Promise<OpportunitiesResponse> {
+	// Read again behind the lock: whoever held it may have just written the
+	// report this call was about to pay a second time for.
+	const latest = await latestStoredReport(brandId);
+	if (latest && isFresh(latest)) return serveStored(latest);
 
 	const digest = await buildDigest(brandId, timezone);
 	if (!digest) {
-		if (latest) return serveStored();
-		return { report: null, reason: "insufficient-data", generatedFor: null, lastEvaluatedAt, model: null };
+		if (latest) return serveStored(latest);
+		return nothingStored("insufficient-data");
 	}
 
 	const prompt = `${GUIDANCE}\n\n=== BRAND DATA ===\n${digest.text}\n\n=== TASK ===\n${TASK}`;
 	const generated = await generateValidReport(prompt);
 	if (!generated) {
 		// No schema-valid report; serve the last good one if there is one.
-		if (latest) return serveStored();
+		if (latest) return serveStored(latest);
 		throw new Error("Failed to generate a valid opportunities report");
 	}
 
@@ -594,4 +651,33 @@ export async function resolveOpportunities(brandId: string, timezone = "UTC"): P
 		lastEvaluatedAt: savedReport?.createdAt.toISOString() ?? null,
 		model: generated.model,
 	};
+}
+
+/**
+ * The stored report and nothing more: no digest, no LLM call, no write. What a
+ * surface that promises its caller a read — the public API, the MCP tool — has
+ * to answer from, since generation spends provider budget.
+ */
+export async function storedOpportunities(brandId: string): Promise<OpportunitiesResponse> {
+	const latest = await latestStoredReport(brandId);
+	return latest ? serveStored(latest) : nothingStored("not-generated");
+}
+
+/**
+ * Generation is inline and synchronous — there is no queue, so a caller either
+ * gets the current report or waits for the one it just caused. The freshness
+ * gate bounds how often one is paid for and the lock bounds how many callers
+ * can pay at once: however many ask, at most one generation happens per brand
+ * per REFRESH_AFTER_DAYS.
+ */
+export async function resolveOpportunities(brandId: string, timezone = "UTC"): Promise<OpportunitiesResponse> {
+	const latest = await latestStoredReport(brandId);
+	if (latest && isFresh(latest)) return serveStored(latest);
+
+	const generated = await withGenerationLock(brandId, () => generateOpportunities(brandId, timezone));
+	if (generated) return generated;
+
+	// Someone else is already generating. A stale report beats waiting on them;
+	// with nothing stored, say that rather than start a second generation.
+	return latest ? serveStored(latest) : nothingStored("generating");
 }

--- a/e2e/bruno/opportunities/a brand with no report says so.bru
+++ b/e2e/bruno/opportunities/a brand with no report says so.bru
@@ -1,5 +1,5 @@
 meta {
-  name: a brand with nothing tracked says so rather than generating
+  name: a brand with no report says so rather than generating one
   type: http
   seq: 6
 }
@@ -16,7 +16,7 @@ headers {
 
 assert {
   res.status: eq 200
-  res.body.status: eq insufficient-data
+  res.body.status: eq not-generated
   res.body.generatedAt: isNull
   res.body.model: isNull
   res.body.opportunities: isEmpty

--- a/packages/api-spec/src/openapi.json
+++ b/packages/api-spec/src/openapi.json
@@ -1658,8 +1658,8 @@
 					},
 					"status": {
 						"type": "string",
-						"description": "`ready` when a report is present. `insufficient-data` when the brand hasn't accumulated enough tracked answers to say anything useful yet, in which case the lists are empty.",
-						"enum": ["ready", "insufficient-data"]
+						"description": "`ready` when a report is present. `not-generated` when no report has been written for this brand yet — Elmo writes the first one from the Opportunities page in the app. `insufficient-data` when the brand hasn't accumulated enough tracked answers to say anything useful yet. The lists are empty for both of the latter.",
+						"enum": ["ready", "insufficient-data", "not-generated"]
 					},
 					"generatedAt": {
 						"type": ["string", "null"],


### PR DESCRIPTION
Fixes #678.

`resolveOpportunities()` read the newest stored report, decided it was stale, and generated a replacement with no lock in between — so every concurrent caller ran its own paid LLM call and appended its own row, and a `readOnly` MCP tool / `analytics:read` GET could each start one.

## Generation is serialized per brand

`resolveOpportunities()` now runs generation behind a per-brand advisory lock and re-reads the stored report once it holds it, so the second caller through the gate serves what the first one wrote.

The lock is session-scoped (`pg_try_advisory_lock` on a checked-out client) rather than transaction-scoped like `withQuotaLock`'s: it has to cover the LLM call, and a transaction left open that long pins a snapshot as well as a connection. Nobody blocks on it either, since waiters would pin a pool connection each for a call they can't speed up — a caller that loses the race serves the stale report, or reports `generating` when there is nothing stored (the Opportunities page says a first report is on its way instead of claiming there isn't enough data).

## Reads only read

`publishedOpportunities()` — the projection behind `GET /api/v1/brands/{brandId}/opportunities` and the `get_opportunities` MCP tool — now answers from `storedOpportunities()`, which never builds a digest, calls a model, or writes. That makes the tool's `readOnly: true` true, which matters beyond documentation because a read-only deployment filters on it, and it matches what the endpoint already documented ("read from the append-only history rather than regenerated").

A brand with no stored report now reads as `not-generated` rather than `insufficient-data`, so an API consumer can tell "nobody has generated one yet" from "not enough tracked answers to write one". Generation still happens from the dashboard's path, as before.

The queued-generation option in the issue is the better end state but needs the generator (and ~3k lines of `@/lib` reads it depends on) to move somewhere the worker can run it; this keeps the spend bounded without that move.

## Tests

`apps/web/src/server/__tests__/opportunities-generation.test.ts` fakes the report table and Postgres advisory locks, and covers: a fresh report served without generating, two callers on the same stale report generating once (the loser served the stale one), a caller with nothing stored told a report is on its way, a caller serving the report a concurrent writer landed while it waited for the lock, the lock released when generation fails, and the read-only surfaces leaving a 90-day-old report alone.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/57da3af3-a67f-449e-95f1-7193393e03de)
