### PR TITLE
Freeze the clock in the lookback default tests

### DIFF
--- a/apps/web/src/lib/__tests__/chart-utils.test.ts
+++ b/apps/web/src/lib/__tests__/chart-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	applyPerPromptKeyedLVCF,
 	citationDateWindow,
@@ -23,6 +23,17 @@ describe("getDaysFromLookback", () => {
 });
 
 describe("getDefaultLookbackPeriod", () => {
+	// Freeze the clock: the 7-day cutoff is exact, so a real clock ticking between
+	// building the input date and reading `now` inside the function flips the boundary case.
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-06-09T12:00:00Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	const daysAgo = (days: number) => new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
 
 	it.each<[string, string | null | undefined]>([


### PR DESCRIPTION
The `getDefaultLookbackPeriod` boundary case (`[7, "1w"]`) is flaky — it failed once on a cold run and then passed on every rerun.

`getDefaultLookbackPeriod` uses an exact, exclusive cutoff (`diffInDays > 7`), but the test builds its input from a separate clock read:

```ts
const daysAgo = (days: number) => new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
```

`daysAgo(7)` snapshots `Date.now()` at T1; the function reads `new Date()` at T2. The difference is `7 days + (T2 - T1)`, so the case passes only when both reads land in the same millisecond. A single millisecond of drift makes it `7.0000000115 > 7` and the result flips to `1m`. Every other row in the table has slack; only the boundary row is on a knife's edge.

Measured on a tight loop: 221 failures in 200,000 iterations (~0.11%), and 100% failure if one millisecond is forced to elapse between the two reads. The observed failure came right after a pnpm install swapped 269 packages, so the transform cache was cold and the process was contending for CPU — enough to cross a millisecond boundary.

Pinning the clock for that describe block makes both reads see the same instant. Production code is unchanged: the exclusive `> 7` boundary is real behavior and is now tested deterministically.

30 consecutive runs of the file pass; `pnpm lint` is clean. Test-only, so no changeset.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/17a41324-d0cc-4373-b06d-fc622cf95409)
